### PR TITLE
ensure addresses are checksummed

### DIFF
--- a/consumer/src/mode/decoded/atom/atom_creation.rs
+++ b/consumer/src/mode/decoded/atom/atom_creation.rs
@@ -144,7 +144,7 @@ impl AtomCreated {
             // for now, this will be updated later with the resolver consumer.
             let atom = Atom::builder()
                 .id(U256Wrapper::from_str(
-                    &self.vaultID.to_string().to_lowercase(),
+                    &self.vaultID.to_string(),
                 )?)
                 .wallet_id(atom_wallet_account.id.clone())
                 .creator_id(creator_account.id)

--- a/consumer/src/mode/decoded/deposited.rs
+++ b/consumer/src/mode/decoded/deposited.rs
@@ -191,7 +191,7 @@ impl Deposited {
             if let Some(atom_id) = vault.atom_id.clone() {
                 Signal::builder()
                     .id(DecodedMessage::event_id(event))
-                    .account_id(self.sender.to_string().to_lowercase())
+                    .account_id(self.sender.to_string())
                     .delta(U256Wrapper::from(self.senderAssetsAfterTotalFees))
                     .atom_id(atom_id)
                     .deposit_id(DecodedMessage::event_id(event))
@@ -207,7 +207,7 @@ impl Deposited {
             } else {
                 Signal::builder()
                     .id(DecodedMessage::event_id(event))
-                    .account_id(self.sender.to_string().to_lowercase())
+                    .account_id(self.sender.to_string())
                     .delta(U256Wrapper::from(self.senderAssetsAfterTotalFees))
                     .triple_id(
                         vault
@@ -237,7 +237,7 @@ impl Deposited {
         format!(
             "{}-{}",
             self.vaultId,
-            self.receiver.to_string().to_lowercase()
+            self.receiver.to_string()
         )
     }
 
@@ -246,7 +246,7 @@ impl Deposited {
         format!(
             "{}-{}",
             self.vaultId,
-            self.receiver.to_string().to_lowercase()
+            self.receiver.to_string()
         )
     }
 
@@ -463,7 +463,7 @@ impl Deposited {
         triple: &Triple,
         vault: &Vault,
     ) -> Result<Claim, ConsumerError> {
-        let claim_id = format!("{}-{}", triple.term_id, self.receiver.to_string().to_lowercase());
+        let claim_id = format!("{}-{}", triple.term_id, self.receiver.to_string());
 
         let claim = match Claim::find_by_id(
             claim_id.clone(),

--- a/consumer/src/mode/decoded/redeemed.rs
+++ b/consumer/src/mode/decoded/redeemed.rs
@@ -106,7 +106,7 @@ impl Redeemed {
         if let Some(triple_id) = vault.triple_id.clone() {
             Signal::builder()
                 .id(DecodedMessage::event_id(event))
-                .account_id(self.sender.to_string().to_lowercase())
+                .account_id(self.sender.to_string())
                 // This is the equivalent of multiplying the assets for receiver by -1
                 .delta(U256Wrapper::from(
                     U256::ZERO.saturating_sub(self.assetsForReceiver),
@@ -125,7 +125,7 @@ impl Redeemed {
         } else {
             Signal::builder()
                 .id(DecodedMessage::event_id(event))
-                .account_id(self.sender.to_string().to_lowercase())
+                .account_id(self.sender.to_string())
                 // This is the equivalent of multiplying the assets for receiver by -1
                 .delta(U256Wrapper::from(
                     U256::ZERO.saturating_sub(self.assetsForReceiver),
@@ -242,7 +242,7 @@ impl Redeemed {
         // When the redemption fully depletes the sender's shares:
         if self.senderTotalSharesInVault == Uint::from(0) {
             // Build the position ID
-            let position_id = format!("{}-{}", vault.id, sender_account.id.to_lowercase());
+            let position_id = format!("{}-{}", vault.id, sender_account.id);
             // Call the handler to remove the position
             self.handle_position_redemption(decoded_consumer_context, &position_id)
                 .await?;
@@ -286,7 +286,7 @@ impl Redeemed {
     ) -> Result<(), ConsumerError> {
         // Update position
         if let Some(mut position) = Position::find_by_id(
-            format!("{}-{}", vault.id, sender_account.id.to_lowercase()),
+            format!("{}-{}", vault.id, sender_account.id),
             &decoded_consumer_context.pg_pool,
             &decoded_consumer_context.backend_schema,
         )
@@ -311,7 +311,7 @@ impl Redeemed {
             .await?
             {
                 if let Some(mut claim) = Claim::find_by_id(
-                    format!("{}-{}", triple.term_id, sender_account.id.to_lowercase()),
+                    format!("{}-{}", triple.term_id, sender_account.id),
                     &decoded_consumer_context.pg_pool,
                     &decoded_consumer_context.backend_schema,
                 )
@@ -356,7 +356,7 @@ impl Redeemed {
             .await?
             {
                 // Delete claim
-                let claim_id = format!("{}-{}", triple.term_id, sender_account.id.to_lowercase());
+                let claim_id = format!("{}-{}", triple.term_id, sender_account.id);
                 Claim::delete(
                     claim_id,
                     &decoded_consumer_context.pg_pool,

--- a/consumer/src/mode/decoded_v1_5/deposited.rs
+++ b/consumer/src/mode/decoded_v1_5/deposited.rs
@@ -246,7 +246,7 @@ impl Deposited {
             if !self.isTriple {
                 Signal::builder()
                     .id(DecodedMessage::event_id(event))
-                    .account_id(self.sender.to_string().to_lowercase())
+                    .account_id(self.sender.to_string())
                     .delta(U256Wrapper::from(self.senderAssetsAfterTotalFees))
                     .atom_id(vault.term_id.clone())
                     .deposit_id(DecodedMessage::event_id(event))
@@ -264,7 +264,7 @@ impl Deposited {
             } else {
                 Signal::builder()
                     .id(DecodedMessage::event_id(event))
-                    .account_id(self.sender.to_string().to_lowercase())
+                    .account_id(self.sender.to_string())
                     .delta(U256Wrapper::from(self.senderAssetsAfterTotalFees))
                     .triple_id(vault.term_id.clone())
                     .deposit_id(DecodedMessage::event_id(event))
@@ -291,7 +291,7 @@ impl Deposited {
         format!(
             "{}-1-{}",
             self.vaultId,
-            self.receiver.to_string().to_lowercase()
+            self.receiver.to_string()
         )
     }
 
@@ -300,7 +300,7 @@ impl Deposited {
         format!(
             "{}-1-{}",
             self.vaultId,
-            self.receiver.to_string().to_lowercase()
+            self.receiver.to_string()
         )
     }
 

--- a/consumer/src/mode/decoded_v1_5/deposited_curve.rs
+++ b/consumer/src/mode/decoded_v1_5/deposited_curve.rs
@@ -90,7 +90,7 @@ impl DepositedCurve {
             "{}-{}-{}",
             self.vaultId,
             self.curveId,
-            self.receiver.to_string().to_lowercase()
+            self.receiver.to_string()
         )
     }
 
@@ -100,7 +100,7 @@ impl DepositedCurve {
             "{}-{}-{}",
             self.vaultId,
             self.curveId,
-            self.receiver.to_string().to_lowercase()
+            self.receiver.to_string()
         )
     }
     /// This function creates a new position or updates an existing one
@@ -173,7 +173,7 @@ impl DepositedCurve {
             if !self.isTriple {
                 Signal::builder()
                     .id(DecodedMessage::event_id(event))
-                    .account_id(self.sender.to_string().to_lowercase())
+                    .account_id(self.sender.to_string())
                     .delta(U256Wrapper::from(self.senderAssetsAfterTotalFees))
                     .atom_id(curve_vault.term_id.clone())
                     .deposit_id(DecodedMessage::event_id(event))
@@ -191,7 +191,7 @@ impl DepositedCurve {
             } else {
                 Signal::builder()
                     .id(DecodedMessage::event_id(event))
-                    .account_id(self.sender.to_string().to_lowercase())
+                    .account_id(self.sender.to_string())
                     .delta(U256Wrapper::from(self.senderAssetsAfterTotalFees))
                     .triple_id(curve_vault.term_id.clone())
                     .deposit_id(DecodedMessage::event_id(event))

--- a/consumer/src/mode/decoded_v1_5/redeemed.rs
+++ b/consumer/src/mode/decoded_v1_5/redeemed.rs
@@ -119,7 +119,7 @@ impl Redeemed {
         if let TermType::Triple = term_type.term_type {
             Signal::builder()
                 .id(DecodedMessage::event_id(event))
-                .account_id(self.sender.to_string().to_lowercase())
+                .account_id(self.sender.to_string())
                 // This is the equivalent of multiplying the assets for receiver by -1
                 .delta(U256Wrapper::from(
                     U256::ZERO.saturating_sub(self.assetsForReceiver),
@@ -140,7 +140,7 @@ impl Redeemed {
         } else {
             Signal::builder()
                 .id(DecodedMessage::event_id(event))
-                .account_id(self.sender.to_string().to_lowercase())
+                .account_id(self.sender.to_string())
                 // This is the equivalent of multiplying the assets for receiver by -1
                 .delta(U256Wrapper::from(
                     U256::ZERO.saturating_sub(self.assetsForReceiver),
@@ -196,7 +196,7 @@ impl Redeemed {
         // When the redemption fully depletes the sender's shares:
         if self.senderTotalSharesInVault == Uint::from(0) {
             // Build the position ID
-            let position_id = format!("{}-1-{}", vault.term_id, sender_account.id.to_lowercase());
+            let position_id = format!("{}-1-{}", vault.term_id, sender_account.id);
             // Call the handler to remove the position
             self.handle_position_redemption(decoded_consumer_context, &position_id)
                 .await?;
@@ -226,7 +226,7 @@ impl Redeemed {
     ) -> Result<(), ConsumerError> {
         // Update position
         if let Some(mut position) = Position::find_by_id(
-            format!("{}-1-{}", vault.term_id, sender_account.id.to_lowercase()),
+            format!("{}-1-{}", vault.term_id, sender_account.id),
             &decoded_consumer_context.pg_pool,
             &decoded_consumer_context.backend_schema,
         )
@@ -260,7 +260,7 @@ impl Redeemed {
         .await?
         {
             // Delete claim
-            let claim_id = format!("{}-{}", triple.term_id, sender_account.id.to_lowercase());
+            let claim_id = format!("{}-{}", triple.term_id, sender_account.id);
             Claim::delete(
                 claim_id,
                 &decoded_consumer_context.pg_pool,

--- a/consumer/src/mode/decoded_v1_5/redeemed_curve.rs
+++ b/consumer/src/mode/decoded_v1_5/redeemed_curve.rs
@@ -85,7 +85,7 @@ impl RedeemedCurve {
             if let TermType::Triple = term_type.term_type {
                 Signal::builder()
                     .id(DecodedMessage::event_id(event))
-                    .account_id(self.sender.to_string().to_lowercase())
+                    .account_id(self.sender.to_string())
                     // This is the equivalent of multiplying the assets for receiver by -1
                     .delta(U256Wrapper::from(
                         U256::ZERO.saturating_sub(self.assetsForReceiver),
@@ -106,7 +106,7 @@ impl RedeemedCurve {
             } else {
                 Signal::builder()
                     .id(DecodedMessage::event_id(event))
-                    .account_id(self.sender.to_string().to_lowercase())
+                    .account_id(self.sender.to_string())
                     // This is the equivalent of multiplying the assets for receiver by -1
                     .delta(U256Wrapper::from(
                         U256::ZERO.saturating_sub(self.assetsForReceiver),
@@ -140,7 +140,7 @@ impl RedeemedCurve {
             "{}-{}-{}",
             curve_vault.term_id,
             self.curveId,
-            self.sender.to_string().to_lowercase()
+            self.sender.to_string()
         );
 
         // Check if the position exists before deleting

--- a/consumer/src/mode/resolver/ens_resolver.rs
+++ b/consumer/src/mode/resolver/ens_resolver.rs
@@ -119,7 +119,7 @@ impl Ens {
 
     /// This function prepares the name for the ENS resolver.
     fn prepare_name(address: Address) -> String {
-        let addr_str = address.to_string().to_lowercase();
+        let addr_str = address.to_string();
         format!("{}.addr.reverse", addr_str.trim_start_matches("0x"))
     }
 }

--- a/consumer/src/mode/types.rs
+++ b/consumer/src/mode/types.rs
@@ -967,8 +967,8 @@ mod tests {
                 let contract_address = decoded_context.base_client.address();
                 // Normalize to lowercase (the builder may parse the address in lowercase).
                 assert_eq!(
-                    contract_address.to_string().to_lowercase(),
-                    "0x1a6950807e33d5bc9975067e6d6b5ea4cd661665"
+                    contract_address.to_string(),
+                    "0x1A6950807E33d5bC9975067e6D6b5Ea4cD661665"
                 );
                 Ok(decoded_context)
             }

--- a/histocrawler/src/app.rs
+++ b/histocrawler/src/app.rs
@@ -30,7 +30,7 @@ impl HistoCrawler {
         let backoff_delay = Duration::from_millis(1500);
         let app_config = AppConfig::find_by_indexer_schema(&env.indexer_schema, &pg_pool).await?;
         if let Some(app_config) = app_config {
-            let contract_address = Address::from_str(&app_config.contract_address.to_lowercase())?;
+            let contract_address = Address::from_str(&app_config.contract_address)?;
             let provider = Self::get_provider(&app_config.rpc_url).await?;
             Ok(Self {
                 contract_address,

--- a/models/src/account.rs
+++ b/models/src/account.rs
@@ -56,7 +56,7 @@ impl SimpleCrud<String> for Account {
         );
 
         sqlx::query_as::<_, Account>(&query)
-            .bind(self.id.to_lowercase())
+            .bind(self.id)
             .bind(self.atom_id.as_ref().and_then(|w| w.to_big_decimal().ok()))
             .bind(&self.label)
             .bind(&self.image)
@@ -87,7 +87,7 @@ impl SimpleCrud<String> for Account {
         );
 
         sqlx::query_as::<_, Account>(&query)
-            .bind(id.to_lowercase())
+            .bind(id)
             .fetch_optional(pool)
             .await
             .map_err(|e| ModelError::QueryError(e.to_string()))

--- a/models/src/atom.rs
+++ b/models/src/atom.rs
@@ -109,8 +109,8 @@ impl SimpleCrud<U256Wrapper> for Atom {
         );
 
         sqlx::query_as::<_, Atom>(&query)
-            .bind(self.wallet_id.to_lowercase())
-            .bind(self.creator_id.to_lowercase())
+            .bind(self.wallet_id)
+            .bind(self.creator_id)
             .bind(self.term_id.to_big_decimal()?)
             .bind(self.data.clone())
             .bind(self.raw_data.clone())

--- a/models/src/claim.rs
+++ b/models/src/claim.rs
@@ -40,9 +40,9 @@ impl SimpleCrud<String> for Claim {
         );
 
         sqlx::query_as::<_, Claim>(&query)
-            .bind(self.id.to_lowercase())
-            .bind(self.account_id.to_lowercase())
-            .bind(self.position_id.to_lowercase())
+            .bind(self.id)
+            .bind(self.account_id)
+            .bind(self.position_id)
             .fetch_one(pool)
             .await
             .map_err(|e| ModelError::InsertError(e.to_string()))
@@ -70,7 +70,7 @@ impl SimpleCrud<String> for Claim {
         );
 
         sqlx::query_as::<_, Claim>(&query)
-            .bind(id.to_lowercase())
+            .bind(id)
             .fetch_optional(pool)
             .await
             .map_err(|e| ModelError::QueryError(e.to_string()))
@@ -84,7 +84,7 @@ impl Deletable for Claim {
         let query = format!(r#"DELETE FROM {}.claim WHERE position_id = $1"#, schema);
 
         sqlx::query(&query)
-            .bind(id.to_lowercase())
+            .bind(id)
             .execute(pool)
             .await
             .map(|_| ())
@@ -98,7 +98,7 @@ impl Claim {
             "{}-{}-{}",
             triple_term_id,
             curve_id,
-            account_id.to_lowercase()
+            account_id
         )
     }
 }

--- a/models/src/deposit.rs
+++ b/models/src/deposit.rs
@@ -79,9 +79,9 @@ impl SimpleCrud<String> for Deposit {
         );
 
         sqlx::query_as::<_, Deposit>(&query)
-            .bind(self.id.to_lowercase())
-            .bind(self.sender_id.to_lowercase())
-            .bind(self.receiver_id.to_lowercase())
+            .bind(self.id)
+            .bind(self.sender_id)
+            .bind(self.receiver_id)
             .bind(self.receiver_total_shares_in_vault.to_big_decimal()?)
             .bind(self.sender_assets_after_total_fees.to_big_decimal()?)
             .bind(self.shares_for_receiver.to_big_decimal()?)
@@ -126,7 +126,7 @@ impl SimpleCrud<String> for Deposit {
         );
 
         sqlx::query_as::<_, Deposit>(&query)
-            .bind(id.to_lowercase())
+            .bind(id)
             .fetch_optional(pool)
             .await
             .map_err(|e| crate::error::ModelError::QueryError(e.to_string()))
@@ -152,7 +152,7 @@ impl Deposit {
         );
 
         let result: Option<U256Wrapper> = sqlx::query_scalar(&query)
-            .bind(receiver_id.to_lowercase())
+            .bind(receiver_id)
             .bind(term_id.to_big_decimal()?)
             .bind(curve_id.to_big_decimal()?)
             .fetch_optional(pool)

--- a/models/src/position.rs
+++ b/models/src/position.rs
@@ -51,8 +51,8 @@ impl SimpleCrud<String> for Position {
         );
 
         sqlx::query_as::<_, Position>(&query)
-            .bind(self.id.to_lowercase())
-            .bind(self.account_id.to_lowercase())
+            .bind(self.id)
+            .bind(self.account_id)
             .bind(self.term_id.to_big_decimal()?)
             .bind(self.shares.to_big_decimal()?)
             .bind(self.curve_id.to_big_decimal()?)
@@ -82,7 +82,7 @@ impl SimpleCrud<String> for Position {
         );
 
         sqlx::query_as::<_, Position>(&query)
-            .bind(id.to_lowercase())
+            .bind(id)
             .fetch_optional(pool)
             .await
             .map_err(|e| ModelError::QueryError(e.to_string()))
@@ -96,7 +96,7 @@ impl Deletable for Position {
         let query = format!(r#"DELETE FROM {}.position WHERE id = $1"#, schema);
 
         sqlx::query(&query)
-            .bind(id.to_lowercase())
+            .bind(id)
             .execute(pool)
             .await
             .map(|_| ())

--- a/models/src/redemption.rs
+++ b/models/src/redemption.rs
@@ -137,7 +137,7 @@ impl Redemption {
         );
 
         let result: Option<U256Wrapper> = sqlx::query_scalar(&query)
-            .bind(sender_id.to_lowercase())
+            .bind(sender_id)
             .bind(term_id.to_big_decimal()?)
             .bind(curve_id.to_big_decimal()?)
             .fetch_optional(pool)

--- a/models/tests/test_deposit_crud.rs
+++ b/models/tests/test_deposit_crud.rs
@@ -37,7 +37,7 @@ mod tests {
 
         // Test initial upsert
         let upserted_deposit = deposit.upsert(&pool, TEST_SCHEMA).await?;
-        assert_eq!(upserted_deposit.id, deposit.id.to_lowercase());
+        assert_eq!(upserted_deposit.id, deposit.id);
         assert_eq!(
             upserted_deposit.shares_for_receiver,
             deposit.shares_for_receiver
@@ -62,7 +62,7 @@ mod tests {
             .await?
             .expect("Deposit should exist");
 
-        assert_eq!(found_deposit.id, deposit.id.to_lowercase());
+        assert_eq!(found_deposit.id, deposit.id);
         assert_eq!(
             found_deposit.shares_for_receiver,
             updated_deposit.shares_for_receiver

--- a/models/tests/test_position_crud.rs
+++ b/models/tests/test_position_crud.rs
@@ -50,7 +50,7 @@ mod tests {
             .await?
             .expect("Position should exist");
 
-        assert_eq!(retrieved_position.id, position.id.to_lowercase());
+        assert_eq!(retrieved_position.id, position.id);
         assert_eq!(retrieved_position.account_id, position.account_id);
         assert_eq!(retrieved_position.term_id, position.term_id);
         assert_eq!(retrieved_position.shares, updated_position.shares);

--- a/substreams-sink/src/substreams_stream.rs
+++ b/substreams-sink/src/substreams_stream.rs
@@ -43,7 +43,7 @@ impl SubstreamsStream {
                     Some(
                         prepared_endpoint_package
                             .mutable_modules(
-                                app.env.intuition_contract_address.clone().to_lowercase(),
+                                app.env.intuition_contract_address.clone(),
                             )
                             .await
                             .unwrap(),


### PR DESCRIPTION
We were lowercasing all contract and wallet addresses, which resulted in a bug where you cannot query for or filter by checksummed addresses.

Whenever a solidity contract provides or emits an address, it will always be checksummed.  When a user copies their wallet address, it will always be checksummed.

In some cases, for example copying an address from a block explorer url, the address will not be checksummed.

We can sanitize the API requests to auto-checksum the addresses, which I would prefer to do but this is up to the team.