### PR TITLE
fix: missing env var

### DIFF
--- a/docker-compose-apps.yml
+++ b/docker-compose-apps.yml
@@ -81,6 +81,7 @@ services:
       INDEXER_DATABASE_URL: "postgres://testuser:test@database:5435/storage"
       INDEXER_SCHEMA: $INDEXER_SCHEMA
       ENVIRONMENT_NAME: "local_v_1_5"
+      INITIAL_CONTRACT_VERSION: $INITIAL_CONTRACT_VERSION
       CONSUMER_METRICS_API_PORT: '3002'
       DATABASE_URL: 'postgres://testuser:test@database:5435/storage'
       DECODED_LOGS_QUEUE_URL: 'http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/decoded_logs.fifo'

--- a/start.sh
+++ b/start.sh
@@ -28,6 +28,7 @@ if [ "$INDEXER_SCHEMA" == "histo_local_1_5" ]; then
 
     # Set env vars
     export INTUITION_CONTRACT_ADDRESS=$CONTRACT_ADDRESS
+    export INITIAL_CONTRACT_VERSION="v1_5"
     export INDEXER_SCHEMA="histo_base_sepolia_1_5"
     export BASE_SEPOLIA_RPC_URL="http://geth:8545"
     export BASE_MAINNET_RPC_URL="http://geth:8545"


### PR DESCRIPTION
Running this with:

```
./start.sh histo_local_1_5 test
```