### PR TITLE
Luis/eng 5776 deploy version 203 of consumers to devbase sepolia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "consumer"
-version = "0.11.0"
+version = "2.0.3"
 dependencies = [
  "alloy",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "consumer"
-version = "2.0.3"
+version = "2.0.5"
 dependencies = [
  "alloy",
  "async-trait",

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "consumer"
-version = "2.0.3"
+version = "2.0.5"
 edition = "2021"
 
 [dependencies]

--- a/consumer/Cargo.toml
+++ b/consumer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "consumer"
-version = "0.11.0"
+version = "2.0.3"
 edition = "2021"
 
 [dependencies]

--- a/devops/aws/consumers/overlays/dev-base-mainnet/decoded/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-mainnet/decoded/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: decoded-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.1
+          image: ghcr.io/0xintuition/consumer:2.0.5
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-mainnet/ipfs-upload/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-mainnet/ipfs-upload/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: ipfs-upload-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.0
+          image: ghcr.io/0xintuition/consumer:2.0.5
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-mainnet/raw/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-mainnet/raw/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: raw-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.0
+          image: ghcr.io/0xintuition/consumer:2.0.5
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-mainnet/resolver/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-mainnet/resolver/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: resolver-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.0
+          image: ghcr.io/0xintuition/consumer:2.0.5
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-sepolia/decoded/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-sepolia/decoded/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: decoded-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.3
+          image: ghcr.io/0xintuition/consumer:2.0.5
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-sepolia/decoded/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-sepolia/decoded/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: decoded-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.0
+          image: ghcr.io/0xintuition/consumer:2.0.3
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-sepolia/ipfs-upload/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-sepolia/ipfs-upload/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: ipfs-upload-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.3
+          image: ghcr.io/0xintuition/consumer:2.0.5
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-sepolia/ipfs-upload/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-sepolia/ipfs-upload/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: ipfs-upload-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.0
+          image: ghcr.io/0xintuition/consumer:2.0.3
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-sepolia/raw/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-sepolia/raw/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: raw-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.3
+          image: ghcr.io/0xintuition/consumer:2.0.5
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-sepolia/raw/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-sepolia/raw/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: raw-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.0
+          image: ghcr.io/0xintuition/consumer:2.0.3
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-sepolia/resolver/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-sepolia/resolver/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: resolver-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.0
+          image: ghcr.io/0xintuition/consumer:2.0.3
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/consumers/overlays/dev-base-sepolia/resolver/deployment-patch.yaml
+++ b/devops/aws/consumers/overlays/dev-base-sepolia/resolver/deployment-patch.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: resolver-consumer
-          image: ghcr.io/0xintuition/consumer:2.0.3
+          image: ghcr.io/0xintuition/consumer:2.0.5
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/services/graphql/overlays/dev-base-sepolia/indexer-migrations.yaml
+++ b/devops/aws/services/graphql/overlays/dev-base-sepolia/indexer-migrations.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: secrets-access-sa
       containers:
         - name: indexer-and-cache-migration
-          image: ghcr.io/0xintuition/indexer-and-cache-migrations:2.0.0
+          image: ghcr.io/0xintuition/indexer-and-cache-migrations:2.0.1
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/devops/aws/services/graphql/overlays/dev-base-sepolia/kustomization.yaml
+++ b/devops/aws/services/graphql/overlays/dev-base-sepolia/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base  # Adjusted to point to the base directory
+  - ../../base
   - secret-provider.yaml
   - indexer-migrations.yaml
 

--- a/devops/aws/services/graphql/overlays/dev-base-sepolia/migrations-patch.yaml
+++ b/devops/aws/services/graphql/overlays/dev-base-sepolia/migrations-patch.yaml
@@ -5,9 +5,10 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: secrets-access-sa
       containers:
         - name: hasura-migrations
-          image: ghcr.io/0xintuition/hasura-migrations:2.0.0
+          image: ghcr.io/0xintuition/hasura-migrations:2.0.1
           imagePullPolicy: Always
           volumeMounts:
             - name: secrets-store-inline

--- a/models/src/atom.rs
+++ b/models/src/atom.rs
@@ -215,15 +215,16 @@ impl Atom {
     pub fn decode_data(data: String) -> Result<String, ModelError> {
         // Remove the "0x" prefix and decode the hex string
         let decoded_data = hex::decode(&data[2..]).expect("Decoding failed");
-        let decoded_string = String::from_utf8(decoded_data).expect("UTF-8 conversion failed");
-        let filtered_bytes: Vec<u8> = decoded_string
-            .as_bytes()
-            .iter()
-            .filter(|&&b| b != 0)
-            .cloned()
-            .collect();
 
-        Ok(String::from_utf8(filtered_bytes)?)
+        // Try UTF-8 first
+        if let Ok(s) = String::from_utf8(decoded_data.clone()) {
+            let filtered_bytes: Vec<u8> =
+                s.as_bytes().iter().filter(|&&b| b != 0).cloned().collect();
+            return Ok(String::from_utf8(filtered_bytes)?);
+        }
+
+        // Fallback to hex representation if not UTF-8
+        Ok(hex::encode(decoded_data))
     }
 }
 

--- a/models/src/atom.rs
+++ b/models/src/atom.rs
@@ -214,17 +214,14 @@ impl Atom {
     /// This function decodes the atom data
     pub fn decode_data(data: String) -> Result<String, ModelError> {
         // Remove the "0x" prefix and decode the hex string
-        let decoded_data = hex::decode(&data[2..]).expect("Decoding failed");
+        let decoded_data =
+            hex::decode(&data[2..]).map_err(|e| ModelError::DecodingError(e.to_string()))?;
 
-        // Try UTF-8 first
-        if let Ok(s) = String::from_utf8(decoded_data.clone()) {
-            let filtered_bytes: Vec<u8> =
-                s.as_bytes().iter().filter(|&&b| b != 0).cloned().collect();
-            return Ok(String::from_utf8(filtered_bytes)?);
-        }
-
-        // Fallback to hex representation if not UTF-8
-        Ok(hex::encode(decoded_data))
+        // Try UTF-8 and fail if invalid
+        let s = String::from_utf8(decoded_data)
+            .map_err(|e| ModelError::DecodingError(e.to_string()))?;
+        let filtered_bytes: Vec<u8> = s.as_bytes().iter().filter(|&&b| b != 0).cloned().collect();
+        String::from_utf8(filtered_bytes).map_err(|e| ModelError::DecodingError(e.to_string()))
     }
 }
 
@@ -240,6 +237,15 @@ mod tests {
         // Use the decode_data function
         let result = Atom::decode_data(hex_string.to_string()).expect("Decoding data failed");
 
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn test_decode_data_non_utf8() {
+        let hex_string = "0xc626cbfe61bac7a1db9d227b90878d872c379c6a";
+        let expected_output = "c626cbfe61bac7a1db9d227b90878d872c379c6a";
+
+        let result = Atom::decode_data(hex_string.to_string()).expect("Decoding data failed");
         assert_eq!(result, expected_output);
     }
 }

--- a/models/src/error.rs
+++ b/models/src/error.rs
@@ -6,6 +6,8 @@ pub enum ModelError {
     ConversionError(String),
     #[error("Database connection error: {0}")]
     DatabaseConnectionError(String),
+    #[error("Decoding error: {0}")]
+    DecodingError(String),
     #[error("Failed to delete data: {0}")]
     DeleteError(String),
     #[error(transparent)]


### PR DESCRIPTION
Updating dev envs to latest consumers. This includes fixes for signals (deposit_id), deposit_id is fixed, fee transfer id is fixed, consumers can process data from arbitrary points in time, textObjects now have the correct label, new schema without cached_images