### PR TITLE
feat: ngnix setup for local development

### DIFF
--- a/docker-compose-shared.yml
+++ b/docker-compose-shared.yml
@@ -56,11 +56,22 @@ services:
     ports:
       - 8000:8000
     
+  nginx:
+    container_name: nginx
+    image: nginx:latest
+    ports:
+      - '8080:80'
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      graphql-engine:
+        condition: service_healthy
+
   graphql-engine:
     container_name: graphql-engine
     image: hasura/graphql-engine:v2.44.0
-    ports:
-      - '8080:8080'
+    expose:
+      - '8080'
     restart: always
     environment:
       HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://postgres:postgres@database:5435/storage

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,24 @@
+http {
+    limit_req_zone $binary_remote_addr zone=graphql_limit:10m rate=10r/s;
+
+    upstream graphql_backend {
+        server graphql-engine:8080;
+    }
+
+    server {
+        listen 80;
+        
+        location / {
+            limit_req zone=graphql_limit burst=20 nodelay;
+            proxy_pass http://graphql_backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}
+
+events {
+    worker_connections 1024;
+} 

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 source .env
 
 # Start shared services
-docker compose -f docker-compose-shared.yml up database vectorizer-worker sqs ipfs safe-content graphql-engine local-migrations indexer-migrations hasura-migrations prometheus -d --wait --force-recreate
+docker compose -f docker-compose-shared.yml up database vectorizer-worker sqs ipfs safe-content graphql-engine nginx local-migrations indexer-migrations hasura-migrations prometheus -d --wait --force-recreate
 
 
 # First arg is indexer schema


### PR DESCRIPTION
Here's what's happening in your nginx rate limiting config:
```
limit_req_zone $binary_remote_addr zone=graphql_limit:10m rate=10r/s;
```

- Creates a shared memory zone named graphql_limit of 10MB
- Tracks requests by IP address ($binary_remote_addr)
- Base rate limit: 10 requests per second

```
limit_req zone=graphql_limit burst=20 nodelay;
```

- Applies the rate limit to the location block
- `burst=20`: Allows 20 requests to queue when rate limit is exceeded
- `nodelay`: Processes burst requests immediately instead of delaying them

So in practice:
- Normal traffic: 10 req/s per IP
- Burst traffic: Can handle up to 20 additional requests in queue
- If queue fills up: Returns 503 error
- Memory usage: ~10MB to store IP tracking data

This is a pretty standard setup for protecting a GraphQL endpoint from abuse while allowing reasonable bursts of traffic.