### PR TITLE
Fixing parsing of unknown schemas

### DIFF
--- a/consumer/src/mode/resolver/atom_resolver.rs
+++ b/consumer/src/mode/resolver/atom_resolver.rs
@@ -14,7 +14,7 @@ use models::{
 use serde_json::Value;
 use sqlx::PgPool;
 use std::str::FromStr;
-use tracing::{info, warn};
+use tracing::warn;
 
 /// Supported schema.org contexts
 pub const SCHEMA_ORG_CONTEXTS: [&str; 4] = [

--- a/consumer/src/mode/resolver/types.rs
+++ b/consumer/src/mode/resolver/types.rs
@@ -149,6 +149,7 @@ impl ResolverMessageType {
             .await?
         };
 
+        info!("Metadata: {:?}", metadata);
         // If at this point we have an atom type that is not unknown (it means it changes it state),
         // we need to update the atom metadata
         if AtomType::from_str(&metadata.atom_type)? != AtomType::Unknown {

--- a/consumer/src/mode/resolver/types.rs
+++ b/consumer/src/mode/resolver/types.rs
@@ -149,7 +149,6 @@ impl ResolverMessageType {
             .await?
         };
 
-        info!("Metadata: {:?}", metadata);
         // If at this point we have an atom type that is not unknown (it means it changes it state),
         // we need to update the atom metadata
         if AtomType::from_str(&metadata.atom_type)? != AtomType::Unknown {


### PR DESCRIPTION
Fixing parsing of unknown schemas, now the resolver consumer is going to bypass the unknown schemas for now