### PR TITLE
Fixing the issue with bad encoding

### DIFF
--- a/consumer/src/mode/decoded/atom/atom_creation.rs
+++ b/consumer/src/mode/decoded/atom/atom_creation.rs
@@ -69,7 +69,9 @@ impl AtomCreated {
 
     /// This function decodes the atom data
     fn decode_data(&self) -> Result<String, ConsumerError> {
-        Ok(String::from_utf8(self.atomData.clone().to_vec())?)
+        let filtered_bytes: Vec<u8> = self.atomData.iter().filter(|&&b| b != 0).cloned().collect();
+
+        Ok(String::from_utf8(filtered_bytes)?)
     }
 
     /// This function verifies if the atom wallet account exists in our DB. If it does, it returns it.


### PR DESCRIPTION
Fixing the issue with bad encoding, the error presented was:

```bash
Error: ModelError(SqlError(Database(PgDatabaseError { severity: Error, code: "22021", message: "invalid byte sequence for encoding \"UTF8\": 0x00", detail: None, hint: None, position: None, where: Some("unnamed portal parameter $5"), schema: None, table: None, column: None, data_type: None, constraint: None, file: Some("mbutils.c"), line: Some(1727), routine: Some("report_invalid_encoding") })))
```