### PR TITLE
feat: add plateform field to Atom and Triple models for DApp detection

### DIFF
--- a/apps/consumer/src/mode/metadata.rs
+++ b/apps/consumer/src/mode/metadata.rs
@@ -28,7 +28,7 @@ pub struct AtomMetadata {
     pub emoji: String,
     pub atom_type: String,
     pub image: Option<String>,
-    pub signature: Option<String>,
+    pub platform: Option<String>,
 }
 
 impl AtomMetadata {
@@ -39,18 +39,18 @@ impl AtomMetadata {
             emoji: "⛓️".to_string(),
             atom_type: "Account".to_string(),
             image,
-            signature: None,
+            platform: None,
         }
     }
 
     /// Creates a new atom metadata for a book
-    pub fn book(name: String, signature: Option<String>) -> Self {
+    pub fn book(name: String, platform: Option<String>) -> Self {
         Self {
             label: name,
             emoji: "📚".to_string(),
             atom_type: "Book".to_string(),
             image: None,
-            signature,
+            platform,
         }
     }
 
@@ -61,7 +61,7 @@ impl AtomMetadata {
             emoji: "🔢".to_string(),
             atom_type: "ByteObject".to_string(),
             image,
-            signature: None,
+            platform: None,
         }
     }
 
@@ -72,7 +72,7 @@ impl AtomMetadata {
             emoji: "🔗".to_string(),
             atom_type: "Caip10".to_string(),
             image: None,
-            signature: None,
+            platform: None,
         }
     }
 
@@ -112,7 +112,7 @@ impl AtomMetadata {
             emoji: "🔔".to_string(),
             atom_type: "FollowAction".to_string(),
             image,
-            signature: None,
+            platform: None,
         }
     }
 
@@ -155,13 +155,13 @@ impl AtomMetadata {
     }
 
     /// Creates a new atom metadata for a json object
-    pub fn json_object(image: Option<String>, signature: Option<String>) -> Self {
+    pub fn json_object(image: Option<String>, platform: Option<String>) -> Self {
         Self {
             label: "json object".to_string(),
             emoji: "📦".to_string(),
             atom_type: "JsonObject".to_string(),
             image,
-            signature,
+            platform,
         }
     }
 
@@ -172,7 +172,7 @@ impl AtomMetadata {
             emoji: "🏷️".to_string(),
             atom_type: "Keywords".to_string(),
             image,
-            signature: None,
+            platform: None,
         }
     }
 
@@ -183,18 +183,18 @@ impl AtomMetadata {
             emoji: "👍".to_string(),
             atom_type: "LikeAction".to_string(),
             image,
-            signature: None,
+            platform: None,
         }
     }
 
     /// Creates a new atom metadata for an organization
-    pub fn organization(name: String, image: Option<String>, signature: Option<String>) -> Self {
+    pub fn organization(name: String, image: Option<String>, platform: Option<String>) -> Self {
         Self {
             label: name,
             emoji: "🏢".to_string(),
             atom_type: "Organization".to_string(),
             image,
-            signature,
+            platform,
         }
     }
 
@@ -205,18 +205,18 @@ impl AtomMetadata {
             emoji: "🏢".to_string(),
             atom_type: "OrganizationPredicate".to_string(),
             image,
-            signature: None,
+            platform: None,
         }
     }
 
     /// Creates a new atom metadata for a person
-    pub fn person(name: String, image: Option<String>, signature: Option<String>) -> Self {
+    pub fn person(name: String, image: Option<String>, platform: Option<String>) -> Self {
         Self {
             label: name,
             emoji: "👤".to_string(),
             atom_type: "Person".to_string(),
             image,
-            signature,
+            platform,
         }
     }
 
@@ -227,7 +227,7 @@ impl AtomMetadata {
             emoji: "👤".to_string(),
             atom_type: "PersonPredicate".to_string(),
             image,
-            signature: None,
+            platform: None,
         }
     }
 
@@ -242,18 +242,18 @@ impl AtomMetadata {
             emoji: "📝".to_string(),
             atom_type: "TextObject".to_string(),
             image: None,
-            signature: None,
+            platform: None,
         }
     }
 
     /// Creates a new atom metadata for a thing
-    pub fn thing(name: String, image: Option<String>, signature: Option<String>) -> Self {
+    pub fn thing(name: String, image: Option<String>, platform: Option<String>) -> Self {
         Self {
             label: name,
             emoji: "🧩".to_string(),
             atom_type: "Thing".to_string(),
             image,
-            signature,
+            platform,
         }
     }
 
@@ -264,7 +264,7 @@ impl AtomMetadata {
             emoji: "🧩".to_string(),
             atom_type: "ThingPredicate".to_string(),
             image,
-            signature: None,
+            platform: None,
         }
     }
 
@@ -275,7 +275,7 @@ impl AtomMetadata {
             emoji: "❓".to_string(),
             atom_type: "Unknown".to_string(),
             image: None,
-            signature: None,
+            platform: None,
         }
     }
 
@@ -344,14 +344,14 @@ impl AtomMetadata {
         atom.atom_type = AtomType::from_str(&self.atom_type)?;
         atom.label = Some(self.label.clone());
         atom.image = self.image.clone();
-        atom.signature = self.signature.clone();
+        atom.platform = self.platform.clone();
         atom.upsert(backend_schema, pg_pool).await?;
         Ok(AtomMetadata {
             label: self.label.clone(),
             emoji: self.emoji.clone(),
             atom_type: self.atom_type.clone(),
             image: self.image.clone(),
-            signature: self.signature.clone(),
+            platform: self.platform.clone(),
         })
     }
 }

--- a/apps/consumer/src/mode/metadata.rs
+++ b/apps/consumer/src/mode/metadata.rs
@@ -28,6 +28,7 @@ pub struct AtomMetadata {
     pub emoji: String,
     pub atom_type: String,
     pub image: Option<String>,
+    pub signature: Option<String>,
 }
 
 impl AtomMetadata {
@@ -38,16 +39,18 @@ impl AtomMetadata {
             emoji: "⛓️".to_string(),
             atom_type: "Account".to_string(),
             image,
+            signature: None,
         }
     }
 
     /// Creates a new atom metadata for a book
-    pub fn book(name: String) -> Self {
+    pub fn book(name: String, signature: Option<String>) -> Self {
         Self {
             label: name,
             emoji: "📚".to_string(),
             atom_type: "Book".to_string(),
             image: None,
+            signature,
         }
     }
 
@@ -58,6 +61,7 @@ impl AtomMetadata {
             emoji: "🔢".to_string(),
             atom_type: "ByteObject".to_string(),
             image,
+            signature: None,
         }
     }
 
@@ -68,6 +72,7 @@ impl AtomMetadata {
             emoji: "🔗".to_string(),
             atom_type: "Caip10".to_string(),
             image: None,
+            signature: None,
         }
     }
 
@@ -107,6 +112,7 @@ impl AtomMetadata {
             emoji: "🔔".to_string(),
             atom_type: "FollowAction".to_string(),
             image,
+            signature: None,
         }
     }
 
@@ -149,12 +155,13 @@ impl AtomMetadata {
     }
 
     /// Creates a new atom metadata for a json object
-    pub fn json_object(image: Option<String>) -> Self {
+    pub fn json_object(image: Option<String>, signature: Option<String>) -> Self {
         Self {
             label: "json object".to_string(),
             emoji: "📦".to_string(),
             atom_type: "JsonObject".to_string(),
             image,
+            signature,
         }
     }
 
@@ -165,6 +172,7 @@ impl AtomMetadata {
             emoji: "🏷️".to_string(),
             atom_type: "Keywords".to_string(),
             image,
+            signature: None,
         }
     }
 
@@ -175,16 +183,18 @@ impl AtomMetadata {
             emoji: "👍".to_string(),
             atom_type: "LikeAction".to_string(),
             image,
+            signature: None,
         }
     }
 
     /// Creates a new atom metadata for an organization
-    pub fn organization(name: String, image: Option<String>) -> Self {
+    pub fn organization(name: String, image: Option<String>, signature: Option<String>) -> Self {
         Self {
             label: name,
             emoji: "🏢".to_string(),
             atom_type: "Organization".to_string(),
             image,
+            signature,
         }
     }
 
@@ -195,16 +205,18 @@ impl AtomMetadata {
             emoji: "🏢".to_string(),
             atom_type: "OrganizationPredicate".to_string(),
             image,
+            signature: None,
         }
     }
 
     /// Creates a new atom metadata for a person
-    pub fn person(name: String, image: Option<String>) -> Self {
+    pub fn person(name: String, image: Option<String>, signature: Option<String>) -> Self {
         Self {
             label: name,
             emoji: "👤".to_string(),
             atom_type: "Person".to_string(),
             image,
+            signature,
         }
     }
 
@@ -215,6 +227,7 @@ impl AtomMetadata {
             emoji: "👤".to_string(),
             atom_type: "PersonPredicate".to_string(),
             image,
+            signature: None,
         }
     }
 
@@ -229,16 +242,18 @@ impl AtomMetadata {
             emoji: "📝".to_string(),
             atom_type: "TextObject".to_string(),
             image: None,
+            signature: None,
         }
     }
 
     /// Creates a new atom metadata for a thing
-    pub fn thing(name: String, image: Option<String>) -> Self {
+    pub fn thing(name: String, image: Option<String>, signature: Option<String>) -> Self {
         Self {
             label: name,
             emoji: "🧩".to_string(),
             atom_type: "Thing".to_string(),
             image,
+            signature,
         }
     }
 
@@ -249,6 +264,7 @@ impl AtomMetadata {
             emoji: "🧩".to_string(),
             atom_type: "ThingPredicate".to_string(),
             image,
+            signature: None,
         }
     }
 
@@ -259,6 +275,7 @@ impl AtomMetadata {
             emoji: "❓".to_string(),
             atom_type: "Unknown".to_string(),
             image: None,
+            signature: None,
         }
     }
 
@@ -327,12 +344,14 @@ impl AtomMetadata {
         atom.atom_type = AtomType::from_str(&self.atom_type)?;
         atom.label = Some(self.label.clone());
         atom.image = self.image.clone();
+        atom.signature = self.signature.clone();
         atom.upsert(backend_schema, pg_pool).await?;
         Ok(AtomMetadata {
             label: self.label.clone(),
             emoji: self.emoji.clone(),
             atom_type: self.atom_type.clone(),
             image: self.image.clone(),
+            signature: self.signature.clone(),
         })
     }
 }

--- a/apps/consumer/src/mode/resolver/atom_resolver.rs
+++ b/apps/consumer/src/mode/resolver/atom_resolver.rs
@@ -83,7 +83,7 @@ async fn try_to_resolve_schema_org_properties(
         if let Ok(atom_type) = AtomType::from_str(obj_type) {
             match atom_type {
                 AtomType::Thing => {
-                    let signature = obj.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
+                    let platform = obj.get("platform").and_then(|s| s.as_str()).map(|s| s.to_string());
                     let thing = create_thing_from_obj(atom, obj)
                         .upsert(consumer_context.backend_schema(), consumer_context.pool())
                         .await?;
@@ -91,11 +91,11 @@ async fn try_to_resolve_schema_org_properties(
                     Ok(AtomMetadata::thing(
                         thing.name.unwrap_or_default(),
                         thing.image.clone(),
-                        signature,
+                        platform,
                     ))
                 }
                 AtomType::Person => {
-                    let signature = obj.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
+                    let platform = obj.get("platform").and_then(|s| s.as_str()).map(|s| s.to_string());
                     let person = create_person_from_obj(atom, obj)
                         .upsert(consumer_context.backend_schema(), consumer_context.pool())
                         .await?;
@@ -103,11 +103,11 @@ async fn try_to_resolve_schema_org_properties(
                     Ok(AtomMetadata::person(
                         person.name.unwrap_or_default(),
                         person.image.clone(),
-                        signature,
+                        platform,
                     ))
                 }
                 AtomType::Organization => {
-                    let signature = obj.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
+                    let platform = obj.get("platform").and_then(|s| s.as_str()).map(|s| s.to_string());
                     let organization = create_organization_from_obj(atom, obj)
                         .upsert(consumer_context.backend_schema(), consumer_context.pool())
                         .await?;
@@ -115,16 +115,16 @@ async fn try_to_resolve_schema_org_properties(
                     Ok(AtomMetadata::organization(
                         organization.name.unwrap_or_default(),
                         organization.image.clone(),
-                        signature,
+                        platform,
                     ))
                 }
                 AtomType::Book => {
-                    let signature = obj.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
+                    let platform = obj.get("platform").and_then(|s| s.as_str()).map(|s| s.to_string());
                     let book = create_book_from_obj(atom, obj)
                         .upsert(consumer_context.backend_schema(), consumer_context.pool())
                         .await?;
                     create_book_atom_value(atom, &book, consumer_context).await?;
-                    Ok(AtomMetadata::book(book.name.unwrap_or_default(), signature))
+                    Ok(AtomMetadata::book(book.name.unwrap_or_default(), platform))
                 }
                 _ => {
                     warn!("Unsupported schema.org type: {}", obj_type);
@@ -327,12 +327,12 @@ async fn handle_regular_json(
         "No @context found in JSON: {:?}, returning it as JsonObject",
         json
     );
-    let signature = json.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
+    let platform = json.get("platform").and_then(|s| s.as_str()).map(|s| s.to_string());
     let json_object = create_json_object_from_obj(atom, json)
         .upsert(consumer_context.backend_schema(), consumer_context.pool())
         .await?;
     create_json_object_atom_value(atom, &json_object, consumer_context).await?;
-    Ok(AtomMetadata::json_object(None, signature))
+    Ok(AtomMetadata::json_object(None, platform))
 }
 
 /// Handles binary data

--- a/apps/consumer/src/mode/resolver/atom_resolver.rs
+++ b/apps/consumer/src/mode/resolver/atom_resolver.rs
@@ -83,6 +83,7 @@ async fn try_to_resolve_schema_org_properties(
         if let Ok(atom_type) = AtomType::from_str(obj_type) {
             match atom_type {
                 AtomType::Thing => {
+                    let signature = obj.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
                     let thing = create_thing_from_obj(atom, obj)
                         .upsert(consumer_context.backend_schema(), consumer_context.pool())
                         .await?;
@@ -90,9 +91,11 @@ async fn try_to_resolve_schema_org_properties(
                     Ok(AtomMetadata::thing(
                         thing.name.unwrap_or_default(),
                         thing.image.clone(),
+                        signature,
                     ))
                 }
                 AtomType::Person => {
+                    let signature = obj.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
                     let person = create_person_from_obj(atom, obj)
                         .upsert(consumer_context.backend_schema(), consumer_context.pool())
                         .await?;
@@ -100,9 +103,11 @@ async fn try_to_resolve_schema_org_properties(
                     Ok(AtomMetadata::person(
                         person.name.unwrap_or_default(),
                         person.image.clone(),
+                        signature,
                     ))
                 }
                 AtomType::Organization => {
+                    let signature = obj.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
                     let organization = create_organization_from_obj(atom, obj)
                         .upsert(consumer_context.backend_schema(), consumer_context.pool())
                         .await?;
@@ -110,14 +115,16 @@ async fn try_to_resolve_schema_org_properties(
                     Ok(AtomMetadata::organization(
                         organization.name.unwrap_or_default(),
                         organization.image.clone(),
+                        signature,
                     ))
                 }
                 AtomType::Book => {
+                    let signature = obj.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
                     let book = create_book_from_obj(atom, obj)
                         .upsert(consumer_context.backend_schema(), consumer_context.pool())
                         .await?;
                     create_book_atom_value(atom, &book, consumer_context).await?;
-                    Ok(AtomMetadata::book(book.name.unwrap_or_default()))
+                    Ok(AtomMetadata::book(book.name.unwrap_or_default(), signature))
                 }
                 _ => {
                     warn!("Unsupported schema.org type: {}", obj_type);
@@ -320,11 +327,12 @@ async fn handle_regular_json(
         "No @context found in JSON: {:?}, returning it as JsonObject",
         json
     );
+    let signature = json.get("signature").and_then(|s| s.as_str()).map(|s| s.to_string());
     let json_object = create_json_object_from_obj(atom, json)
         .upsert(consumer_context.backend_schema(), consumer_context.pool())
         .await?;
     create_json_object_atom_value(atom, &json_object, consumer_context).await?;
-    Ok(AtomMetadata::json_object(None))
+    Ok(AtomMetadata::json_object(None, signature))
 }
 
 /// Handles binary data

--- a/apps/models/src/atom.rs
+++ b/apps/models/src/atom.rs
@@ -28,7 +28,7 @@ pub struct Atom {
     pub transaction_hash: String,
     pub resolving_status: AtomResolvingStatus,
     pub log_index: i64,
-    pub signature: Option<String>,
+    pub platform: Option<String>,
 }
 
 #[derive(sqlx::Type, Clone, Debug, Display, EnumString, PartialEq, Serialize, Deserialize)]
@@ -78,7 +78,7 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
             WITH upsert AS (
                 INSERT INTO {0}.atom (
                     wallet_id, creator_id, term_id, data, raw_data, type, emoji, label,
-                    image, value_id, block_number, created_at, transaction_hash, resolving_status, log_index, signature
+                    image, value_id, block_number, created_at, transaction_hash, resolving_status, log_index, platform
                 )
                 VALUES (
                     $1, $2, $3, $4, $5, $6::text::{0}.atom_type, $7, $8, $9, $10, $11, $12, $13, $14::text::{0}.atom_resolving_status, $15, $16
@@ -98,7 +98,7 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
                     transaction_hash = EXCLUDED.transaction_hash,
                     resolving_status = EXCLUDED.resolving_status,
                     log_index = EXCLUDED.log_index,
-                    signature = EXCLUDED.signature
+                    platform = EXCLUDED.platform
                 RETURNING
                     wallet_id,
                     creator_id,
@@ -115,7 +115,7 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
                     transaction_hash,
                     resolving_status,
                     log_index,
-                    signature
+                    platform
             )
             SELECT * FROM upsert
             UNION ALL
@@ -135,7 +135,7 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
                 transaction_hash,
                 resolving_status,
                 log_index,
-                signature
+                platform
             FROM {0}.atom
             WHERE term_id = $3
               AND NOT EXISTS (SELECT 1 FROM upsert)
@@ -159,7 +159,7 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
             .bind(self.transaction_hash.clone())
             .bind(self.resolving_status.to_string())
             .bind(self.log_index)
-            .bind(self.signature.clone())
+            .bind(self.platform.clone())
             .fetch_one(executor)
             .await
             .map_err(ModelError::from)
@@ -203,7 +203,7 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
                    transaction_hash,
                    resolving_status,
                    log_index,
-                   signature
+                   platform
             FROM {}.atom
             WHERE term_id = $1
             "#,

--- a/apps/models/src/atom.rs
+++ b/apps/models/src/atom.rs
@@ -28,6 +28,7 @@ pub struct Atom {
     pub transaction_hash: String,
     pub resolving_status: AtomResolvingStatus,
     pub log_index: i64,
+    pub signature: Option<String>,
 }
 
 #[derive(sqlx::Type, Clone, Debug, Display, EnumString, PartialEq, Serialize, Deserialize)]
@@ -77,10 +78,10 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
             WITH upsert AS (
                 INSERT INTO {0}.atom (
                     wallet_id, creator_id, term_id, data, raw_data, type, emoji, label,
-                    image, value_id, block_number, created_at, transaction_hash, resolving_status, log_index
+                    image, value_id, block_number, created_at, transaction_hash, resolving_status, log_index, signature
                 )
                 VALUES (
-                    $1, $2, $3, $4, $5, $6::text::{0}.atom_type, $7, $8, $9, $10, $11, $12, $13, $14::text::{0}.atom_resolving_status, $15
+                    $1, $2, $3, $4, $5, $6::text::{0}.atom_type, $7, $8, $9, $10, $11, $12, $13, $14::text::{0}.atom_resolving_status, $15, $16
                 )
                 ON CONFLICT (term_id) DO UPDATE SET
                     wallet_id = EXCLUDED.wallet_id,
@@ -96,7 +97,8 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
                     created_at = EXCLUDED.created_at,
                     transaction_hash = EXCLUDED.transaction_hash,
                     resolving_status = EXCLUDED.resolving_status,
-                    log_index = EXCLUDED.log_index
+                    log_index = EXCLUDED.log_index,
+                    signature = EXCLUDED.signature
                 RETURNING
                     wallet_id,
                     creator_id,
@@ -112,7 +114,8 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
                     created_at,
                     transaction_hash,
                     resolving_status,
-                    log_index
+                    log_index,
+                    signature
             )
             SELECT * FROM upsert
             UNION ALL
@@ -131,7 +134,8 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
                 created_at,
                 transaction_hash,
                 resolving_status,
-                log_index
+                log_index,
+                signature
             FROM {0}.atom
             WHERE term_id = $3
               AND NOT EXISTS (SELECT 1 FROM upsert)
@@ -155,6 +159,7 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
             .bind(self.transaction_hash.clone())
             .bind(self.resolving_status.to_string())
             .bind(self.log_index)
+            .bind(self.signature.clone())
             .fetch_one(executor)
             .await
             .map_err(ModelError::from)
@@ -197,7 +202,8 @@ impl SimpleCrud<FixedBytesWrapper> for Atom {
                    created_at,
                    transaction_hash,
                    resolving_status,
-                   log_index
+                   log_index,
+                   signature
             FROM {}.atom
             WHERE term_id = $1
             "#,

--- a/apps/models/src/triple.rs
+++ b/apps/models/src/triple.rs
@@ -20,7 +20,7 @@ pub struct Triple {
     pub block_number: U256Wrapper,
     pub created_at: DateTime<Utc>,
     pub transaction_hash: String,
-    pub signature: Option<String>,
+    pub platform: Option<String>,
 }
 
 /// This is a trait that all models must implement.
@@ -36,7 +36,7 @@ impl SimpleCrud<FixedBytesWrapper> for Triple {
     {
         let query = format!(
             r#"
-            INSERT INTO {}.triple (creator_id, subject_id, predicate_id, object_id, term_id, counter_term_id, block_number, created_at, transaction_hash, signature)
+            INSERT INTO {}.triple (creator_id, subject_id, predicate_id, object_id, term_id, counter_term_id, block_number, created_at, transaction_hash, platform)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (term_id) DO UPDATE SET
                 creator_id = EXCLUDED.creator_id,
@@ -48,9 +48,9 @@ impl SimpleCrud<FixedBytesWrapper> for Triple {
                 block_number = EXCLUDED.block_number,
                 created_at = EXCLUDED.created_at,
                 transaction_hash = EXCLUDED.transaction_hash,
-                signature = EXCLUDED.signature
+                platform = EXCLUDED.platform
             RETURNING creator_id, subject_id, predicate_id, object_id, 
-                      term_id, counter_term_id, block_number, created_at, transaction_hash, signature
+                      term_id, counter_term_id, block_number, created_at, transaction_hash, platform
             "#,
             schema,
         );
@@ -65,7 +65,7 @@ impl SimpleCrud<FixedBytesWrapper> for Triple {
             .bind(self.block_number.to_big_decimal()?)
             .bind(self.created_at)
             .bind(&self.transaction_hash)
-            .bind(self.signature.clone())
+            .bind(self.platform.clone())
             .fetch_one(executor)
             .await
             .map_err(ModelError::from)
@@ -92,7 +92,7 @@ impl SimpleCrud<FixedBytesWrapper> for Triple {
                 block_number, 
                 created_at, 
                 transaction_hash, 
-                signature
+                platform
             FROM {}.triple
             WHERE term_id = $1 OR counter_term_id = $1
             "#,

--- a/apps/models/src/triple.rs
+++ b/apps/models/src/triple.rs
@@ -20,6 +20,7 @@ pub struct Triple {
     pub block_number: U256Wrapper,
     pub created_at: DateTime<Utc>,
     pub transaction_hash: String,
+    pub signature: Option<String>,
 }
 
 /// This is a trait that all models must implement.
@@ -35,8 +36,8 @@ impl SimpleCrud<FixedBytesWrapper> for Triple {
     {
         let query = format!(
             r#"
-            INSERT INTO {}.triple (creator_id, subject_id, predicate_id, object_id, term_id, counter_term_id, block_number, created_at, transaction_hash)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            INSERT INTO {}.triple (creator_id, subject_id, predicate_id, object_id, term_id, counter_term_id, block_number, created_at, transaction_hash, signature)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             ON CONFLICT (term_id) DO UPDATE SET
                 creator_id = EXCLUDED.creator_id,
                 subject_id = EXCLUDED.subject_id,
@@ -46,9 +47,10 @@ impl SimpleCrud<FixedBytesWrapper> for Triple {
                 counter_term_id = EXCLUDED.counter_term_id,
                 block_number = EXCLUDED.block_number,
                 created_at = EXCLUDED.created_at,
-                transaction_hash = EXCLUDED.transaction_hash
+                transaction_hash = EXCLUDED.transaction_hash,
+                signature = EXCLUDED.signature
             RETURNING creator_id, subject_id, predicate_id, object_id, 
-                      term_id, counter_term_id, block_number, created_at, transaction_hash
+                      term_id, counter_term_id, block_number, created_at, transaction_hash, signature
             "#,
             schema,
         );
@@ -63,6 +65,7 @@ impl SimpleCrud<FixedBytesWrapper> for Triple {
             .bind(self.block_number.to_big_decimal()?)
             .bind(self.created_at)
             .bind(&self.transaction_hash)
+            .bind(self.signature.clone())
             .fetch_one(executor)
             .await
             .map_err(ModelError::from)
@@ -88,7 +91,8 @@ impl SimpleCrud<FixedBytesWrapper> for Triple {
                 counter_term_id, 
                 block_number, 
                 created_at, 
-                transaction_hash
+                transaction_hash, 
+                signature
             FROM {}.triple
             WHERE term_id = $1 OR counter_term_id = $1
             "#,


### PR DESCRIPTION
## Summary
  - Add optional `platform` field to `Atom` and `Triple` models
  - Extract `platform` from JSON data in atom resolver
  - Allow filtering atoms/triples by DApp signature (e.g., "Sofia")

  ## Changes
  - Updated `Atom` and `Triple` structs with `platform: Option<String>`
  - Modified SQL queries to include platform field
  - Added platform extraction in `atom_resolver.rs`
  - All existing tests pass 

  ## Test 
  - Unit tests pass (7/7) 
  - Models and consumer packages compile successfully 
  - Ready for GraphQL filtering: `WHERE plateform = 'Sofia'`