### PR TITLE
Add chart-api PnL endpoints

### DIFF
--- a/.cargo/makefiles/development.toml
+++ b/.cargo/makefiles/development.toml
@@ -98,6 +98,16 @@ dependencies = ["stop", "start-local"]
 [tasks.quick-restart]
 dependencies = ["stop", "start-local"]
 
+# Run the chart-api server locally
+[tasks.chart-api-local]
+env = { RUST_LOG = "info" }
+command = "cargo"
+args = [
+    "run",
+    "--bin",
+    "chart-api"
+]
+
 # Simply format and lint checking with `cargo clippy` for all targets
 # in the workspace, promoting `warnings` to `errors`
 [tasks.clippy]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chart-api"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "axum",
+ "chrono",
+ "dotenvy",
+ "env_logger",
+ "envy",
+ "http 1.3.1",
+ "log",
+ "models",
+ "redis",
+ "serde",
+ "serde_json",
+ "shared-utils",
+ "sqlx",
+ "svg",
+ "thiserror 2.0.16",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "utoipa",
+ "utoipa-swagger-ui",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6098,6 +6126,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svg"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["apps/cli", "apps/tui", "apps/consumer", "apps/histocrawler", "apps/image-guard", "apps/models", "apps/rpc-proxy", "apps/shared-utils"]
+members = ["apps/chart-api", "apps/cli", "apps/tui", "apps/consumer", "apps/histocrawler", "apps/image-guard", "apps/models", "apps/rpc-proxy", "apps/shared-utils"]
 
 
 [workspace.dependencies]

--- a/apps/chart-api/ANALYSIS.md
+++ b/apps/chart-api/ANALYSIS.md
@@ -1,0 +1,321 @@
+# Chart-API Analysis
+
+## 1. Overall Architecture and Structure
+
+The **chart-api** is a high-performance REST API built with **Axum** that serves share price chart data for the Intuition protocol. It follows a clean, modular architecture:
+
+### Directory Structure
+```
+chart-api/
+├── src/
+│   ├── main.rs              # Entry point
+│   ├── app.rs               # Application setup & router
+│   ├── state.rs             # Shared application state
+│   ├── types.rs             # Core type definitions
+│   ├── error.rs             # Error handling
+│   ├── openapi.rs           # OpenAPI/Swagger configuration
+│   ├── endpoints/
+│   │   ├── mod.rs
+│   │   └── chart_data.rs    # Main chart endpoint handler
+│   ├── models/
+│   │   ├── mod.rs
+│   │   └── chart_data.rs    # Data models for chart responses
+│   ├── services/
+│   │   ├── mod.rs
+│   │   ├── data_fetcher.rs  # PostgreSQL/TimescaleDB queries
+│   │   ├── gap_filler.rs    # Time series gap-filling logic
+│   │   └── svg_generator.rs # SVG chart generation
+│   └── cache/
+│       ├── mod.rs
+│       └── redis.rs         # Redis caching layer
+```
+
+### Architectural Flow
+```
+Client Request → Axum Router → Redis Cache Check →
+PostgreSQL/TimescaleDB Query → Gap Filling →
+Format (JSON/SVG) → Cache & Return
+```
+
+---
+
+## 2. Main Dependencies and Their Purposes
+
+### Core Framework Dependencies
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| axum | 0.8.4 | Web framework for building the REST API |
+| tokio | 1.20.1 | Async runtime |
+| tower-http | 0.6.2 | CORS middleware |
+
+### Database & Caching
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| sqlx | 0.8.6 | PostgreSQL database access with compile-time query checking |
+| redis | 0.32.0 | Redis caching with async support |
+
+### Data Handling
+| Dependency | Purpose |
+|------------|---------|
+| alloy (workspace) | Ethereum types (U256, FixedBytes) for blockchain data |
+| chrono (workspace) | DateTime manipulation |
+| serde / serde_json (workspace) | Serialization/deserialization |
+
+### Visualization
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| svg | 0.18.0 | Lightweight SVG generation (no runtime dependencies) |
+
+### Documentation
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| utoipa | 5.4.0 | OpenAPI spec generation |
+| utoipa-swagger-ui | 9.0.2 | Interactive API documentation |
+
+### Workspace Dependencies
+- **models**: Shared data models (U256Wrapper, database entities)
+- **shared-utils**: Common utilities (PostgreSQL connection pooling)
+
+---
+
+## 3. API Endpoints and Functionality
+
+### Primary Endpoint
+```
+GET /api/v1/curves/{curve_id}/terms/{term_id}/data
+```
+
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| curve_id | String | Numeric identifier for the bonding curve |
+| term_id | String | Hex identifier (e.g., `0x1234...abcd`) |
+
+**Query Parameters:**
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| interval | Yes | Time bucket interval (`1h`, `1d`, `1w`, `1m`) |
+| format | Yes | Output format (`json`, `svg`) |
+| count | No | Number of data points (defaults based on interval) |
+| width | No | SVG width in pixels (default: 800) |
+| height | No | SVG height in pixels (default: 400) |
+| line_color | No | SVG line color (default: `#3B82F6`) |
+| background_color | No | SVG background color (default: transparent) |
+
+**Default Count Values:**
+| Interval | Default Count | Coverage |
+|----------|---------------|----------|
+| Hourly (`1h`) | 24 | Last 24 hours |
+| Daily (`1d`) | 30 | Last 30 days |
+| Weekly (`1w`) | 12 | Last 12 weeks |
+| Monthly (`1m`) | 12 | Last 12 months |
+
+### Auxiliary Endpoints
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /health` | Health check (returns "OK") |
+| `GET /swagger-ui/` | Interactive API documentation |
+| `GET /api-docs/openapi.json` | OpenAPI specification |
+
+---
+
+## 4. Data Models and Types
+
+### Core Types (`src/types.rs`)
+
+**`Interval` Enum:**
+```rust
+enum Interval {
+    Hourly,   // 1h
+    Daily,    // 1d
+    Weekly,   // 1w
+    Monthly,  // 1m
+}
+```
+
+**`OutputFormat` Enum:**
+```rust
+enum OutputFormat {
+    Json,
+    Svg,
+}
+```
+
+**`SvgConfig` Struct:**
+- Configurable dimensions, colors, line width, padding
+
+### Data Models (`src/models/chart_data.rs`)
+
+**`ChartDataPoint`:**
+```rust
+struct ChartDataPoint {
+    timestamp: DateTime<Utc>,
+    share_price: U256Wrapper,  // Serialized as string for precision
+}
+```
+
+**`ChartResponse` (JSON output):**
+```rust
+struct ChartResponse {
+    term_id: String,
+    curve_id: String,
+    interval: String,
+    count: usize,
+    data: Vec<ChartDataPoint>,
+}
+```
+
+**`AggregateDataPoint` (from TimescaleDB):**
+```rust
+struct AggregateDataPoint {
+    bucket: DateTime<Utc>,
+    term_id: String,
+    curve_id: U256Wrapper,
+    first_share_price: U256Wrapper,
+    last_share_price: U256Wrapper,
+    difference: U256Wrapper,
+    change_count: i64,
+}
+```
+
+---
+
+## 5. Notable Patterns, Design Decisions, and Areas of Concern
+
+### Design Strengths
+
+#### 1. Intelligent Caching Strategy
+- Redis caching with **interval-based TTL** (30s-5min)
+- Cache keys include all query parameters to avoid stale data
+- Smart cache-aside pattern with automatic population
+
+#### 2. Gap-Filling Algorithm
+- Ensures continuous time series even with missing data
+- Three-tier fallback strategy:
+  1. Use actual data points and fill gaps with last known value
+  2. If no data in range, use most recent historical data
+  3. Return 404 if no data exists at all
+
+#### 3. TimescaleDB Continuous Aggregates
+- Queries pre-computed aggregate views:
+  - `share_price_change_stats_hourly`
+  - `share_price_change_stats_daily`
+  - `share_price_change_stats_weekly`
+  - `share_price_change_stats_monthly`
+
+#### 4. Type-Safe Architecture
+- Extensive use of `Result<T, ApiError>` for error handling
+- Custom `ApiError` type with `thiserror` for clear error messages
+- Proper HTTP status code mapping (400, 404, 500)
+
+#### 5. Precision Handling
+- U256 values serialized as strings in JSON to avoid JavaScript precision loss
+
+#### 6. Separation of Concerns
+- Clean module boundaries: endpoints, services, models, cache
+- Services are testable and independent
+- Dependency injection via `AppState`
+
+### Design Concerns & Potential Issues
+
+| Issue | Risk Level | Description | Recommendation |
+|-------|------------|-------------|----------------|
+| SQL Query Construction | LOW | Uses format! for view names (from trusted enum) | Consider `sqlx::query_builder` for full parameterization |
+| Gap-Filling Complexity | MEDIUM | Monthly intervals use approximate 30-day duration | Add extensive unit tests for edge cases |
+| SVG Precision Loss | LOW | Large U256 values lose precision when converted to f64 | Acceptable for charts, document inline |
+| Redis Connection | MEDIUM | No connection health checks or retry logic | Add timeout handling and pool monitoring |
+| No LIMIT Clause | MEDIUM | Could return excessive data for malformed requests | Add maximum count validation (e.g., max 1000) |
+| Error Context Loss | LOW | Specific errors converted to generic Internal error | Preserve error types for debugging |
+| CORS Policy | MEDIUM | Allows all origins | Restrict to known origins in production |
+| Missing Input Validation | HIGH | No validation on count, term_id, curve_id | Add validation layer before database queries |
+| Test Coverage | MEDIUM | Only 3 test functions across 2 modules | Add comprehensive test suite |
+
+---
+
+## 6. Integration with intuition-rs Project
+
+### Workspace Integration
+- Part of a monorepo workspace with 8 other applications
+- Shares common dependencies via `[workspace.dependencies]`
+- Uses **edition = "2024"** (bleeding-edge Rust edition)
+
+### Internal Dependencies
+
+| Crate | Location | Usage |
+|-------|----------|-------|
+| models | `apps/models` | U256Wrapper, database entities, error types |
+| shared-utils | `apps/shared-utils` | PostgreSQL connection pooling |
+
+### Database Schema Expectations
+
+**Tables:**
+- `vault`: Stores term_id/curve_id combinations for validation
+- `share_price_change`: Hypertable tracking price changes over time
+
+**Continuous Aggregates:**
+```sql
+-- Expected aggregate view schema
+bucket TIMESTAMP,
+term_id TEXT,
+curve_id NUMERIC(78, 0),
+first_share_price NUMERIC(78, 0),
+last_share_price NUMERIC(78, 0),
+difference NUMERIC(78, 0),
+change_count BIGINT
+```
+
+### Deployment Architecture
+- Built as part of `ghcr.io/0xintuition/apps:latest` multi-binary image
+- Runs as separate container in `docker-compose-apps.yml`
+- Exposed on port 3010
+- Depends on: PostgreSQL (port 5435), Redis (port 6379)
+
+### Related Applications
+| App | Purpose |
+|-----|---------|
+| consumer | Ingests blockchain events and populates `share_price_change` |
+| histocrawler | Backfills historical data |
+| rpc-proxy | Provides blockchain RPC access |
+| cli/tui | Administrative tools |
+
+---
+
+## 7. Recommendations
+
+### Immediate Actions (High Priority)
+1. Add input validation for `count`, `term_id`, `curve_id` parameters
+2. Implement max count limit (e.g., 1000) to prevent excessive queries
+3. Add connection retry logic for Redis and PostgreSQL
+4. Restrict CORS origins in production
+
+### Medium Priority
+5. Expand test coverage (target: 80%+ for services and endpoints)
+6. Add query result size limits to database queries
+7. Implement connection pool monitoring and health checks
+8. Add structured logging with request tracing
+
+### Low Priority
+9. Improve error context preservation in error mapping
+10. Document timezone handling for timestamp truncation
+11. Add request rate limiting to prevent abuse
+
+---
+
+## Summary
+
+The **chart-api** is a well-architected, purpose-built microservice for serving time-series chart data from the Intuition protocol.
+
+**Strengths:**
+- Excellent separation of concerns with clear module boundaries
+- Smart caching strategy with interval-based TTL
+- Robust gap-filling logic for continuous time series
+- Type-safe design leveraging Rust's strengths
+- Good documentation (comprehensive README, OpenAPI spec)
+
+**Areas for Improvement:**
+- Enhanced input validation
+- Expanded test coverage
+- Better error context preservation
+- Production-hardened security (CORS, rate limiting)
+
+The application integrates cleanly into the larger `intuition-rs` ecosystem, relying on shared models and utilities while maintaining independence as a deployable service.

--- a/apps/chart-api/Cargo.toml
+++ b/apps/chart-api/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "chart-api"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+alloy.workspace = true
+axum = { version = "0.8.4", features = ["tokio"] }
+chrono.workspace = true
+dotenvy.workspace = true
+env_logger.workspace = true
+envy.workspace = true
+http = "1.1.0"
+log.workspace = true
+models = { path = "../models" }
+redis = { version = "0.32.0", features = ["tokio-comp", "connection-manager"] }
+serde.workspace = true
+serde_json.workspace = true
+shared-utils = { path = "../shared-utils" }
+sqlx.workspace = true
+svg = "0.18.0"
+thiserror.workspace = true
+tokio.workspace = true
+tower-http = { version = "0.6.2", features = ["cors"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+utoipa = { version = "5.4.0" }
+utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }

--- a/apps/chart-api/Dockerfile
+++ b/apps/chart-api/Dockerfile
@@ -1,0 +1,57 @@
+# Stage 1 - Generate recipe file
+FROM rust:1.89.0-slim-bookworm AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 2 - Build dependencies and application
+FROM rust:1.89.0-slim-bookworm AS builder
+RUN cargo install cargo-chef
+WORKDIR /app
+COPY --from=planner /app/recipe.json recipe.json
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    cmake \
+    libclang-dev \
+    libssl-dev \
+    pkg-config \
+    curl \
+    capnproto \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo chef cook --release --recipe-path recipe.json
+
+COPY . .
+ENV SQLX_OFFLINE=true
+RUN cargo build --release --bin chart-api
+
+# Stage 3 - Final runtime image
+FROM debian:bookworm-slim AS runtime
+
+# Create non-root user
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+# Install runtime dependencies only
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Workdir
+WORKDIR /app
+
+# Copy binary from builder (with ownership set at copy time)
+COPY --from=builder --chown=appuser:appuser /app/target/release/chart-api /app/chart-api
+
+# Use non-root user
+USER appuser
+
+# Set runtime configs
+ENV RUST_LOG=info
+
+CMD ["/app/chart-api"]

--- a/apps/chart-api/README.md
+++ b/apps/chart-api/README.md
@@ -1,0 +1,346 @@
+# Chart API
+
+A high-performance Axum-based REST API for serving share price chart data with Redis caching, automatic gap-filling, and SVG chart generation.
+
+## Features
+
+- **Multiple Output Formats**: JSON data or SVG line charts
+- **Automatic Gap-Filling**: Returns continuous time series even when data points are missing
+- **Redis Caching**: Intelligent caching with interval-based TTL
+- **TimescaleDB Integration**: Leverages continuous aggregates for efficient queries
+- **OpenAPI Documentation**: Swagger UI for interactive API exploration
+- **Configurable SVG Charts**: Customize dimensions, colors, and styling
+
+## API Endpoint
+
+```
+GET /api/v1/curve/{curve_id}/term/{term_id}/data
+```
+
+### Path Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `curve_id` | string | The curve identifier (numeric, stored as string for precision) |
+| `term_id` | string | The term identifier (hex string, e.g., `0x...`) |
+
+### Query Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `interval` | string | Yes | - | Time interval: `1h`, `1d`, `1w`, `1m` |
+| `format` | string | Yes | - | Output format: `json` or `svg` |
+| `start` | string | Yes | - | Range start timestamp (unix seconds, unix milliseconds, or RFC3339) |
+| `end` | string | Yes | - | Range end timestamp (unix seconds, unix milliseconds, or RFC3339) |
+| `width` | integer | No | `800` | SVG width in pixels |
+| `height` | integer | No | `400` | SVG height in pixels |
+| `line_color` | string | No | `#3B82F6` | SVG line color (hex) |
+| `background_color` | string | No | transparent | SVG background color (hex) |
+
+### Range Behavior
+
+Data points are derived from the aligned interval buckets within `[start, end)`. For example:
+- `start=2026-01-01T00:00:00Z`, `end=2026-02-01T00:00:00Z`, `interval=1w` → 4 points
+- `start=2026-01-01T00:00:00Z`, `end=2026-02-01T00:00:00Z`, `interval=1d` → 31 points
+
+## Response Formats
+
+### JSON Response
+
+```json
+{
+  "term_id": "0x1234...abcd",
+  "curve_id": "1",
+  "interval": "1d",
+  "count": 30,
+  "data": [
+    {
+      "timestamp": "2024-01-01T00:00:00Z",
+      "share_price": "1000000000000000000"
+    },
+    {
+      "timestamp": "2024-01-02T00:00:00Z",
+      "share_price": "1050000000000000000"
+    }
+  ]
+}
+```
+
+> **Note**: `share_price` is serialized as a string to preserve precision for large numbers (U256).
+
+### SVG Response
+
+Returns an SVG line chart with:
+- Responsive viewBox
+- Subtle grid lines
+- Configurable line color and dimensions
+- "No data available" message when empty
+
+Content-Type: `image/svg+xml`
+
+## Gap-Filling Behavior
+
+The API ensures continuous time series data:
+
+1. **Data exists for the requested range**: Returns actual data points with gaps filled using the last known value.
+
+2. **No data in requested range but historical data exists**: Uses the most recent historical data point to create a constant line.
+
+3. **No data exists at all**: Returns a `404 Not Found` error.
+
+### Example
+
+If data exists for Day 1 and Day 5:
+- Day 1: `1000` (actual)
+- Day 2: `1000` (filled from Day 1)
+- Day 3: `1000` (filled from Day 1)
+- Day 4: `1000` (filled from Day 1)
+- Day 5: `1200` (actual)
+
+## Caching
+
+Redis caching with interval-based TTL:
+
+| Interval | Cache TTL |
+|----------|-----------|
+| `1h` | 30 seconds |
+| `1d` | 60 seconds |
+| `1w` | 120 seconds |
+| `1m` | 300 seconds |
+
+Cache key format: `chart:{graph_type}:{term_id}:{curve_id}:{interval}:{start}:{end}:{format}`
+
+## Error Responses
+
+| Status Code | Description |
+|-------------|-------------|
+| `400 Bad Request` | Invalid term_id/curve_id combination, invalid interval, or invalid format |
+| `404 Not Found` | No data available for the requested term/curve |
+| `500 Internal Server Error` | Database or internal error |
+
+### Error Response Body
+
+```json
+{
+  "error": "Invalid term_id/curve_id combination: no vault exists"
+}
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `CHART_API_PORT` | Yes | - | Port to listen on (e.g., `3010`) |
+| `DATABASE_URL` | Yes | - | PostgreSQL connection string |
+| `REDIS_URL` | Yes | - | Redis connection string |
+| `CORS_ALLOWED_ORIGINS` | No | `*` | Comma-separated list of allowed CORS origins |
+| `RUST_LOG` | No | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+
+### Example `.env` File
+
+```env
+CHART_API_PORT=3010
+DATABASE_URL=postgres://postgres:postgres@localhost:5435/storage
+REDIS_URL=redis://localhost:6379
+RUST_LOG=info
+```
+
+## Running Locally
+
+### Prerequisites
+
+- Rust 1.89+
+- PostgreSQL with TimescaleDB
+- Redis
+- The database must have the required tables and continuous aggregates
+
+### Using Cargo Make
+
+```bash
+# Start the required infrastructure (DB, Redis, etc.)
+cargo make start-docker-shared
+
+# Run the chart-api locally
+cargo make chart-api-local
+```
+
+### Using Cargo Directly
+
+```bash
+# Set environment variables
+export CHART_API_PORT=3010
+export DATABASE_URL=postgres://postgres:postgres@localhost:5435/storage
+export REDIS_URL=redis://localhost:6379
+
+# Run the service
+cargo run --bin chart-api
+```
+
+## Docker Deployment
+
+### Build
+
+```bash
+# Build the Docker image
+docker build -f apps/chart-api/Dockerfile -t chart-api .
+
+# Or build all apps (includes chart-api)
+cargo make build-apps
+```
+
+### Run with Docker Compose
+
+The service is configured in `docker/docker-compose-apps.yml`:
+
+```yaml
+chart-api:
+  container_name: chart-api
+  image: ghcr.io/0xintuition/apps:latest
+  command: ./chart-api
+  environment:
+    CHART_API_PORT: '3010'
+    DATABASE_URL: 'postgres://postgres:postgres@database:5435/storage'
+    REDIS_URL: 'redis://redis:6379'
+    RUST_LOG: 'info'
+  restart: always
+  ports:
+    - 3010:3010
+```
+
+```bash
+# Start all services
+cargo make start-docker-apps
+```
+
+## API Documentation
+
+Swagger UI is available at:
+
+```
+http://localhost:3010/swagger-ui/
+```
+
+OpenAPI JSON spec:
+
+```
+http://localhost:3010/api-docs/openapi.json
+```
+
+## Health Check
+
+```
+GET /health
+```
+
+Returns `OK` with status `200` if the service is running.
+
+## Examples
+
+### Get Daily JSON Data (Monthly Range)
+
+```bash
+curl "http://localhost:3010/api/v1/curves/1/terms/0x1234abcd/data?interval=1d&format=json&start=2026-01-01T00:00:00Z&end=2026-02-01T00:00:00Z"
+```
+
+### Get Hourly JSON Data (48-Hour Range)
+
+```bash
+curl "http://localhost:3010/api/v1/curves/1/terms/0x1234abcd/data?interval=1h&format=json&start=2026-01-01T00:00:00Z&end=2026-01-03T00:00:00Z"
+```
+
+### Get SVG Chart (Default Styling)
+
+```bash
+curl "http://localhost:3010/api/v1/curves/1/terms/0x1234abcd/data?interval=1d&format=svg&start=2026-01-01T00:00:00Z&end=2026-02-01T00:00:00Z" > chart.svg
+```
+
+### Get Custom SVG Chart
+
+```bash
+curl "http://localhost:3010/api/v1/curves/1/terms/0x1234abcd/data?interval=1w&format=svg&start=2026-01-01T00:00:00Z&end=2026-02-01T00:00:00Z&width=1200&height=600&line_color=%23FF5733&background_color=%23FFFFFF" > chart.svg
+```
+
+### Embed SVG in HTML
+
+```html
+<img src="http://localhost:3010/api/v1/curves/1/terms/0x1234abcd/data?interval=1d&format=svg&start=2026-01-01T00:00:00Z&end=2026-02-01T00:00:00Z" alt="Share Price Chart" />
+```
+
+## Database Requirements
+
+The API queries the following TimescaleDB continuous aggregates:
+
+- `share_price_change_stats_hourly`
+- `share_price_change_stats_daily`
+- `share_price_change_stats_weekly`
+- `share_price_change_stats_monthly`
+
+These are automatically maintained by TimescaleDB based on the `share_price_change` hypertable.
+
+### Required Tables
+
+- `vault` - For validating term_id/curve_id combinations
+- `share_price_change` - Source hypertable for price data
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         Client Request                          │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                          Axum Router                            │
+│  GET /api/v1/curves/{curve_id}/terms/{term_id}/data            │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                        Redis Cache                              │
+│  Key: chart:{graph_type}:{term_id}:{curve_id}:{interval}:{start}:{end}:{format}   │
+│  TTL: 30s - 300s based on interval                             │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                         Cache Miss
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                       Data Fetcher                              │
+│  Queries TimescaleDB continuous aggregates                      │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                        Gap Filler                               │
+│  Fills missing time buckets with last known values              │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Response Generator                           │
+│  JSON serialization or SVG chart generation                     │
+└─────────────────────────────────────────────────────────────────┘
+                                │
+                                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      Cache & Return                             │
+│  Store in Redis, return to client                               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Performance Considerations
+
+1. **Continuous Aggregates**: Pre-computed by TimescaleDB, ensuring fast queries even for large datasets.
+
+2. **Redis Caching**: Reduces database load for frequently requested charts.
+
+3. **Gap-Filling in Application**: Performed in Rust for maximum flexibility and performance.
+
+4. **SVG Generation**: Lightweight `svg` crate with no runtime dependencies.
+
+## License
+
+See the repository root for license information.

--- a/apps/chart-api/src/app.rs
+++ b/apps/chart-api/src/app.rs
@@ -1,5 +1,11 @@
 use crate::{
-    endpoints::get_chart_data, error::ApiError, openapi::ApiDoc, state::AppState, types::Env,
+    endpoints::{
+        get_account_pnl_chart, get_account_pnl_current, get_chart_data, get_position_pnl_chart,
+    },
+    error::ApiError,
+    openapi::ApiDoc,
+    state::AppState,
+    types::Env,
 };
 use axum::{Router, extract::State, routing::get};
 use http::{
@@ -115,6 +121,15 @@ impl App {
             .route(
                 "/api/v1/curve/{curve_id}/term/{term_id}/data",
                 get(get_chart_data),
+            )
+            .route(
+                "/api/v1/accounts/{account_id}/positions/{term_id}/{curve_id}/pnl",
+                get(get_position_pnl_chart),
+            )
+            .route("/api/v1/accounts/{account_id}/pnl", get(get_account_pnl_chart))
+            .route(
+                "/api/v1/accounts/{account_id}/pnl/current",
+                get(get_account_pnl_current),
             )
             .route("/health", get(health_check))
             .with_state(self.app_state.clone())

--- a/apps/chart-api/src/app.rs
+++ b/apps/chart-api/src/app.rs
@@ -1,0 +1,191 @@
+use crate::{
+    endpoints::get_chart_data, error::ApiError, openapi::ApiDoc, state::AppState, types::Env,
+};
+use axum::{Router, extract::State, routing::get};
+use http::{
+    Method,
+    header::{AUTHORIZATION, CONTENT_TYPE},
+};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tower_http::cors::{Any, CorsLayer};
+use tracing::info;
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+
+pub struct App {
+    env: Env,
+    app_state: AppState,
+}
+
+impl App {
+    /// Build a TCP listener for the application.
+    async fn build_listener(&self) -> Result<TcpListener, ApiError> {
+        TcpListener::bind(format!("0.0.0.0:{}", self.env.chart_api_port))
+            .await
+            .map_err(ApiError::from)
+    }
+
+    /// Configure CORS based on environment variable.
+    ///
+    /// If CORS_ALLOWED_ORIGINS is:
+    /// - "*": Allow all origins (not recommended for production)
+    /// - Empty/not set: Restrictive mode (no cross-origin requests allowed)
+    /// - Comma-separated list: Allow only those specific origins
+    fn cors(&self) -> CorsLayer {
+        use tracing::warn;
+
+        let cors = CorsLayer::new()
+            .allow_methods([Method::GET, Method::OPTIONS])
+            .allow_headers([CONTENT_TYPE, AUTHORIZATION])
+            .max_age(Duration::from_secs(3600));
+
+        // Parse CORS origins from environment
+        let origins = &self.env.cors_allowed_origins;
+
+        if origins == "*" {
+            // Explicit wildcard - allow all origins (not recommended for production)
+            warn!("CORS configured to allow all origins (*). This is not recommended for production.");
+            cors.allow_origin(Any)
+        } else if origins.is_empty() {
+            // Empty/not set - restrictive mode (default secure behavior)
+            info!("CORS not configured. Running in restrictive mode (no cross-origin requests).");
+            cors
+        } else {
+            // Parse comma-separated list of allowed origins
+            let origin_list: Vec<_> = origins
+                .split(',')
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .filter_map(|s| s.parse::<http::HeaderValue>().ok())
+                .collect();
+
+            if origin_list.is_empty() {
+                // If parsing failed, fall back to restrictive mode
+                warn!("Failed to parse CORS_ALLOWED_ORIGINS. Running in restrictive mode.");
+                cors
+            } else {
+                info!("CORS configured with {} allowed origin(s)", origin_list.len());
+                cors.allow_origin(origin_list)
+            }
+        }
+    }
+
+    /// Initialize the environment variables.
+    async fn initialize() -> Result<Env, ApiError> {
+        // Initialize tracing subscriber for structured logging
+        // Falls back to env_logger format if RUST_LOG is not set
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+            )
+            .with_target(true)
+            .with_thread_ids(false)
+            .with_file(true)
+            .with_line_number(true)
+            .init();
+
+        // Read the .env file from the current directory or parents
+        dotenvy::dotenv().ok();
+        // Load the environment variables into our struct
+        let env = envy::from_env::<Env>().map_err(ApiError::from)?;
+        Ok(env)
+    }
+
+    /// Merge the router with the Swagger UI.
+    fn merge_layers(&self) -> Router {
+        self.router()
+            .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+            .layer(self.cors())
+    }
+
+    /// Initialize the application.
+    pub async fn new() -> Result<Self, ApiError> {
+        let env = Self::initialize().await?;
+        let app_state = AppState::new(&env)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?;
+        Ok(Self { env, app_state })
+    }
+
+    /// Create the router for the application.
+    fn router(&self) -> Router {
+        Router::new()
+            .route(
+                "/api/v1/curve/{curve_id}/term/{term_id}/data",
+                get(get_chart_data),
+            )
+            .route("/health", get(health_check))
+            .with_state(self.app_state.clone())
+    }
+
+    /// Serve the application.
+    pub async fn serve(&self) -> Result<(), ApiError> {
+        info!(
+            "Starting chart-api server on port {}...",
+            self.env.chart_api_port
+        );
+        let listener = self.build_listener().await?;
+        info!("Ready to receive requests");
+        info!(
+            "Swagger UI available at: http://localhost:{}/swagger-ui/",
+            self.env.chart_api_port
+        );
+        axum::serve(listener, self.merge_layers())
+            .await
+            .map_err(ApiError::from)
+    }
+}
+
+/// Health check endpoint with connection monitoring
+async fn health_check(State(state): State<AppState>) -> Result<axum::Json<HealthStatus>, ApiError> {
+    use tracing::error;
+
+    // Check PostgreSQL health
+    let postgres_healthy = match state.check_postgres_health().await {
+        Ok(_) => true,
+        Err(e) => {
+            error!("PostgreSQL health check failed: {}", e);
+            false
+        }
+    };
+
+    // Check Redis health
+    let redis_healthy = match state.check_redis_health().await {
+        Ok(_) => true,
+        Err(e) => {
+            error!("Redis health check failed: {}", e);
+            false
+        }
+    };
+
+    // Get connection pool stats
+    let pool_size = state.pg_pool.size();
+    let pool_idle = state.pg_pool.num_idle();
+
+    let status = HealthStatus {
+        status: if postgres_healthy && redis_healthy {
+            "healthy"
+        } else {
+            "degraded"
+        }
+        .to_string(),
+        postgres: postgres_healthy,
+        redis: redis_healthy,
+        postgres_pool_size: pool_size,
+        postgres_pool_idle: pool_idle,
+    };
+
+    Ok(axum::Json(status))
+}
+
+/// Health status response
+#[derive(serde::Serialize)]
+struct HealthStatus {
+    status: String,
+    postgres: bool,
+    redis: bool,
+    postgres_pool_size: u32,
+    postgres_pool_idle: usize,
+}

--- a/apps/chart-api/src/cache/mod.rs
+++ b/apps/chart-api/src/cache/mod.rs
@@ -1,0 +1,3 @@
+mod redis;
+
+pub use redis::*;

--- a/apps/chart-api/src/cache/redis.rs
+++ b/apps/chart-api/src/cache/redis.rs
@@ -1,0 +1,95 @@
+use crate::error::ApiError;
+use crate::types::{GraphType, Interval, OutputFormat};
+use chrono::{DateTime, Utc};
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+use tracing::debug;
+
+/// Cache manager for chart data
+#[derive(Clone)]
+pub struct ChartCache {
+    connection: ConnectionManager,
+}
+
+impl ChartCache {
+    pub fn new(connection: ConnectionManager) -> Self {
+        Self { connection }
+    }
+
+    /// Generate a cache key for chart data
+    ///
+    /// Format: chart:{graph_type}:{term_id}:{curve_id}:{interval}:{start}:{end}:{format}
+    /// For term-level graphs without curve_id, use "none" as the curve_id value.
+    pub fn cache_key(
+        graph_type: GraphType,
+        term_id: &str,
+        curve_id: Option<&str>,
+        interval: Interval,
+        range_start: DateTime<Utc>,
+        range_end: DateTime<Utc>,
+        format: OutputFormat,
+    ) -> String {
+        let curve_id_str = curve_id.unwrap_or("none");
+        format!(
+            "chart:{}:{}:{}:{}:{}:{}:{}",
+            graph_type,
+            term_id,
+            curve_id_str,
+            interval,
+            range_start.timestamp(),
+            range_end.timestamp(),
+            format
+        )
+    }
+
+    /// Get cached data if available (binary)
+    #[allow(dead_code)]
+    pub async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ApiError> {
+        let mut conn = self.connection.clone();
+        let result: Option<Vec<u8>> = conn.get(key).await?;
+
+        if result.is_some() {
+            debug!("Cache hit for key: {}", key);
+        } else {
+            debug!("Cache miss for key: {}", key);
+        }
+
+        Ok(result)
+    }
+
+    /// Set data in cache with TTL (binary)
+    #[allow(dead_code)]
+    pub async fn set(&self, key: &str, value: &[u8], ttl_seconds: u64) -> Result<(), ApiError> {
+        let mut conn = self.connection.clone();
+        let _: () = conn.set_ex(key, value, ttl_seconds).await?;
+        debug!("Cached data for key: {} with TTL: {}s", key, ttl_seconds);
+        Ok(())
+    }
+
+    /// Get cached string data
+    pub async fn get_string(&self, key: &str) -> Result<Option<String>, ApiError> {
+        let mut conn = self.connection.clone();
+        let result: Option<String> = conn.get(key).await?;
+
+        if result.is_some() {
+            debug!("Cache hit for key: {}", key);
+        } else {
+            debug!("Cache miss for key: {}", key);
+        }
+
+        Ok(result)
+    }
+
+    /// Set string data in cache with TTL
+    pub async fn set_string(
+        &self,
+        key: &str,
+        value: &str,
+        ttl_seconds: u64,
+    ) -> Result<(), ApiError> {
+        let mut conn = self.connection.clone();
+        let _: () = conn.set_ex(key, value, ttl_seconds).await?;
+        debug!("Cached string for key: {} with TTL: {}s", key, ttl_seconds);
+        Ok(())
+    }
+}

--- a/apps/chart-api/src/endpoints/chart_data.rs
+++ b/apps/chart-api/src/endpoints/chart_data.rs
@@ -1,0 +1,199 @@
+use crate::cache::ChartCache;
+use crate::error::ApiError;
+use crate::models::{ChartResponse, ChartSvgResponse};
+use crate::services::{
+    align_range, build_expected_buckets, data_exists, fetch_chart_data, fetch_latest_value,
+    fill_gaps, generate_svg,
+};
+use crate::state::AppState;
+use crate::types::{ChartQueryParams, GraphType, Interval, OutputFormat, SvgConfig};
+use crate::validation::{
+    parse_timestamp, validate_count, validate_curve_id, validate_term_id, validate_time_range,
+};
+use axum::extract::{Path, Query, State};
+use axum::http::header;
+use axum::response::{IntoResponse, Response};
+use tracing::info;
+
+/// Handler for chart data endpoint
+/// GET /api/v1/curve/{curve_id}/term/{term_id}/data
+#[utoipa::path(
+    get,
+    path = "/api/v1/curve/{curve_id}/term/{term_id}/data",
+    params(
+        ("curve_id" = String, Path, description = "Curve ID (use 'none' for term-level graphs)"),
+        ("term_id" = String, Path, description = "Term ID"),
+        ("interval" = String, Query, description = "Time interval: 1h, 1d, 1w, 1m"),
+        ("format" = String, Query, description = "Output format: json or svg"),
+        ("start" = String, Query, description = "Range start timestamp (unix seconds, unix milliseconds, or RFC3339)"),
+        ("end" = String, Query, description = "Range end timestamp (unix seconds, unix milliseconds, or RFC3339)"),
+        ("graph_type" = Option<String>, Query, description = "Graph type: sharePriceChange (default), totalMarketCap"),
+        ("width" = Option<u32>, Query, description = "SVG width (pixels)"),
+        ("height" = Option<u32>, Query, description = "SVG height (pixels)"),
+        ("line_color" = Option<String>, Query, description = "SVG line color"),
+        ("background_color" = Option<String>, Query, description = "SVG background color"),
+    ),
+    responses(
+        (status = 200, description = "Chart data", content_type = "application/json"),
+        (status = 400, description = "Invalid parameters"),
+        (status = 404, description = "No data found"),
+        (status = 500, description = "Internal server error"),
+    ),
+    tag = "Chart"
+)]
+pub async fn get_chart_data(
+    State(state): State<AppState>,
+    Path((curve_id, term_id)): Path<(String, String)>,
+    Query(params): Query<ChartQueryParams>,
+) -> Result<Response, ApiError> {
+    // Parse and validate graph_type (default to SharePriceChange)
+    let graph_type = if let Some(ref gt) = params.graph_type {
+        GraphType::from_str(gt).ok_or_else(|| ApiError::InvalidGraphType(gt.clone()))?
+    } else {
+        GraphType::default()
+    };
+
+    // Validate term_id
+    validate_term_id(&term_id)?;
+
+    // Validate curve_id only if required by the graph type
+    let curve_id_opt = if graph_type.requires_curve_id() {
+        // For curve-level graphs, curve_id is required
+        if curve_id == "none" {
+            return Err(ApiError::MissingCurveId);
+        }
+        validate_curve_id(&curve_id)?;
+        Some(curve_id.as_str())
+    } else {
+        // For term-level graphs, curve_id is not used (even if provided)
+        None
+    };
+
+    // Parse and validate interval
+    let interval = Interval::from_str(&params.interval)
+        .ok_or_else(|| ApiError::InvalidInterval(params.interval.clone()))?;
+
+    // Parse and validate format
+    let format = OutputFormat::from_str(&params.format)
+        .ok_or_else(|| ApiError::InvalidFormat(params.format.clone()))?;
+
+    // Parse and validate timestamps
+    let start = parse_timestamp(&params.start)
+        .ok_or_else(|| ApiError::InvalidStartTimestamp(params.start.clone()))?;
+    let end = parse_timestamp(&params.end)
+        .ok_or_else(|| ApiError::InvalidEndTimestamp(params.end.clone()))?;
+    validate_time_range(start, end)?;
+
+    // Align range to bucket boundaries and derive expected bucket count
+    let (range_start, range_end) = align_range(start, end, interval);
+    let expected_buckets = build_expected_buckets(range_start, range_end, interval);
+    let count = expected_buckets.len() as u32;
+
+    // Validate derived count is within acceptable bounds
+    validate_count(count)?;
+
+    info!(
+        "Chart request: term_id={}, curve_id={:?}, graph_type={}, interval={}, format={}, start={}, end={}, count={}",
+        term_id, curve_id_opt, graph_type, interval, format, range_start, range_end, count
+    );
+
+    // Initialize cache
+    let cache = ChartCache::new(state.redis.clone());
+
+    // Check cache first
+    let cache_key =
+        ChartCache::cache_key(graph_type, &term_id, curve_id_opt, interval, range_start, range_end, format);
+
+    if let Some(cached_data) = cache.get_string(&cache_key).await? {
+        info!("Returning cached response for {}", cache_key);
+        return match format {
+            OutputFormat::Json | OutputFormat::SvgJson => {
+                Ok(([(header::CONTENT_TYPE, "application/json")], cached_data).into_response())
+            }
+            OutputFormat::Svg => {
+                Ok(([(header::CONTENT_TYPE, "image/svg+xml")], cached_data).into_response())
+            }
+        };
+    }
+
+    // Validate that the entity exists (vault for curve-level, term for term-level)
+    if !data_exists(&state.pg_pool, graph_type, &term_id, curve_id_opt).await? {
+        return Err(ApiError::InvalidCombination);
+    }
+
+    // Fetch chart data
+    let chart_data = fetch_chart_data(
+        &state.pg_pool,
+        graph_type,
+        &term_id,
+        curve_id_opt,
+        interval,
+        range_start,
+        range_end,
+        count,
+    )
+    .await?;
+
+    // Get fallback value if no data in range
+    let fallback_value = if chart_data.is_empty() {
+        fetch_latest_value(
+            &state.pg_pool,
+            graph_type,
+            &term_id,
+            curve_id_opt,
+            interval,
+            range_start,
+        )
+            .await?
+            .map(|(_, value)| value)
+    } else {
+        None
+    };
+
+    // If no data at all, return error
+    if chart_data.is_empty() && fallback_value.is_none() {
+        return Err(ApiError::NoDataAvailable);
+    }
+
+    // Fill gaps in data
+    let data_points = fill_gaps(chart_data, interval, &expected_buckets, fallback_value);
+
+    // Generate response based on format
+    let response_body = match format {
+        OutputFormat::Json => {
+            let response = ChartResponse {
+                term_id: term_id.clone(),
+                curve_id: curve_id_opt.map(|s| s.to_string()),
+                graph_type: graph_type.to_string(),
+                interval: interval.to_string(),
+                count: data_points.len(),
+                data: data_points,
+            };
+            serde_json::to_string(&response)?
+        }
+        OutputFormat::Svg => {
+            let svg_config = SvgConfig::from_query_params(&params);
+            generate_svg(&data_points, &svg_config)
+        }
+        OutputFormat::SvgJson => {
+            let svg_config = SvgConfig::from_query_params(&params);
+            let svg = generate_svg(&data_points, &svg_config);
+            let response = ChartSvgResponse { svg };
+            serde_json::to_string(&response)?
+        }
+    };
+
+    // Cache the response
+    let ttl = interval.cache_ttl_seconds();
+    cache.set_string(&cache_key, &response_body, ttl).await?;
+
+    // Return response with appropriate content type
+    match format {
+        OutputFormat::Json | OutputFormat::SvgJson => {
+            Ok(([(header::CONTENT_TYPE, "application/json")], response_body).into_response())
+        }
+        OutputFormat::Svg => {
+            Ok(([(header::CONTENT_TYPE, "image/svg+xml")], response_body).into_response())
+        }
+    }
+}

--- a/apps/chart-api/src/endpoints/mod.rs
+++ b/apps/chart-api/src/endpoints/mod.rs
@@ -1,0 +1,3 @@
+mod chart_data;
+
+pub use chart_data::*;

--- a/apps/chart-api/src/endpoints/mod.rs
+++ b/apps/chart-api/src/endpoints/mod.rs
@@ -1,3 +1,5 @@
 mod chart_data;
+mod position_pnl;
 
 pub use chart_data::*;
+pub use position_pnl::*;

--- a/apps/chart-api/src/endpoints/position_pnl.rs
+++ b/apps/chart-api/src/endpoints/position_pnl.rs
@@ -1,0 +1,333 @@
+use crate::cache::ChartCache;
+use crate::error::ApiError;
+use crate::models::{
+    AccountPnlChartPoint, AccountPnlChartResponse, AccountPnlSnapshot, PnlChartPoint,
+    PnlChartResponse,
+};
+use crate::services::{
+    align_pnl_range, build_pnl_expected_buckets, build_position_pnl_series,
+    fetch_account_current_totals, fetch_account_positions, position_exists,
+};
+use crate::state::AppState;
+use crate::types::{PnlChartQueryParams, PnlInterval};
+use crate::validation::{
+    parse_timestamp, validate_account_id, validate_count, validate_curve_id, validate_term_id,
+    validate_time_range,
+};
+use axum::extract::{Path, Query, State};
+use axum::http::header;
+use axum::response::{IntoResponse, Response};
+use chrono::Utc;
+use sqlx::types::BigDecimal;
+use tracing::info;
+
+fn bigdecimal_to_string(value: &BigDecimal) -> String {
+    value.to_string()
+}
+
+/// Handler for position-specific PnL chart endpoint
+/// GET /api/v1/accounts/{account_id}/positions/{term_id}/{curve_id}/pnl
+#[utoipa::path(
+    get,
+    path = "/api/v1/accounts/{account_id}/positions/{term_id}/{curve_id}/pnl",
+    params(
+        ("account_id" = String, Path, description = "Account ID"),
+        ("term_id" = String, Path, description = "Term ID"),
+        ("curve_id" = String, Path, description = "Curve ID"),
+        ("interval" = String, Query, description = "Time interval: 1m, 5m, 1h, 1d"),
+        ("start" = String, Query, description = "Range start timestamp (unix seconds, unix milliseconds, or RFC3339)"),
+        ("end" = String, Query, description = "Range end timestamp (unix seconds, unix milliseconds, or RFC3339)"),
+    ),
+    responses(
+        (status = 200, description = "PnL chart data", content_type = "application/json"),
+        (status = 400, description = "Invalid parameters"),
+        (status = 404, description = "No data found"),
+        (status = 500, description = "Internal server error"),
+    ),
+    tag = "PnL"
+)]
+pub async fn get_position_pnl_chart(
+    State(state): State<AppState>,
+    Path((account_id, term_id, curve_id)): Path<(String, String, String)>,
+    Query(params): Query<PnlChartQueryParams>,
+) -> Result<Response, ApiError> {
+    validate_account_id(&account_id)?;
+    validate_term_id(&term_id)?;
+    validate_curve_id(&curve_id)?;
+
+    let interval = PnlInterval::from_str(&params.interval)
+        .ok_or_else(|| ApiError::InvalidPnlInterval(params.interval.clone()))?;
+
+    let start = parse_timestamp(&params.start)
+        .ok_or_else(|| ApiError::InvalidStartTimestamp(params.start.clone()))?;
+    let end = parse_timestamp(&params.end)
+        .ok_or_else(|| ApiError::InvalidEndTimestamp(params.end.clone()))?;
+    validate_time_range(start, end)?;
+
+    let (range_start, range_end) = align_pnl_range(start, end, interval);
+    let expected_buckets = build_pnl_expected_buckets(range_start, range_end, interval);
+    let count = expected_buckets.len() as u32;
+    validate_count(count)?;
+
+    info!(
+        "Position PnL request: account_id={}, term_id={}, curve_id={}, interval={}, start={}, end={}, count={}",
+        account_id, term_id, curve_id, interval, range_start, range_end, count
+    );
+
+    let cache = ChartCache::new(state.redis.clone());
+    let cache_key = format!(
+        "pnl:position:{}:{}:{}:{}:{}:{}",
+        account_id,
+        term_id,
+        curve_id,
+        interval,
+        range_start.timestamp(),
+        range_end.timestamp()
+    );
+
+    if let Some(cached_data) = cache.get_string(&cache_key).await? {
+        return Ok(([(header::CONTENT_TYPE, "application/json")], cached_data).into_response());
+    }
+
+    if !position_exists(&state.pg_pool, &account_id, &term_id, &curve_id).await? {
+        return Err(ApiError::InvalidPositionCombination);
+    }
+
+    let series = build_position_pnl_series(
+        &state.pg_pool,
+        &account_id,
+        &term_id,
+        &curve_id,
+        interval,
+        range_start,
+        range_end,
+        &expected_buckets,
+    )
+    .await?;
+
+    if series.is_empty() {
+        return Err(ApiError::NoDataAvailable);
+    }
+
+    let data_points = series
+        .into_iter()
+        .map(|point| PnlChartPoint {
+            timestamp: point.timestamp,
+            shares_total: bigdecimal_to_string(&point.shares_total),
+            share_price: bigdecimal_to_string(&point.share_price),
+            equity_value: bigdecimal_to_string(&point.equity_value),
+            total_assets_in: bigdecimal_to_string(&point.total_assets_in),
+            total_assets_out: bigdecimal_to_string(&point.total_assets_out),
+            net_invested: bigdecimal_to_string(&point.net_invested),
+            total_pnl: bigdecimal_to_string(&point.total_pnl),
+            pnl_pct: bigdecimal_to_string(&point.pnl_pct),
+        })
+        .collect::<Vec<_>>();
+
+    let response = PnlChartResponse {
+        account_id: account_id.clone(),
+        term_id: term_id.clone(),
+        curve_id: curve_id.clone(),
+        interval: interval.to_string(),
+        count: data_points.len(),
+        data: data_points,
+    };
+
+    let response_body = serde_json::to_string(&response)?;
+    let ttl = interval.cache_ttl_seconds();
+    cache.set_string(&cache_key, &response_body, ttl).await?;
+
+    Ok(([(header::CONTENT_TYPE, "application/json")], response_body).into_response())
+}
+
+/// Handler for account-level PnL chart endpoint
+/// GET /api/v1/accounts/{account_id}/pnl
+#[utoipa::path(
+    get,
+    path = "/api/v1/accounts/{account_id}/pnl",
+    params(
+        ("account_id" = String, Path, description = "Account ID"),
+        ("interval" = String, Query, description = "Time interval: 1m, 5m, 1h, 1d"),
+        ("start" = String, Query, description = "Range start timestamp (unix seconds, unix milliseconds, or RFC3339)"),
+        ("end" = String, Query, description = "Range end timestamp (unix seconds, unix milliseconds, or RFC3339)"),
+    ),
+    responses(
+        (status = 200, description = "Account PnL chart data", content_type = "application/json"),
+        (status = 400, description = "Invalid parameters"),
+        (status = 404, description = "No data found"),
+        (status = 500, description = "Internal server error"),
+    ),
+    tag = "PnL"
+)]
+pub async fn get_account_pnl_chart(
+    State(state): State<AppState>,
+    Path(account_id): Path<String>,
+    Query(params): Query<PnlChartQueryParams>,
+) -> Result<Response, ApiError> {
+    validate_account_id(&account_id)?;
+
+    let interval = PnlInterval::from_str(&params.interval)
+        .ok_or_else(|| ApiError::InvalidPnlInterval(params.interval.clone()))?;
+
+    let start = parse_timestamp(&params.start)
+        .ok_or_else(|| ApiError::InvalidStartTimestamp(params.start.clone()))?;
+    let end = parse_timestamp(&params.end)
+        .ok_or_else(|| ApiError::InvalidEndTimestamp(params.end.clone()))?;
+    validate_time_range(start, end)?;
+
+    let (range_start, range_end) = align_pnl_range(start, end, interval);
+    let expected_buckets = build_pnl_expected_buckets(range_start, range_end, interval);
+    let count = expected_buckets.len() as u32;
+    validate_count(count)?;
+
+    info!(
+        "Account PnL request: account_id={}, interval={}, start={}, end={}, count={}",
+        account_id, interval, range_start, range_end, count
+    );
+
+    let cache = ChartCache::new(state.redis.clone());
+    let cache_key = format!(
+        "pnl:account:{}:{}:{}:{}",
+        account_id,
+        interval,
+        range_start.timestamp(),
+        range_end.timestamp()
+    );
+
+    if let Some(cached_data) = cache.get_string(&cache_key).await? {
+        return Ok(([(header::CONTENT_TYPE, "application/json")], cached_data).into_response());
+    }
+
+    let positions = fetch_account_positions(&state.pg_pool, &account_id).await?;
+    if positions.is_empty() {
+        return Err(ApiError::NoDataAvailable);
+    }
+
+    let mut aggregates: Vec<(BigDecimal, BigDecimal, BigDecimal)> =
+        vec![(BigDecimal::from(0), BigDecimal::from(0), BigDecimal::from(0)); expected_buckets.len()];
+    let mut any_series = false;
+
+    for position in positions {
+        match build_position_pnl_series(
+            &state.pg_pool,
+            &account_id,
+            &position.term_id,
+            &position.curve_id,
+            interval,
+            range_start,
+            range_end,
+            &expected_buckets,
+        )
+        .await
+        {
+            Ok(series) => {
+                any_series = true;
+                for (index, point) in series.iter().enumerate() {
+                    let (ref mut equity, ref mut assets_in, ref mut assets_out) = aggregates[index];
+                    *equity = equity.clone() + point.equity_value.clone();
+                    *assets_in = assets_in.clone() + point.total_assets_in.clone();
+                    *assets_out = assets_out.clone() + point.total_assets_out.clone();
+                }
+            }
+            Err(ApiError::NoDataAvailable) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    if !any_series {
+        return Err(ApiError::NoDataAvailable);
+    }
+
+    let hundred = BigDecimal::from(100);
+    let zero = BigDecimal::from(0);
+    let one = BigDecimal::from(1);
+
+    let data_points = expected_buckets
+        .iter()
+        .enumerate()
+        .map(|(index, bucket)| {
+            let (equity_value, total_assets_in, total_assets_out) = &aggregates[index];
+            let net_invested = total_assets_in.clone() - total_assets_out.clone();
+            let total_pnl = equity_value.clone() + total_assets_out.clone() - total_assets_in.clone();
+            let denom = if net_invested > zero {
+                net_invested.clone()
+            } else {
+                one.clone()
+            };
+            let pnl_pct = (total_pnl.clone() * hundred.clone()) / denom;
+
+            AccountPnlChartPoint {
+                timestamp: *bucket,
+                equity_value: bigdecimal_to_string(equity_value),
+                total_assets_in: bigdecimal_to_string(total_assets_in),
+                total_assets_out: bigdecimal_to_string(total_assets_out),
+                net_invested: bigdecimal_to_string(&net_invested),
+                total_pnl: bigdecimal_to_string(&total_pnl),
+                pnl_pct: bigdecimal_to_string(&pnl_pct),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let response = AccountPnlChartResponse {
+        account_id: account_id.clone(),
+        interval: interval.to_string(),
+        count: data_points.len(),
+        data: data_points,
+    };
+
+    let response_body = serde_json::to_string(&response)?;
+    let ttl = interval.cache_ttl_seconds();
+    cache.set_string(&cache_key, &response_body, ttl).await?;
+
+    Ok(([(header::CONTENT_TYPE, "application/json")], response_body).into_response())
+}
+
+/// Handler for current account PnL snapshot
+/// GET /api/v1/accounts/{account_id}/pnl/current
+#[utoipa::path(
+    get,
+    path = "/api/v1/accounts/{account_id}/pnl/current",
+    params(
+        ("account_id" = String, Path, description = "Account ID"),
+    ),
+    responses(
+        (status = 200, description = "Current account PnL snapshot", content_type = "application/json"),
+        (status = 400, description = "Invalid parameters"),
+        (status = 404, description = "No data found"),
+        (status = 500, description = "Internal server error"),
+    ),
+    tag = "PnL"
+)]
+pub async fn get_account_pnl_current(
+    State(state): State<AppState>,
+    Path(account_id): Path<String>,
+) -> Result<Response, ApiError> {
+    validate_account_id(&account_id)?;
+
+    let totals = fetch_account_current_totals(&state.pg_pool, &account_id).await?;
+    let totals = totals.ok_or(ApiError::NoDataAvailable)?;
+
+    let net_invested = totals.total_assets_in.clone() - totals.total_assets_out.clone();
+    let total_pnl = totals.equity_value.clone() + totals.total_assets_out.clone()
+        - totals.total_assets_in.clone();
+    let denom = if net_invested > BigDecimal::from(0) {
+        net_invested.clone()
+    } else {
+        BigDecimal::from(1)
+    };
+    let pnl_pct = (total_pnl.clone() * BigDecimal::from(100)) / denom;
+
+    let response = AccountPnlSnapshot {
+        account_id: account_id.clone(),
+        timestamp: Utc::now(),
+        equity_value: bigdecimal_to_string(&totals.equity_value),
+        total_assets_in: bigdecimal_to_string(&totals.total_assets_in),
+        total_assets_out: bigdecimal_to_string(&totals.total_assets_out),
+        net_invested: bigdecimal_to_string(&net_invested),
+        total_pnl: bigdecimal_to_string(&total_pnl),
+        pnl_pct: bigdecimal_to_string(&pnl_pct),
+    };
+
+    let response_body = serde_json::to_string(&response)?;
+    Ok(([(header::CONTENT_TYPE, "application/json")], response_body).into_response())
+}

--- a/apps/chart-api/src/error.rs
+++ b/apps/chart-api/src/error.rs
@@ -1,0 +1,111 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Serialize;
+use thiserror::Error;
+
+/// Error response body for JSON responses
+#[derive(Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+    pub code: String,
+}
+
+/// Error types for the Chart API
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("Invalid term_id/curve_id combination: no vault exists")]
+    InvalidCombination,
+    #[error("No data available for the requested term/curve")]
+    NoDataAvailable,
+    #[error("Invalid interval: {0}. Valid values are: 1h, 1d, 1w, 1m")]
+    InvalidInterval(String),
+    #[error("Invalid format: {0}. Valid values are: json, svg, svg_json")]
+    InvalidFormat(String),
+    #[error("Invalid range: {0} buckets. Must be between 1 and {1}")]
+    InvalidRange(u32, u32),
+    #[error("Invalid start timestamp: {0}. Expected unix seconds, unix milliseconds, or RFC3339")]
+    InvalidStartTimestamp(String),
+    #[error("Invalid end timestamp: {0}. Expected unix seconds, unix milliseconds, or RFC3339")]
+    InvalidEndTimestamp(String),
+    #[error("Invalid time range: start must be before end")]
+    InvalidTimeRange,
+    #[error("Invalid term_id: {0}. Must be a hex string starting with 0x")]
+    InvalidTermId(String),
+    #[error("Invalid curve_id: {0}. Must be a valid numeric string")]
+    InvalidCurveId(String),
+    #[error("Invalid graph type: {0}. Valid values are: sharePriceChange, totalMarketCap")]
+    InvalidGraphType(String),
+    #[error("Missing curve_id: this graph type requires a curve_id parameter")]
+    MissingCurveId,
+    #[error(transparent)]
+    Env(#[from] envy::Error),
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    Redis(#[from] redis::RedisError),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    Model(#[from] models::error::ModelError),
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl ApiError {
+    /// Get the error code for this error type
+    fn code(&self) -> &'static str {
+        match self {
+            ApiError::InvalidCombination => "INVALID_COMBINATION",
+            ApiError::NoDataAvailable => "NO_DATA",
+            ApiError::InvalidInterval(_) => "INVALID_INTERVAL",
+            ApiError::InvalidFormat(_) => "INVALID_FORMAT",
+            ApiError::InvalidRange(_, _) => "INVALID_RANGE",
+            ApiError::InvalidStartTimestamp(_) => "INVALID_START_TIMESTAMP",
+            ApiError::InvalidEndTimestamp(_) => "INVALID_END_TIMESTAMP",
+            ApiError::InvalidTimeRange => "INVALID_TIME_RANGE",
+            ApiError::InvalidTermId(_) => "INVALID_TERM_ID",
+            ApiError::InvalidCurveId(_) => "INVALID_CURVE_ID",
+            ApiError::InvalidGraphType(_) => "INVALID_GRAPH_TYPE",
+            ApiError::MissingCurveId => "MISSING_CURVE_ID",
+            ApiError::Env(_) => "ENV_ERROR",
+            ApiError::IO(_) => "IO_ERROR",
+            ApiError::Sqlx(_) => "DATABASE_ERROR",
+            ApiError::Redis(_) => "CACHE_ERROR",
+            ApiError::Serde(_) => "SERIALIZATION_ERROR",
+            ApiError::Model(_) => "MODEL_ERROR",
+            ApiError::Internal(_) => "INTERNAL_ERROR",
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            ApiError::InvalidCombination => StatusCode::BAD_REQUEST,
+            ApiError::NoDataAvailable => StatusCode::NOT_FOUND,
+            ApiError::InvalidInterval(_) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidFormat(_) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidRange(_, _) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidStartTimestamp(_) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidEndTimestamp(_) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidTimeRange => StatusCode::BAD_REQUEST,
+            ApiError::InvalidTermId(_) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidCurveId(_) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidGraphType(_) => StatusCode::BAD_REQUEST,
+            ApiError::MissingCurveId => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+
+        let body = ErrorResponse {
+            error: self.to_string(),
+            code: self.code().to_string(),
+        };
+
+        (status, Json(body)).into_response()
+    }
+}

--- a/apps/chart-api/src/error.rs
+++ b/apps/chart-api/src/error.rs
@@ -22,6 +22,8 @@ pub enum ApiError {
     NoDataAvailable,
     #[error("Invalid interval: {0}. Valid values are: 1h, 1d, 1w, 1m")]
     InvalidInterval(String),
+    #[error("Invalid PnL interval: {0}. Valid values are: 1m, 5m, 1h, 1d")]
+    InvalidPnlInterval(String),
     #[error("Invalid format: {0}. Valid values are: json, svg, svg_json")]
     InvalidFormat(String),
     #[error("Invalid range: {0} buckets. Must be between 1 and {1}")]
@@ -36,10 +38,14 @@ pub enum ApiError {
     InvalidTermId(String),
     #[error("Invalid curve_id: {0}. Must be a valid numeric string")]
     InvalidCurveId(String),
+    #[error("Invalid account_id: {0}. Must be a non-empty string")]
+    InvalidAccountId(String),
     #[error("Invalid graph type: {0}. Valid values are: sharePriceChange, totalMarketCap")]
     InvalidGraphType(String),
     #[error("Missing curve_id: this graph type requires a curve_id parameter")]
     MissingCurveId,
+    #[error("Invalid account_id/term_id/curve_id combination: no position exists")]
+    InvalidPositionCombination,
     #[error(transparent)]
     Env(#[from] envy::Error),
     #[error(transparent)]
@@ -63,6 +69,7 @@ impl ApiError {
             ApiError::InvalidCombination => "INVALID_COMBINATION",
             ApiError::NoDataAvailable => "NO_DATA",
             ApiError::InvalidInterval(_) => "INVALID_INTERVAL",
+            ApiError::InvalidPnlInterval(_) => "INVALID_PNL_INTERVAL",
             ApiError::InvalidFormat(_) => "INVALID_FORMAT",
             ApiError::InvalidRange(_, _) => "INVALID_RANGE",
             ApiError::InvalidStartTimestamp(_) => "INVALID_START_TIMESTAMP",
@@ -70,8 +77,10 @@ impl ApiError {
             ApiError::InvalidTimeRange => "INVALID_TIME_RANGE",
             ApiError::InvalidTermId(_) => "INVALID_TERM_ID",
             ApiError::InvalidCurveId(_) => "INVALID_CURVE_ID",
+            ApiError::InvalidAccountId(_) => "INVALID_ACCOUNT_ID",
             ApiError::InvalidGraphType(_) => "INVALID_GRAPH_TYPE",
             ApiError::MissingCurveId => "MISSING_CURVE_ID",
+            ApiError::InvalidPositionCombination => "INVALID_POSITION_COMBINATION",
             ApiError::Env(_) => "ENV_ERROR",
             ApiError::IO(_) => "IO_ERROR",
             ApiError::Sqlx(_) => "DATABASE_ERROR",
@@ -89,6 +98,7 @@ impl IntoResponse for ApiError {
             ApiError::InvalidCombination => StatusCode::BAD_REQUEST,
             ApiError::NoDataAvailable => StatusCode::NOT_FOUND,
             ApiError::InvalidInterval(_) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidPnlInterval(_) => StatusCode::BAD_REQUEST,
             ApiError::InvalidFormat(_) => StatusCode::BAD_REQUEST,
             ApiError::InvalidRange(_, _) => StatusCode::BAD_REQUEST,
             ApiError::InvalidStartTimestamp(_) => StatusCode::BAD_REQUEST,
@@ -96,8 +106,10 @@ impl IntoResponse for ApiError {
             ApiError::InvalidTimeRange => StatusCode::BAD_REQUEST,
             ApiError::InvalidTermId(_) => StatusCode::BAD_REQUEST,
             ApiError::InvalidCurveId(_) => StatusCode::BAD_REQUEST,
+            ApiError::InvalidAccountId(_) => StatusCode::BAD_REQUEST,
             ApiError::InvalidGraphType(_) => StatusCode::BAD_REQUEST,
             ApiError::MissingCurveId => StatusCode::BAD_REQUEST,
+            ApiError::InvalidPositionCombination => StatusCode::BAD_REQUEST,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/apps/chart-api/src/main.rs
+++ b/apps/chart-api/src/main.rs
@@ -1,0 +1,18 @@
+use app::App;
+use error::ApiError;
+
+mod app;
+mod cache;
+mod endpoints;
+mod error;
+mod models;
+mod openapi;
+mod services;
+mod state;
+mod types;
+mod validation;
+
+#[tokio::main]
+async fn main() -> Result<(), ApiError> {
+    App::new().await?.serve().await
+}

--- a/apps/chart-api/src/models/chart_data.rs
+++ b/apps/chart-api/src/models/chart_data.rs
@@ -1,0 +1,84 @@
+use chrono::{DateTime, Utc};
+use models::types::U256Wrapper;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// A single data point in the chart (for serialization)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChartDataPoint {
+    /// Timestamp of this data point (bucket time)
+    pub timestamp: DateTime<Utc>,
+    /// Value at this time (serialized as string to avoid JS precision issues)
+    #[serde(serialize_with = "serialize_u256_as_string")]
+    pub value: U256Wrapper,
+}
+
+/// Custom serializer to convert U256Wrapper to string
+fn serialize_u256_as_string<S>(value: &U256Wrapper, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+/// Schema-compatible data point for OpenAPI docs
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ChartDataPointSchema {
+    /// Timestamp of this data point (bucket time)
+    pub timestamp: String,
+    /// Value at this time (as string to preserve precision)
+    pub value: String,
+}
+
+/// Response for JSON format
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ChartResponse {
+    /// Term ID
+    pub term_id: String,
+    /// Curve ID (as string to preserve precision). Optional for term-level graphs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub curve_id: Option<String>,
+    /// Graph type (e.g., "sharePriceChange", "totalMarketCap")
+    pub graph_type: String,
+    /// Interval used
+    pub interval: String,
+    /// Number of data points
+    pub count: usize,
+    /// The actual data points
+    #[schema(value_type = Vec<ChartDataPointSchema>)]
+    pub data: Vec<ChartDataPoint>,
+}
+
+/// Response for SVG wrapped in JSON (for Hasura actions)
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ChartSvgResponse {
+    /// SVG content as a string
+    pub svg: String,
+}
+
+/// Raw data from the continuous aggregate view (legacy - kept for backward compatibility)
+#[allow(dead_code)]
+#[derive(Debug, sqlx::FromRow)]
+pub struct AggregateDataPoint {
+    pub bucket: DateTime<Utc>,
+    pub term_id: String,
+    pub curve_id: U256Wrapper,
+    pub first_share_price: U256Wrapper,
+    pub last_share_price: U256Wrapper,
+    pub difference: U256Wrapper,
+    pub change_count: i64,
+}
+
+/// Generic data row for different graph types
+///
+/// This struct represents a single data point fetched from the database,
+/// which could come from either curve-level or term-level views.
+#[derive(Debug)]
+#[allow(dead_code)] // Fields used in DB queries and deserialization
+pub struct GenericDataRow {
+    pub bucket: DateTime<Utc>,
+    pub term_id: String,
+    /// Optional curve_id (None for term-level graphs like TotalMarketCap)
+    pub curve_id: Option<U256Wrapper>,
+    pub value: U256Wrapper,
+}

--- a/apps/chart-api/src/models/mod.rs
+++ b/apps/chart-api/src/models/mod.rs
@@ -1,0 +1,5 @@
+mod chart_data;
+
+pub use chart_data::{
+    ChartDataPoint, ChartDataPointSchema, ChartResponse, ChartSvgResponse, GenericDataRow,
+};

--- a/apps/chart-api/src/models/mod.rs
+++ b/apps/chart-api/src/models/mod.rs
@@ -1,5 +1,10 @@
 mod chart_data;
+mod pnl_chart;
 
 pub use chart_data::{
     ChartDataPoint, ChartDataPointSchema, ChartResponse, ChartSvgResponse, GenericDataRow,
+};
+pub use pnl_chart::{
+    AccountPnlChartPoint, AccountPnlChartPointSchema, AccountPnlChartResponse, AccountPnlSnapshot,
+    PnlChartPoint, PnlChartPointSchema, PnlChartResponse,
 };

--- a/apps/chart-api/src/models/pnl_chart.rs
+++ b/apps/chart-api/src/models/pnl_chart.rs
@@ -1,0 +1,90 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// A single PnL data point in the chart (for serialization)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PnlChartPoint {
+    pub timestamp: DateTime<Utc>,
+    pub shares_total: String,
+    pub share_price: String,
+    pub equity_value: String,
+    pub total_assets_in: String,
+    pub total_assets_out: String,
+    pub net_invested: String,
+    pub total_pnl: String,
+    pub pnl_pct: String,
+}
+
+/// Schema-compatible PnL data point for OpenAPI docs
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct PnlChartPointSchema {
+    pub timestamp: String,
+    pub shares_total: String,
+    pub share_price: String,
+    pub equity_value: String,
+    pub total_assets_in: String,
+    pub total_assets_out: String,
+    pub net_invested: String,
+    pub total_pnl: String,
+    pub pnl_pct: String,
+}
+
+/// Response for position PnL chart
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct PnlChartResponse {
+    pub account_id: String,
+    pub term_id: String,
+    pub curve_id: String,
+    pub interval: String,
+    pub count: usize,
+    #[schema(value_type = Vec<PnlChartPointSchema>)]
+    pub data: Vec<PnlChartPoint>,
+}
+
+/// A single account-level PnL data point
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountPnlChartPoint {
+    pub timestamp: DateTime<Utc>,
+    pub equity_value: String,
+    pub total_assets_in: String,
+    pub total_assets_out: String,
+    pub net_invested: String,
+    pub total_pnl: String,
+    pub pnl_pct: String,
+}
+
+/// Schema-compatible account-level PnL data point
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct AccountPnlChartPointSchema {
+    pub timestamp: String,
+    pub equity_value: String,
+    pub total_assets_in: String,
+    pub total_assets_out: String,
+    pub net_invested: String,
+    pub total_pnl: String,
+    pub pnl_pct: String,
+}
+
+/// Response for account-level PnL chart
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct AccountPnlChartResponse {
+    pub account_id: String,
+    pub interval: String,
+    pub count: usize,
+    #[schema(value_type = Vec<AccountPnlChartPointSchema>)]
+    pub data: Vec<AccountPnlChartPoint>,
+}
+
+/// Current account PnL snapshot
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct AccountPnlSnapshot {
+    pub account_id: String,
+    pub timestamp: DateTime<Utc>,
+    pub equity_value: String,
+    pub total_assets_in: String,
+    pub total_assets_out: String,
+    pub net_invested: String,
+    pub total_pnl: String,
+    pub pnl_pct: String,
+}

--- a/apps/chart-api/src/openapi.rs
+++ b/apps/chart-api/src/openapi.rs
@@ -1,0 +1,25 @@
+use crate::models::{ChartDataPointSchema, ChartResponse};
+use crate::types::{ChartQueryParams, GraphType, Interval, OutputFormat};
+use utoipa::OpenApi;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(crate::endpoints::get_chart_data),
+    components(schemas(
+        ChartResponse,
+        ChartDataPointSchema,
+        ChartQueryParams,
+        GraphType,
+        Interval,
+        OutputFormat,
+    )),
+    tags(
+        (name = "Chart", description = "Chart data endpoints with support for multiple graph types")
+    ),
+    info(
+        title = "Chart API",
+        version = "1.0.0",
+        description = "API for fetching chart data with gap-filling and SVG generation. Supports multiple graph types including share price changes and total market cap."
+    )
+)]
+pub struct ApiDoc;

--- a/apps/chart-api/src/openapi.rs
+++ b/apps/chart-api/src/openapi.rs
@@ -1,10 +1,18 @@
-use crate::models::{ChartDataPointSchema, ChartResponse};
-use crate::types::{ChartQueryParams, GraphType, Interval, OutputFormat};
+use crate::models::{
+    AccountPnlChartPointSchema, AccountPnlChartResponse, AccountPnlSnapshot, ChartDataPointSchema,
+    ChartResponse, PnlChartPointSchema, PnlChartResponse,
+};
+use crate::types::{ChartQueryParams, GraphType, Interval, OutputFormat, PnlChartQueryParams, PnlInterval};
 use utoipa::OpenApi;
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(crate::endpoints::get_chart_data),
+    paths(
+        crate::endpoints::get_chart_data,
+        crate::endpoints::get_position_pnl_chart,
+        crate::endpoints::get_account_pnl_chart,
+        crate::endpoints::get_account_pnl_current
+    ),
     components(schemas(
         ChartResponse,
         ChartDataPointSchema,
@@ -12,9 +20,17 @@ use utoipa::OpenApi;
         GraphType,
         Interval,
         OutputFormat,
+        PnlChartResponse,
+        PnlChartPointSchema,
+        PnlChartQueryParams,
+        PnlInterval,
+        AccountPnlChartResponse,
+        AccountPnlChartPointSchema,
+        AccountPnlSnapshot,
     )),
     tags(
-        (name = "Chart", description = "Chart data endpoints with support for multiple graph types")
+        (name = "Chart", description = "Chart data endpoints with support for multiple graph types"),
+        (name = "PnL", description = "PnL chart endpoints for account and position views")
     ),
     info(
         title = "Chart API",

--- a/apps/chart-api/src/services/data_fetcher.rs
+++ b/apps/chart-api/src/services/data_fetcher.rs
@@ -1,0 +1,232 @@
+use crate::error::ApiError;
+use crate::models::GenericDataRow;
+use crate::types::{GraphType, Interval};
+use chrono::{DateTime, Utc};
+use models::types::U256Wrapper;
+use sqlx::{Pool, Postgres, Row};
+
+/// Fetch chart data from the continuous aggregate views
+///
+/// This generic function builds dynamic SQL based on the graph type and interval.
+/// For curve-level graphs (e.g., SharePriceChange), curve_id must be Some.
+/// For term-level graphs (e.g., TotalMarketCap), curve_id should be None.
+///
+/// # SQL Injection Safety
+///
+/// This function uses dynamic SQL with interpolated table/column names, but is safe because:
+/// - `view_name` and `value_column` come from `GraphType` enum methods that return
+///   hardcoded `&'static str` values (not user input)
+/// - All user-provided values (`term_id`, `curve_id`, timestamps, limit) are passed
+///   via parameterized queries (`$1`, `$2`, etc.) which are properly escaped by sqlx
+/// - The `term_id` and `curve_id` are validated before reaching this function
+pub async fn fetch_chart_data(
+    pool: &Pool<Postgres>,
+    graph_type: GraphType,
+    term_id: &str,
+    curve_id: Option<&str>,
+    interval: Interval,
+    range_start: DateTime<Utc>,
+    range_end: DateTime<Utc>,
+    limit: u32,
+) -> Result<Vec<GenericDataRow>, ApiError> {
+    let view_name = graph_type.view_name(interval);
+    let value_column = graph_type.value_column();
+
+    // Build the WHERE clause based on whether curve_id is needed
+    // Filter out rows where value column is '-' or NULL (invalid data)
+    let query = if graph_type.requires_curve_id() {
+        format!(
+            r#"
+            SELECT
+                bucket,
+                term_id,
+                curve_id,
+                {} as value
+            FROM {}
+            WHERE term_id = $1
+              AND curve_id = $2::numeric
+              AND bucket >= $3
+              AND bucket < $4
+              AND {} IS NOT NULL
+              AND {}::text != '-'
+            ORDER BY bucket ASC
+            LIMIT $5
+            "#,
+            value_column, view_name, value_column, value_column
+        )
+    } else {
+        format!(
+            r#"
+            SELECT
+                bucket,
+                term_id,
+                {} as value
+            FROM {}
+            WHERE term_id = $1
+              AND bucket >= $2
+              AND bucket < $3
+              AND {} IS NOT NULL
+              AND {}::text != '-'
+            ORDER BY bucket ASC
+            LIMIT $4
+            "#,
+            value_column, view_name, value_column, value_column
+        )
+    };
+
+    // Execute query with appropriate bindings
+    let rows = if graph_type.requires_curve_id() {
+        let curve_id = curve_id.ok_or(ApiError::MissingCurveId)?;
+        sqlx::query(&query)
+            .bind(term_id)
+            .bind(curve_id)
+            .bind(range_start)
+            .bind(range_end)
+            .bind(limit as i64)
+            .fetch_all(pool)
+            .await?
+    } else {
+        sqlx::query(&query)
+            .bind(term_id)
+            .bind(range_start)
+            .bind(range_end)
+            .bind(limit as i64)
+            .fetch_all(pool)
+            .await?
+    };
+
+    // Parse rows into GenericDataRow
+    let mut data_points = Vec::with_capacity(rows.len());
+    for row in rows {
+        let curve_id_value = if graph_type.requires_curve_id() {
+            Some(row.get("curve_id"))
+        } else {
+            None
+        };
+
+        data_points.push(GenericDataRow {
+            bucket: row.get("bucket"),
+            term_id: row.get("term_id"),
+            curve_id: curve_id_value,
+            value: row.get("value"),
+        });
+    }
+
+    Ok(data_points)
+}
+
+/// Fetch the most recent data point before a given time (for fallback)
+///
+/// This is used when there's no data in the requested time range,
+/// to provide a constant line based on the last known value.
+pub async fn fetch_latest_value(
+    pool: &Pool<Postgres>,
+    graph_type: GraphType,
+    term_id: &str,
+    curve_id: Option<&str>,
+    interval: Interval,
+    before: DateTime<Utc>,
+) -> Result<Option<(DateTime<Utc>, U256Wrapper)>, ApiError> {
+    let view_name = graph_type.view_name(interval);
+    let value_column = graph_type.value_column();
+
+    // Filter out rows where value column is '-' or NULL (invalid data)
+    let query = if graph_type.requires_curve_id() {
+        format!(
+            r#"
+            SELECT bucket, {} as value
+            FROM {}
+            WHERE term_id = $1
+              AND curve_id = $2::numeric
+              AND bucket < $3
+              AND {} IS NOT NULL
+              AND {}::text != '-'
+            ORDER BY bucket DESC
+            LIMIT 1
+            "#,
+            value_column, view_name, value_column, value_column
+        )
+    } else {
+        format!(
+            r#"
+            SELECT bucket, {} as value
+            FROM {}
+            WHERE term_id = $1
+              AND bucket < $2
+              AND {} IS NOT NULL
+              AND {}::text != '-'
+            ORDER BY bucket DESC
+            LIMIT 1
+            "#,
+            value_column, view_name, value_column, value_column
+        )
+    };
+
+    let row = if graph_type.requires_curve_id() {
+        let curve_id = curve_id.ok_or(ApiError::MissingCurveId)?;
+        sqlx::query(&query)
+            .bind(term_id)
+            .bind(curve_id)
+            .bind(before)
+            .fetch_optional(pool)
+            .await?
+    } else {
+        sqlx::query(&query)
+            .bind(term_id)
+            .bind(before)
+            .fetch_optional(pool)
+            .await?
+    };
+
+    match row {
+        Some(row) => {
+            let bucket: DateTime<Utc> = row.get("bucket");
+            let value: U256Wrapper = row.get("value");
+            Ok(Some((bucket, value)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Check if the requested entity exists
+///
+/// For curve-level graphs: validates that a vault exists for the term_id/curve_id combination
+/// For term-level graphs: validates that the term exists
+pub async fn data_exists(
+    pool: &Pool<Postgres>,
+    graph_type: GraphType,
+    term_id: &str,
+    curve_id: Option<&str>,
+) -> Result<bool, ApiError> {
+    if graph_type.requires_curve_id() {
+        let curve_id = curve_id.ok_or(ApiError::MissingCurveId)?;
+        // Check if vault exists
+        let row = sqlx::query(
+            r#"
+            SELECT 1 FROM vault
+            WHERE term_id = $1 AND curve_id = $2::numeric
+            LIMIT 1
+            "#,
+        )
+        .bind(term_id)
+        .bind(curve_id)
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(row.is_some())
+    } else {
+        // Check if term exists
+        let row = sqlx::query(
+            r#"
+            SELECT 1 FROM atom
+            WHERE term_id = $1
+            LIMIT 1
+            "#,
+        )
+        .bind(term_id)
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(row.is_some())
+    }
+}

--- a/apps/chart-api/src/services/gap_filler.rs
+++ b/apps/chart-api/src/services/gap_filler.rs
@@ -1,0 +1,215 @@
+use crate::models::{ChartDataPoint, GenericDataRow};
+use crate::types::Interval;
+use chrono::{DateTime, Duration, Months, Utc};
+use models::types::U256Wrapper;
+use std::collections::HashMap;
+
+/// Align a range to interval bucket boundaries (end is exclusive)
+pub fn align_range(
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    interval: Interval,
+) -> (DateTime<Utc>, DateTime<Utc>) {
+    let range_start = ceil_to_bucket(start, interval);
+    let range_end = ceil_to_bucket(end, interval);
+    (range_start, range_end)
+}
+
+/// Build expected bucket timestamps for the aligned range (end is exclusive)
+pub fn build_expected_buckets(
+    range_start: DateTime<Utc>,
+    range_end: DateTime<Utc>,
+    interval: Interval,
+) -> Vec<DateTime<Utc>> {
+    if range_start >= range_end {
+        return Vec::new();
+    }
+
+    let mut buckets = Vec::new();
+    let mut current = range_start;
+
+    while current < range_end {
+        buckets.push(current);
+        let next = next_bucket(current, interval);
+        if next <= current {
+            break;
+        }
+        current = next;
+    }
+
+    buckets
+}
+
+/// Fill gaps in the data to provide continuous time series
+///
+/// If there are missing buckets between data points, fill them with the last known value.
+/// If there's no data at all, use the fallback value to create a constant line.
+pub fn fill_gaps(
+    data_points: Vec<GenericDataRow>,
+    interval: Interval,
+    expected_buckets: &[DateTime<Utc>],
+    fallback_value: Option<U256Wrapper>,
+) -> Vec<ChartDataPoint> {
+    if expected_buckets.is_empty() {
+        return Vec::new();
+    }
+
+    // If no data and no fallback, return empty
+    if data_points.is_empty() && fallback_value.is_none() {
+        return Vec::new();
+    }
+
+    // Create a map of existing data points by bucket
+    let data_map: HashMap<DateTime<Utc>, U256Wrapper> = data_points
+        .into_iter()
+        .map(|dp| (truncate_to_bucket(dp.bucket, interval), dp.value))
+        .collect();
+
+    // Determine the initial "last known" value
+    let initial_value = data_map
+        .iter()
+        .min_by_key(|(bucket, _)| *bucket)
+        .map(|(_, value)| value.clone())
+        .or(fallback_value.clone())
+        .unwrap_or_default();
+
+    // Fill gaps
+    let mut result = Vec::with_capacity(expected_buckets.len());
+    let mut last_known_value = initial_value;
+
+    for bucket in expected_buckets {
+        let truncated = truncate_to_bucket(*bucket, interval);
+        let value = data_map
+            .get(&truncated)
+            .cloned()
+            .unwrap_or_else(|| last_known_value.clone());
+
+        last_known_value = value.clone();
+
+        result.push(ChartDataPoint {
+            timestamp: truncated,
+            value,
+        });
+    }
+
+    result
+}
+
+/// Get the next bucket timestamp based on interval
+fn next_bucket(current: DateTime<Utc>, interval: Interval) -> DateTime<Utc> {
+    match interval {
+        Interval::Hourly => current + Duration::hours(1),
+        Interval::Daily => current + Duration::days(1),
+        Interval::Weekly => current + Duration::weeks(1),
+        Interval::Monthly => current
+            .checked_add_months(Months::new(1))
+            .unwrap_or_else(|| current + Duration::days(31)),
+    }
+}
+
+/// Truncate a timestamp to its bucket boundary
+fn truncate_to_bucket(timestamp: DateTime<Utc>, interval: Interval) -> DateTime<Utc> {
+    use chrono::{Datelike, Timelike};
+
+    match interval {
+        Interval::Hourly => timestamp
+            .with_minute(0)
+            .and_then(|t| t.with_second(0))
+            .and_then(|t| t.with_nanosecond(0))
+            .unwrap_or(timestamp),
+        Interval::Daily => timestamp
+            .with_hour(0)
+            .and_then(|t| t.with_minute(0))
+            .and_then(|t| t.with_second(0))
+            .and_then(|t| t.with_nanosecond(0))
+            .unwrap_or(timestamp),
+        Interval::Weekly => {
+            // Truncate to start of week (Monday)
+            let days_since_monday = timestamp.weekday().num_days_from_monday();
+            let start_of_week = timestamp - Duration::days(days_since_monday as i64);
+            start_of_week
+                .with_hour(0)
+                .and_then(|t| t.with_minute(0))
+                .and_then(|t| t.with_second(0))
+                .and_then(|t| t.with_nanosecond(0))
+                .unwrap_or(timestamp)
+        }
+        Interval::Monthly => {
+            // Truncate to start of month
+            timestamp
+                .with_day(1)
+                .and_then(|t| t.with_hour(0))
+                .and_then(|t| t.with_minute(0))
+                .and_then(|t| t.with_second(0))
+                .and_then(|t| t.with_nanosecond(0))
+                .unwrap_or(timestamp)
+        }
+    }
+}
+
+/// Ceil a timestamp to its bucket boundary
+fn ceil_to_bucket(timestamp: DateTime<Utc>, interval: Interval) -> DateTime<Utc> {
+    let truncated = truncate_to_bucket(timestamp, interval);
+    if truncated == timestamp {
+        truncated
+    } else {
+        next_bucket(truncated, interval)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::U256;
+    use chrono::{Datelike, Timelike};
+
+    #[test]
+    fn test_truncate_to_bucket_hourly() {
+        let ts = "2024-01-15T14:35:42Z".parse::<DateTime<Utc>>().unwrap();
+        let truncated = truncate_to_bucket(ts, Interval::Hourly);
+        assert_eq!(truncated.hour(), 14);
+        assert_eq!(truncated.minute(), 0);
+        assert_eq!(truncated.second(), 0);
+    }
+
+    #[test]
+    fn test_truncate_to_bucket_daily() {
+        let ts = "2024-01-15T14:35:42Z".parse::<DateTime<Utc>>().unwrap();
+        let truncated = truncate_to_bucket(ts, Interval::Daily);
+        assert_eq!(truncated.hour(), 0);
+        assert_eq!(truncated.minute(), 0);
+        assert_eq!(truncated.day(), 15);
+    }
+
+    #[test]
+    fn test_fill_gaps_with_data() {
+        let now = Utc::now();
+        let bucket_duration = Duration::hours(1);
+
+        // Create data with a gap
+        let data = vec![
+            GenericDataRow {
+                bucket: now - bucket_duration * 3,
+                term_id: "test".to_string(),
+                curve_id: Some(U256Wrapper(U256::from(1))),
+                value: U256Wrapper(U256::from(100)),
+            },
+            // Gap at now - 2 hours
+            GenericDataRow {
+                bucket: now - bucket_duration,
+                term_id: "test".to_string(),
+                curve_id: Some(U256Wrapper(U256::from(1))),
+                value: U256Wrapper(U256::from(150)),
+            },
+        ];
+
+        let range_start = truncate_to_bucket(now - bucket_duration * 3, Interval::Hourly);
+        let range_end = range_start + bucket_duration * 4;
+        let expected_buckets = build_expected_buckets(range_start, range_end, Interval::Hourly);
+
+        let result = fill_gaps(data, Interval::Hourly, &expected_buckets, None);
+
+        // Should have 4 data points with gaps filled
+        assert!(!result.is_empty());
+    }
+}

--- a/apps/chart-api/src/services/mod.rs
+++ b/apps/chart-api/src/services/mod.rs
@@ -1,7 +1,11 @@
 mod data_fetcher;
 mod gap_filler;
+mod pnl_data_fetcher;
+mod pnl_time;
 mod svg_generator;
 
 pub use data_fetcher::*;
 pub use gap_filler::*;
+pub use pnl_data_fetcher::*;
+pub use pnl_time::*;
 pub use svg_generator::*;

--- a/apps/chart-api/src/services/mod.rs
+++ b/apps/chart-api/src/services/mod.rs
@@ -1,0 +1,7 @@
+mod data_fetcher;
+mod gap_filler;
+mod svg_generator;
+
+pub use data_fetcher::*;
+pub use gap_filler::*;
+pub use svg_generator::*;

--- a/apps/chart-api/src/services/pnl_data_fetcher.rs
+++ b/apps/chart-api/src/services/pnl_data_fetcher.rs
@@ -1,0 +1,359 @@
+use crate::error::ApiError;
+use crate::types::PnlInterval;
+use chrono::{DateTime, Utc};
+use sqlx::{Pool, Postgres, Row};
+use sqlx::types::BigDecimal;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub struct PnlComputedPoint {
+    pub timestamp: DateTime<Utc>,
+    pub shares_total: BigDecimal,
+    pub share_price: BigDecimal,
+    pub equity_value: BigDecimal,
+    pub total_assets_in: BigDecimal,
+    pub total_assets_out: BigDecimal,
+    pub net_invested: BigDecimal,
+    pub total_pnl: BigDecimal,
+    pub pnl_pct: BigDecimal,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PositionDeltaRow {
+    pub bucket: DateTime<Utc>,
+    pub shares_delta_period: BigDecimal,
+    pub assets_in_period: BigDecimal,
+    pub assets_out_period: BigDecimal,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PriceBucketRow {
+    pub bucket: DateTime<Utc>,
+    pub share_price: BigDecimal,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PositionTotalsRow {
+    pub shares_total: BigDecimal,
+    pub assets_in_total: BigDecimal,
+    pub assets_out_total: BigDecimal,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct AccountPositionRow {
+    pub term_id: String,
+    pub curve_id: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct AccountCurrentTotalsRow {
+    pub equity_value: BigDecimal,
+    pub total_assets_in: BigDecimal,
+    pub total_assets_out: BigDecimal,
+    pub position_count: i64,
+}
+
+/// Check if a position exists for account/term/curve
+pub async fn position_exists(
+    pool: &Pool<Postgres>,
+    account_id: &str,
+    term_id: &str,
+    curve_id: &str,
+) -> Result<bool, ApiError> {
+    let row = sqlx::query(
+        r#"
+        SELECT 1 FROM position
+        WHERE account_id = $1
+          AND term_id = $2
+          AND curve_id = $3::numeric
+        LIMIT 1
+        "#,
+    )
+    .bind(account_id)
+    .bind(term_id)
+    .bind(curve_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.is_some())
+}
+
+/// Fetch distinct positions for an account
+pub async fn fetch_account_positions(
+    pool: &Pool<Postgres>,
+    account_id: &str,
+) -> Result<Vec<AccountPositionRow>, ApiError> {
+    let rows = sqlx::query_as::<_, AccountPositionRow>(
+        r#"
+        SELECT term_id, curve_id::text as curve_id
+        FROM position
+        WHERE account_id = $1
+        ORDER BY term_id, curve_id
+        "#,
+    )
+    .bind(account_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows)
+}
+
+/// Fetch cumulative position totals before the start of the range
+async fn fetch_position_totals_before(
+    pool: &Pool<Postgres>,
+    account_id: &str,
+    term_id: &str,
+    curve_id: &str,
+    range_start: DateTime<Utc>,
+) -> Result<PositionTotalsRow, ApiError> {
+    let row = sqlx::query_as::<_, PositionTotalsRow>(
+        r#"
+        SELECT
+            COALESCE(SUM(shares_delta), 0) AS shares_total,
+            COALESCE(SUM(assets_in), 0) AS assets_in_total,
+            COALESCE(SUM(assets_out), 0) AS assets_out_total
+        FROM position_change
+        WHERE account_id = $1
+          AND term_id = $2
+          AND curve_id = $3::numeric
+          AND created_at < $4
+        "#,
+    )
+    .bind(account_id)
+    .bind(term_id)
+    .bind(curve_id)
+    .bind(range_start)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(row)
+}
+
+/// Fetch position deltas by bucket within the range
+async fn fetch_position_deltas(
+    pool: &Pool<Postgres>,
+    account_id: &str,
+    term_id: &str,
+    curve_id: &str,
+    interval: PnlInterval,
+    range_start: DateTime<Utc>,
+    range_end: DateTime<Utc>,
+) -> Result<Vec<PositionDeltaRow>, ApiError> {
+    let query = r#"
+        SELECT
+            time_bucket($4::interval, created_at) AS bucket,
+            COALESCE(SUM(shares_delta), 0) AS shares_delta_period,
+            COALESCE(SUM(assets_in), 0) AS assets_in_period,
+            COALESCE(SUM(assets_out), 0) AS assets_out_period
+        FROM position_change
+        WHERE account_id = $1
+          AND term_id = $2
+          AND curve_id = $3::numeric
+          AND created_at >= $5
+          AND created_at < $6
+        GROUP BY bucket
+        ORDER BY bucket ASC
+    "#;
+
+    let rows = sqlx::query_as::<_, PositionDeltaRow>(query)
+        .bind(account_id)
+        .bind(term_id)
+        .bind(curve_id)
+        .bind(interval.as_postgres_interval())
+        .bind(range_start)
+        .bind(range_end)
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows)
+}
+
+/// Fetch share price buckets within the range
+async fn fetch_price_buckets(
+    pool: &Pool<Postgres>,
+    term_id: &str,
+    curve_id: &str,
+    interval: PnlInterval,
+    range_start: DateTime<Utc>,
+    range_end: DateTime<Utc>,
+) -> Result<Vec<PriceBucketRow>, ApiError> {
+    let query = r#"
+        SELECT
+            time_bucket($3::interval, updated_at) AS bucket,
+            last(share_price, updated_at) AS share_price
+        FROM share_price_change
+        WHERE term_id = $1
+          AND curve_id = $2::numeric
+          AND updated_at >= $4
+          AND updated_at < $5
+        GROUP BY bucket
+        ORDER BY bucket ASC
+    "#;
+
+    let rows = sqlx::query_as::<_, PriceBucketRow>(query)
+        .bind(term_id)
+        .bind(curve_id)
+        .bind(interval.as_postgres_interval())
+        .bind(range_start)
+        .bind(range_end)
+        .fetch_all(pool)
+        .await?;
+
+    Ok(rows)
+}
+
+/// Fetch the latest share price before the range start
+async fn fetch_latest_price_before(
+    pool: &Pool<Postgres>,
+    term_id: &str,
+    curve_id: &str,
+    range_start: DateTime<Utc>,
+) -> Result<Option<BigDecimal>, ApiError> {
+    let row = sqlx::query(
+        r#"
+        SELECT share_price
+        FROM share_price_change
+        WHERE term_id = $1
+          AND curve_id = $2::numeric
+          AND updated_at < $3
+        ORDER BY updated_at DESC
+        LIMIT 1
+        "#,
+    )
+    .bind(term_id)
+    .bind(curve_id)
+    .bind(range_start)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|row| row.get("share_price")))
+}
+
+/// Build a position-level PnL series for an account/term/curve
+pub async fn build_position_pnl_series(
+    pool: &Pool<Postgres>,
+    account_id: &str,
+    term_id: &str,
+    curve_id: &str,
+    interval: PnlInterval,
+    range_start: DateTime<Utc>,
+    range_end: DateTime<Utc>,
+    expected_buckets: &[DateTime<Utc>],
+) -> Result<Vec<PnlComputedPoint>, ApiError> {
+    let totals_before =
+        fetch_position_totals_before(pool, account_id, term_id, curve_id, range_start).await?;
+    let deltas = fetch_position_deltas(
+        pool,
+        account_id,
+        term_id,
+        curve_id,
+        interval,
+        range_start,
+        range_end,
+    )
+    .await?;
+    let price_buckets =
+        fetch_price_buckets(pool, term_id, curve_id, interval, range_start, range_end).await?;
+    let latest_price_before =
+        fetch_latest_price_before(pool, term_id, curve_id, range_start).await?;
+
+    let mut delta_map: HashMap<DateTime<Utc>, PositionDeltaRow> = HashMap::new();
+    for row in deltas {
+        delta_map.insert(row.bucket, row);
+    }
+
+    let mut price_map: HashMap<DateTime<Utc>, BigDecimal> = HashMap::new();
+    for row in price_buckets.iter() {
+        price_map.insert(row.bucket, row.share_price.clone());
+    }
+
+    let mut last_price = latest_price_before.or_else(|| {
+        price_buckets
+            .first()
+            .map(|row| row.share_price.clone())
+    });
+
+    if last_price.is_none() {
+        return Err(ApiError::NoDataAvailable);
+    }
+
+    let scale = BigDecimal::from_str("1000000000000000000")
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let hundred = BigDecimal::from(100);
+    let zero = BigDecimal::from(0);
+    let one = BigDecimal::from(1);
+
+    let mut shares_total = totals_before.shares_total;
+    let mut assets_in_total = totals_before.assets_in_total;
+    let mut assets_out_total = totals_before.assets_out_total;
+
+    let mut series = Vec::with_capacity(expected_buckets.len());
+
+    for bucket in expected_buckets {
+        if let Some(delta) = delta_map.get(bucket) {
+            shares_total = shares_total.clone() + delta.shares_delta_period.clone();
+            assets_in_total = assets_in_total.clone() + delta.assets_in_period.clone();
+            assets_out_total = assets_out_total.clone() + delta.assets_out_period.clone();
+        }
+
+        if let Some(price) = price_map.get(bucket) {
+            last_price = Some(price.clone());
+        }
+
+        let share_price = last_price.clone().ok_or(ApiError::NoDataAvailable)?;
+        let equity_value = (shares_total.clone() * share_price.clone()) / scale.clone();
+        let net_invested = assets_in_total.clone() - assets_out_total.clone();
+        let total_pnl = equity_value.clone() + assets_out_total.clone() - assets_in_total.clone();
+        let denom = if net_invested > zero {
+            net_invested.clone()
+        } else {
+            one.clone()
+        };
+        let pnl_pct = (total_pnl.clone() * hundred.clone()) / denom;
+
+        series.push(PnlComputedPoint {
+            timestamp: *bucket,
+            shares_total: shares_total.clone(),
+            share_price,
+            equity_value,
+            total_assets_in: assets_in_total.clone(),
+            total_assets_out: assets_out_total.clone(),
+            net_invested,
+            total_pnl,
+            pnl_pct,
+        });
+    }
+
+    Ok(series)
+}
+
+/// Fetch current account totals from positions and vaults
+pub async fn fetch_account_current_totals(
+    pool: &Pool<Postgres>,
+    account_id: &str,
+) -> Result<Option<AccountCurrentTotalsRow>, ApiError> {
+    let row = sqlx::query_as::<_, AccountCurrentTotalsRow>(
+        r#"
+        SELECT
+            COALESCE(SUM((p.shares * v.current_share_price) / 1000000000000000000), 0) AS equity_value,
+            COALESCE(SUM(p.total_deposit_assets_after_total_fees), 0) AS total_assets_in,
+            COALESCE(SUM(p.total_redeem_assets_for_receiver), 0) AS total_assets_out,
+            COUNT(*) AS position_count
+        FROM position p
+        JOIN vault v
+          ON p.term_id = v.term_id
+         AND p.curve_id = v.curve_id
+        WHERE p.account_id = $1
+        "#,
+    )
+    .bind(account_id)
+    .fetch_one(pool)
+    .await?;
+
+    if row.position_count == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(row))
+}

--- a/apps/chart-api/src/services/pnl_time.rs
+++ b/apps/chart-api/src/services/pnl_time.rs
@@ -1,0 +1,88 @@
+use crate::types::PnlInterval;
+use chrono::{DateTime, Duration, Timelike, Utc};
+use std::cmp::Ordering;
+
+/// Align a range to interval bucket boundaries (end is exclusive)
+pub fn align_pnl_range(
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    interval: PnlInterval,
+) -> (DateTime<Utc>, DateTime<Utc>) {
+    let range_start = ceil_to_bucket(start, interval);
+    let range_end = ceil_to_bucket(end, interval);
+    (range_start, range_end)
+}
+
+/// Build expected bucket timestamps for the aligned range (end is exclusive)
+pub fn build_pnl_expected_buckets(
+    range_start: DateTime<Utc>,
+    range_end: DateTime<Utc>,
+    interval: PnlInterval,
+) -> Vec<DateTime<Utc>> {
+    if range_start >= range_end {
+        return Vec::new();
+    }
+
+    let mut buckets = Vec::new();
+    let mut current = range_start;
+
+    while current < range_end {
+        buckets.push(current);
+        let next = next_bucket(current, interval);
+        if next <= current {
+            break;
+        }
+        current = next;
+    }
+
+    buckets
+}
+
+/// Get the next bucket timestamp based on interval
+fn next_bucket(current: DateTime<Utc>, interval: PnlInterval) -> DateTime<Utc> {
+    match interval {
+        PnlInterval::OneMinute => current + Duration::minutes(1),
+        PnlInterval::FiveMinutes => current + Duration::minutes(5),
+        PnlInterval::OneHour => current + Duration::hours(1),
+        PnlInterval::OneDay => current + Duration::days(1),
+    }
+}
+
+/// Truncate a timestamp to its bucket boundary
+fn truncate_to_bucket(timestamp: DateTime<Utc>, interval: PnlInterval) -> DateTime<Utc> {
+    match interval {
+        PnlInterval::OneMinute => timestamp
+            .with_second(0)
+            .and_then(|t| t.with_nanosecond(0))
+            .unwrap_or(timestamp),
+        PnlInterval::FiveMinutes => {
+            let minute = timestamp.minute();
+            let floored = (minute / 5) * 5;
+            timestamp
+                .with_minute(floored)
+                .and_then(|t| t.with_second(0))
+                .and_then(|t| t.with_nanosecond(0))
+                .unwrap_or(timestamp)
+        }
+        PnlInterval::OneHour => timestamp
+            .with_minute(0)
+            .and_then(|t| t.with_second(0))
+            .and_then(|t| t.with_nanosecond(0))
+            .unwrap_or(timestamp),
+        PnlInterval::OneDay => timestamp
+            .with_hour(0)
+            .and_then(|t| t.with_minute(0))
+            .and_then(|t| t.with_second(0))
+            .and_then(|t| t.with_nanosecond(0))
+            .unwrap_or(timestamp),
+    }
+}
+
+/// Ceil a timestamp to its bucket boundary
+fn ceil_to_bucket(timestamp: DateTime<Utc>, interval: PnlInterval) -> DateTime<Utc> {
+    let truncated = truncate_to_bucket(timestamp, interval);
+    match truncated.cmp(&timestamp) {
+        Ordering::Equal => truncated,
+        _ => next_bucket(truncated, interval),
+    }
+}

--- a/apps/chart-api/src/services/svg_generator.rs
+++ b/apps/chart-api/src/services/svg_generator.rs
@@ -1,0 +1,278 @@
+use crate::models::ChartDataPoint;
+use crate::types::SvgConfig;
+use alloy::primitives::U256;
+use svg::Document;
+use svg::node::element::{Group, Line, Path, Rectangle, Text};
+
+/// Generate an SVG line chart from chart data points
+pub fn generate_svg(data_points: &[ChartDataPoint], config: &SvgConfig) -> String {
+    if data_points.is_empty() {
+        return generate_empty_svg(config);
+    }
+
+    let chart_width = config.width - (2 * config.padding);
+    let chart_height = config.height - (2 * config.padding);
+
+    // Find min/max values for scaling
+    let (min_value, max_value) = find_value_range(data_points);
+    let value_range = if max_value > min_value {
+        max_value - min_value
+    } else {
+        U256::from(1) // Avoid division by zero for constant values
+    };
+
+    // Build SVG document
+    let mut document = Document::new()
+        .set("viewBox", (0, 0, config.width, config.height))
+        .set("width", config.width)
+        .set("height", config.height)
+        .set("xmlns", "http://www.w3.org/2000/svg");
+
+    // Add background if specified
+    if let Some(ref bg_color) = config.background_color {
+        let background = Rectangle::new()
+            .set("x", 0)
+            .set("y", 0)
+            .set("width", config.width)
+            .set("height", config.height)
+            .set("fill", bg_color.as_str());
+        document = document.add(background);
+    }
+
+    // Create chart group with padding offset
+    let chart_group = Group::new().set(
+        "transform",
+        format!("translate({}, {})", config.padding, config.padding),
+    );
+
+    // Add grid lines (optional, for better visualization)
+    let grid_group = create_grid(chart_width, chart_height);
+
+    // Build the path for the line chart
+    let path_data = build_path_data(
+        data_points,
+        chart_width as f64,
+        chart_height as f64,
+        &min_value,
+        &value_range,
+    );
+
+    let path = Path::new()
+        .set("d", path_data)
+        .set("fill", "none")
+        .set("stroke", config.line_color.as_str())
+        .set("stroke-width", config.line_width)
+        .set("stroke-linecap", "round")
+        .set("stroke-linejoin", "round");
+
+    document = document.add(chart_group.add(grid_group).add(path));
+
+    document.to_string()
+}
+
+/// Generate an empty SVG with a message
+fn generate_empty_svg(config: &SvgConfig) -> String {
+    let mut document = Document::new()
+        .set("viewBox", (0, 0, config.width, config.height))
+        .set("width", config.width)
+        .set("height", config.height)
+        .set("xmlns", "http://www.w3.org/2000/svg");
+
+    // Add background if specified
+    if let Some(ref bg_color) = config.background_color {
+        let background = Rectangle::new()
+            .set("x", 0)
+            .set("y", 0)
+            .set("width", config.width)
+            .set("height", config.height)
+            .set("fill", bg_color.as_str());
+        document = document.add(background);
+    }
+
+    // Add "No Data" text
+    let text = Text::new("No data available")
+        .set("x", config.width / 2)
+        .set("y", config.height / 2)
+        .set("text-anchor", "middle")
+        .set("dominant-baseline", "middle")
+        .set("fill", "#666666")
+        .set("font-family", "sans-serif")
+        .set("font-size", "14");
+
+    document = document.add(text);
+
+    document.to_string()
+}
+
+/// Find the min and max value in the data
+fn find_value_range(data_points: &[ChartDataPoint]) -> (U256, U256) {
+    let mut min = U256::MAX;
+    let mut max = U256::ZERO;
+
+    for point in data_points {
+        let value = point.value.0;
+        if value < min {
+            min = value;
+        }
+        if value > max {
+            max = value;
+        }
+    }
+
+    // If all values are the same, add some padding
+    if min == max {
+        let padding = min / U256::from(10);
+        if padding > U256::ZERO {
+            min = min.saturating_sub(padding);
+            max = max.saturating_add(padding);
+        } else {
+            // Very small values, use fixed padding
+            max = max.saturating_add(U256::from(1));
+        }
+    }
+
+    (min, max)
+}
+
+/// Build the SVG path data string for the line chart
+fn build_path_data(
+    data_points: &[ChartDataPoint],
+    chart_width: f64,
+    chart_height: f64,
+    min_value: &U256,
+    value_range: &U256,
+) -> String {
+    let mut path_data = String::new();
+    let point_count = data_points.len();
+
+    if point_count == 0 {
+        return path_data;
+    }
+
+    for (i, point) in data_points.iter().enumerate() {
+        let x = if point_count > 1 {
+            (i as f64 / (point_count - 1) as f64) * chart_width
+        } else {
+            chart_width / 2.0
+        };
+
+        let normalized_value = normalize_value(&point.value.0, min_value, value_range);
+        let y = (1.0 - normalized_value) * chart_height; // Invert Y axis
+
+        if i == 0 {
+            path_data.push_str(&format!("M {} {}", x, y));
+        } else {
+            path_data.push_str(&format!(" L {} {}", x, y));
+        }
+    }
+
+    path_data
+}
+
+/// Normalize a value to a 0.0-1.0 range
+fn normalize_value(value: &U256, min_value: &U256, value_range: &U256) -> f64 {
+    if *value_range == U256::ZERO {
+        return 0.5; // Middle of chart for constant values
+    }
+
+    let offset = value.saturating_sub(*min_value);
+
+    // Convert to f64 for division (may lose precision for very large numbers)
+    // This is acceptable for visualization purposes
+    let offset_f64 = u256_to_f64(&offset);
+    let range_f64 = u256_to_f64(value_range);
+
+    if range_f64 > 0.0 {
+        (offset_f64 / range_f64).clamp(0.0, 1.0)
+    } else {
+        0.5
+    }
+}
+
+/// Convert U256 to f64 (may lose precision for very large numbers)
+fn u256_to_f64(value: &U256) -> f64 {
+    // For visualization, we can safely convert to f64
+    // Large values will lose precision but will still render correctly
+    let s = value.to_string();
+    s.parse::<f64>().unwrap_or(0.0)
+}
+
+/// Create subtle grid lines for the chart
+fn create_grid(width: u32, height: u32) -> Group {
+    let mut grid = Group::new()
+        .set("stroke", "#e0e0e0")
+        .set("stroke-width", 0.5);
+
+    // Horizontal grid lines (5 lines)
+    for i in 0..=4 {
+        let y = (height as f64 / 4.0) * i as f64;
+        let line = Line::new()
+            .set("x1", 0)
+            .set("y1", y)
+            .set("x2", width)
+            .set("y2", y);
+        grid = grid.add(line);
+    }
+
+    // Vertical grid lines (based on data points, max 10)
+    for i in 0..=4 {
+        let x = (width as f64 / 4.0) * i as f64;
+        let line = Line::new()
+            .set("x1", x)
+            .set("y1", 0)
+            .set("x2", x)
+            .set("y2", height);
+        grid = grid.add(line);
+    }
+
+    grid
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use models::types::U256Wrapper;
+
+    #[test]
+    fn test_generate_svg_with_data() {
+        let data = vec![
+            ChartDataPoint {
+                timestamp: Utc::now(),
+                value: U256Wrapper(U256::from(100)),
+            },
+            ChartDataPoint {
+                timestamp: Utc::now(),
+                value: U256Wrapper(U256::from(150)),
+            },
+            ChartDataPoint {
+                timestamp: Utc::now(),
+                value: U256Wrapper(U256::from(120)),
+            },
+        ];
+
+        let config = SvgConfig::default();
+        let svg = generate_svg(&data, &config);
+
+        assert!(svg.contains("<svg"));
+        assert!(svg.contains("</svg>"));
+        assert!(svg.contains("<path"));
+    }
+
+    #[test]
+    fn test_generate_empty_svg() {
+        let config = SvgConfig::default();
+        let svg = generate_svg(&[], &config);
+
+        assert!(svg.contains("No data available"));
+    }
+
+    #[test]
+    fn test_normalize_value() {
+        let min = U256::from(100);
+        let range = U256::from(100);
+
+        let result = normalize_value(&U256::from(150), &min, &range);
+        assert!((result - 0.5).abs() < 0.001);
+    }
+}

--- a/apps/chart-api/src/state.rs
+++ b/apps/chart-api/src/state.rs
@@ -1,0 +1,124 @@
+use crate::types::Env;
+use redis::Client as RedisClient;
+use redis::aio::ConnectionManager;
+use shared_utils::postgres::connect_to_db;
+use sqlx::{Pool, Postgres};
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+/// Application state shared across handlers
+#[derive(Clone)]
+pub struct AppState {
+    pub pg_pool: Pool<Postgres>,
+    pub redis: ConnectionManager,
+}
+
+/// Maximum number of connection retry attempts
+const MAX_RETRIES: u32 = 5;
+
+/// Base delay between retries (in milliseconds)
+const RETRY_DELAY_MS: u64 = 1000;
+
+impl AppState {
+    pub async fn new(env: &Env) -> Result<Self, Box<dyn std::error::Error>> {
+        // Connect to PostgreSQL with retry logic
+        let pg_pool = Self::connect_postgres_with_retry(&env.database_url).await?;
+
+        // Connect to Redis with retry logic
+        let redis = Self::connect_redis_with_retry(&env.redis_url).await?;
+
+        Ok(Self { pg_pool, redis })
+    }
+
+    /// Connect to PostgreSQL with exponential backoff retry
+    async fn connect_postgres_with_retry(
+        database_url: &str,
+    ) -> Result<Pool<Postgres>, Box<dyn std::error::Error>> {
+        let mut attempts = 0;
+
+        loop {
+            attempts += 1;
+            match connect_to_db(database_url).await {
+                Ok(pool) => {
+                    info!("Successfully connected to PostgreSQL");
+                    return Ok(pool);
+                }
+                Err(e) if attempts < MAX_RETRIES => {
+                    let delay = Duration::from_millis(RETRY_DELAY_MS * 2u64.pow(attempts - 1));
+                    warn!(
+                        "Failed to connect to PostgreSQL (attempt {}/{}): {}. Retrying in {:?}...",
+                        attempts, MAX_RETRIES, e, delay
+                    );
+                    sleep(delay).await;
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to connect to PostgreSQL after {} attempts: {}",
+                        MAX_RETRIES, e
+                    );
+                    return Err(Box::new(e));
+                }
+            }
+        }
+    }
+
+    /// Connect to Redis with exponential backoff retry
+    async fn connect_redis_with_retry(
+        redis_url: &str,
+    ) -> Result<ConnectionManager, Box<dyn std::error::Error>> {
+        let mut attempts = 0;
+
+        loop {
+            attempts += 1;
+            match Self::try_connect_redis(redis_url).await {
+                Ok(manager) => {
+                    info!("Successfully connected to Redis");
+                    return Ok(manager);
+                }
+                Err(e) if attempts < MAX_RETRIES => {
+                    let delay = Duration::from_millis(RETRY_DELAY_MS * 2u64.pow(attempts - 1));
+                    warn!(
+                        "Failed to connect to Redis (attempt {}/{}): {}. Retrying in {:?}...",
+                        attempts, MAX_RETRIES, e, delay
+                    );
+                    sleep(delay).await;
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to connect to Redis after {} attempts: {}",
+                        MAX_RETRIES, e
+                    );
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Attempt to connect to Redis once with configured timeouts
+    async fn try_connect_redis(
+        redis_url: &str,
+    ) -> Result<ConnectionManager, Box<dyn std::error::Error>> {
+        let redis_client = RedisClient::open(redis_url)?;
+        // Configure connection with timeouts
+        let config = redis::aio::ConnectionManagerConfig::new()
+            .set_connection_timeout(Duration::from_secs(10))
+            .set_response_timeout(Duration::from_secs(5));
+        let manager = ConnectionManager::new_with_config(redis_client, config).await?;
+        Ok(manager)
+    }
+
+    /// Check if PostgreSQL connection is healthy
+    pub async fn check_postgres_health(&self) -> Result<(), sqlx::Error> {
+        sqlx::query("SELECT 1").fetch_one(&self.pg_pool).await?;
+        Ok(())
+    }
+
+    /// Check if Redis connection is healthy
+    pub async fn check_redis_health(&self) -> Result<(), redis::RedisError> {
+        use redis::cmd;
+        let mut conn = self.redis.clone();
+        cmd("PING").query_async::<String>(&mut conn).await?;
+        Ok(())
+    }
+}

--- a/apps/chart-api/src/types.rs
+++ b/apps/chart-api/src/types.rs
@@ -193,6 +193,74 @@ pub struct ChartQueryParams {
     pub background_color: Option<String>,
 }
 
+/// Time interval for PnL chart data
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum PnlInterval {
+    #[serde(rename = "1m")]
+    OneMinute,
+    #[serde(rename = "5m")]
+    FiveMinutes,
+    #[serde(rename = "1h")]
+    OneHour,
+    #[serde(rename = "1d")]
+    OneDay,
+}
+
+impl PnlInterval {
+    /// Parse interval from string
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "1m" => Some(PnlInterval::OneMinute),
+            "5m" => Some(PnlInterval::FiveMinutes),
+            "1h" => Some(PnlInterval::OneHour),
+            "1d" => Some(PnlInterval::OneDay),
+            _ => None,
+        }
+    }
+
+    /// Get the cache TTL in seconds for this interval
+    pub fn cache_ttl_seconds(&self) -> u64 {
+        match self {
+            PnlInterval::OneMinute => 30,
+            PnlInterval::FiveMinutes => 60,
+            PnlInterval::OneHour => 120,
+            PnlInterval::OneDay => 300,
+        }
+    }
+
+    /// Get the Postgres interval string
+    pub fn as_postgres_interval(&self) -> &'static str {
+        match self {
+            PnlInterval::OneMinute => "1 minute",
+            PnlInterval::FiveMinutes => "5 minutes",
+            PnlInterval::OneHour => "1 hour",
+            PnlInterval::OneDay => "1 day",
+        }
+    }
+}
+
+impl fmt::Display for PnlInterval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PnlInterval::OneMinute => write!(f, "1m"),
+            PnlInterval::FiveMinutes => write!(f, "5m"),
+            PnlInterval::OneHour => write!(f, "1h"),
+            PnlInterval::OneDay => write!(f, "1d"),
+        }
+    }
+}
+
+/// Query parameters for PnL chart endpoints
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PnlChartQueryParams {
+    /// Time interval: 1m, 5m, 1h, 1d
+    pub interval: String,
+    /// Range start timestamp (unix seconds, unix milliseconds, or RFC3339)
+    pub start: String,
+    /// Range end timestamp (unix seconds, unix milliseconds, or RFC3339)
+    pub end: String,
+}
+
 /// SVG configuration with defaults
 #[derive(Debug, Clone)]
 pub struct SvgConfig {

--- a/apps/chart-api/src/types.rs
+++ b/apps/chart-api/src/types.rs
@@ -1,0 +1,295 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use utoipa::ToSchema;
+
+/// Environment configuration
+#[derive(Deserialize, Clone)]
+pub struct Env {
+    pub chart_api_port: u16,
+    pub database_url: String,
+    pub redis_url: String,
+    /// Comma-separated list of allowed CORS origins. If not set, defaults to restrictive mode (no wildcard).
+    /// Use "*" to allow all origins (not recommended for production).
+    #[serde(default = "default_cors_origins")]
+    pub cors_allowed_origins: String,
+}
+
+/// Default CORS origins (empty means restrictive mode)
+fn default_cors_origins() -> String {
+    String::new()
+}
+
+/// Supported graph types for charting
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum GraphType {
+    /// Share price change over time (default)
+    #[default]
+    #[serde(rename = "sharePriceChange")]
+    SharePriceChange,
+    /// Total market cap over time (term-level, no curve_id required)
+    #[serde(rename = "totalMarketCap")]
+    TotalMarketCap,
+}
+
+impl GraphType {
+    /// Parse graph type from string (case-insensitive, supports snake_case and camelCase)
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().replace('_', "").as_str() {
+            "sharepricechange" => Some(GraphType::SharePriceChange),
+            "totalmarketcap" => Some(GraphType::TotalMarketCap),
+            _ => None,
+        }
+    }
+
+    /// Whether this graph type requires a curve_id parameter
+    pub fn requires_curve_id(&self) -> bool {
+        match self {
+            GraphType::SharePriceChange => true,
+            GraphType::TotalMarketCap => false,
+        }
+    }
+
+    /// Get the view name prefix (without interval suffix)
+    pub fn view_name_prefix(&self) -> &'static str {
+        match self {
+            GraphType::SharePriceChange => "share_price_change_stats",
+            GraphType::TotalMarketCap => "term_total_state_change_stats",
+        }
+    }
+
+    /// Get the full view name for the given interval
+    pub fn view_name(&self, interval: Interval) -> String {
+        format!("{}_{}", self.view_name_prefix(), interval.suffix())
+    }
+
+    /// Get the column name that contains the value to chart
+    pub fn value_column(&self) -> &'static str {
+        match self {
+            GraphType::SharePriceChange => "last_share_price",
+            GraphType::TotalMarketCap => "last_total_market_cap",
+        }
+    }
+}
+
+impl fmt::Display for GraphType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GraphType::SharePriceChange => write!(f, "sharePriceChange"),
+            GraphType::TotalMarketCap => write!(f, "totalMarketCap"),
+        }
+    }
+}
+
+/// Time interval for chart data
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum Interval {
+    #[serde(rename = "1h")]
+    Hourly,
+    #[serde(rename = "1d")]
+    Daily,
+    #[serde(rename = "1w")]
+    Weekly,
+    #[serde(rename = "1m")]
+    Monthly,
+}
+
+impl Interval {
+    /// Parse interval from string
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "1h" => Some(Interval::Hourly),
+            "1d" => Some(Interval::Daily),
+            "1w" => Some(Interval::Weekly),
+            "1m" => Some(Interval::Monthly),
+            _ => None,
+        }
+    }
+
+    /// Get the cache TTL in seconds for this interval
+    pub fn cache_ttl_seconds(&self) -> u64 {
+        match self {
+            Interval::Hourly => 30,   // 30 seconds
+            Interval::Daily => 60,    // 1 minute
+            Interval::Weekly => 120,  // 2 minutes
+            Interval::Monthly => 300, // 5 minutes
+        }
+    }
+
+    /// Get the interval suffix for view names (e.g., "hourly", "daily")
+    pub fn suffix(&self) -> &'static str {
+        match self {
+            Interval::Hourly => "hourly",
+            Interval::Daily => "daily",
+            Interval::Weekly => "weekly",
+            Interval::Monthly => "monthly",
+        }
+    }
+}
+
+impl fmt::Display for Interval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Interval::Hourly => write!(f, "1h"),
+            Interval::Daily => write!(f, "1d"),
+            Interval::Weekly => write!(f, "1w"),
+            Interval::Monthly => write!(f, "1m"),
+        }
+    }
+}
+
+/// Output format for chart data
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFormat {
+    Json,
+    Svg,
+    /// SVG wrapped in JSON (for Hasura actions)
+    SvgJson,
+}
+
+impl OutputFormat {
+    /// Parse format from string
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "json" => Some(OutputFormat::Json),
+            "svg" => Some(OutputFormat::Svg),
+            "svg_json" => Some(OutputFormat::SvgJson),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputFormat::Json => write!(f, "json"),
+            OutputFormat::Svg => write!(f, "svg"),
+            OutputFormat::SvgJson => write!(f, "svg_json"),
+        }
+    }
+}
+
+/// Query parameters for the chart endpoint
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ChartQueryParams {
+    /// Time interval: 1h, 1d, 1w, 1m
+    pub interval: String,
+    /// Output format: json or svg
+    pub format: String,
+    /// Range start timestamp (unix seconds, unix milliseconds, or RFC3339)
+    pub start: String,
+    /// Range end timestamp (unix seconds, unix milliseconds, or RFC3339)
+    pub end: String,
+    /// Graph type: sharePriceChange (default), totalMarketCap
+    pub graph_type: Option<String>,
+    /// Optional: SVG width in pixels (default: 800)
+    pub width: Option<u32>,
+    /// Optional: SVG height in pixels (default: 400)
+    pub height: Option<u32>,
+    /// Optional: SVG line color (default: #3B82F6)
+    pub line_color: Option<String>,
+    /// Optional: SVG background color (default: transparent)
+    pub background_color: Option<String>,
+}
+
+/// SVG configuration with defaults
+#[derive(Debug, Clone)]
+pub struct SvgConfig {
+    pub width: u32,
+    pub height: u32,
+    pub line_color: String,
+    pub background_color: Option<String>,
+    pub line_width: f32,
+    pub padding: u32,
+}
+
+/// SVG dimension limits to prevent memory exhaustion
+const SVG_MIN_DIMENSION: u32 = 100;
+const SVG_MAX_DIMENSION: u32 = 4000;
+const SVG_DEFAULT_WIDTH: u32 = 800;
+const SVG_DEFAULT_HEIGHT: u32 = 400;
+const SVG_DEFAULT_COLOR: &str = "#3B82F6";
+
+impl Default for SvgConfig {
+    fn default() -> Self {
+        Self {
+            width: SVG_DEFAULT_WIDTH,
+            height: SVG_DEFAULT_HEIGHT,
+            line_color: SVG_DEFAULT_COLOR.to_string(),
+            background_color: None,
+            line_width: 2.0,
+            padding: 40,
+        }
+    }
+}
+
+impl SvgConfig {
+    /// Validate and sanitize a color string.
+    /// Only allows hex colors (#RGB, #RRGGBB, #RRGGBBAA) or basic CSS color names.
+    fn sanitize_color(color: &str) -> Option<String> {
+        let color = color.trim();
+
+        // Allow hex colors: #RGB, #RRGGBB, #RRGGBBAA
+        if color.starts_with('#') {
+            let hex_part = &color[1..];
+            let valid_len = matches!(hex_part.len(), 3 | 6 | 8);
+            let valid_chars = hex_part.chars().all(|c| c.is_ascii_hexdigit());
+            if valid_len && valid_chars {
+                return Some(color.to_string());
+            }
+            return None;
+        }
+
+        // Allow basic CSS color names (lowercase, no spaces or special chars)
+        const ALLOWED_COLORS: &[&str] = &[
+            "black", "white", "red", "green", "blue", "yellow", "orange", "purple",
+            "pink", "gray", "grey", "cyan", "magenta", "brown", "navy", "teal",
+            "maroon", "olive", "lime", "aqua", "fuchsia", "silver", "transparent",
+        ];
+
+        let lower = color.to_lowercase();
+        if ALLOWED_COLORS.contains(&lower.as_str()) {
+            return Some(lower);
+        }
+
+        None
+    }
+
+    /// Clamp a dimension value to safe bounds
+    fn clamp_dimension(value: u32) -> u32 {
+        value.clamp(SVG_MIN_DIMENSION, SVG_MAX_DIMENSION)
+    }
+
+    pub fn from_query_params(params: &ChartQueryParams) -> Self {
+        let width = params
+            .width
+            .map(Self::clamp_dimension)
+            .unwrap_or(SVG_DEFAULT_WIDTH);
+
+        let height = params
+            .height
+            .map(Self::clamp_dimension)
+            .unwrap_or(SVG_DEFAULT_HEIGHT);
+
+        let line_color = params
+            .line_color
+            .as_ref()
+            .and_then(|c| Self::sanitize_color(c))
+            .unwrap_or_else(|| SVG_DEFAULT_COLOR.to_string());
+
+        let background_color = params
+            .background_color
+            .as_ref()
+            .and_then(|c| Self::sanitize_color(c));
+
+        Self {
+            width,
+            height,
+            line_color,
+            background_color,
+            line_width: 2.0,
+            padding: 40,
+        }
+    }
+}

--- a/apps/chart-api/src/validation.rs
+++ b/apps/chart-api/src/validation.rs
@@ -96,6 +96,17 @@ pub fn validate_curve_id(curve_id: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
+/// Validate the account_id parameter
+///
+/// account_id should be a non-empty string
+pub fn validate_account_id(account_id: &str) -> Result<(), ApiError> {
+    if account_id.trim().is_empty() {
+        return Err(ApiError::InvalidAccountId(account_id.to_string()));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/chart-api/src/validation.rs
+++ b/apps/chart-api/src/validation.rs
@@ -1,0 +1,178 @@
+use crate::error::ApiError;
+use chrono::{DateTime, TimeZone, Utc};
+
+/// Maximum allowed count for data points
+pub const MAX_COUNT: u32 = 1000;
+
+/// Minimum allowed count for data points
+pub const MIN_COUNT: u32 = 1;
+
+/// Validate the derived bucket count
+///
+/// # Arguments
+///
+/// * `count` - The count to validate
+///
+/// # Returns
+///
+/// Returns `Ok(())` if valid, `Err(ApiError::InvalidRange)` if invalid
+pub fn validate_count(count: u32) -> Result<(), ApiError> {
+    if !(MIN_COUNT..=MAX_COUNT).contains(&count) {
+        return Err(ApiError::InvalidRange(count, MAX_COUNT));
+    }
+    Ok(())
+}
+
+/// Parse a timestamp from unix seconds, unix milliseconds, or RFC3339
+pub fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    if let Ok(ts) = value.parse::<i64>() {
+        let dt = if ts.abs() >= 1_000_000_000_000 {
+            Utc.timestamp_millis_opt(ts).single()
+        } else {
+            Utc.timestamp_opt(ts, 0).single()
+        };
+        return dt;
+    }
+
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// Validate the time range
+pub fn validate_time_range(start: DateTime<Utc>, end: DateTime<Utc>) -> Result<(), ApiError> {
+    if start >= end {
+        return Err(ApiError::InvalidTimeRange);
+    }
+    Ok(())
+}
+
+/// Validate the term_id parameter
+///
+/// term_id should be a hex string starting with "0x"
+///
+/// # Arguments
+///
+/// * `term_id` - The term_id to validate
+///
+/// # Returns
+///
+/// Returns `Ok(())` if valid, `Err(ApiError::InvalidTermId)` if invalid
+pub fn validate_term_id(term_id: &str) -> Result<(), ApiError> {
+    if !term_id.starts_with("0x") {
+        return Err(ApiError::InvalidTermId(term_id.to_string()));
+    }
+
+    // Validate that the rest of the string is valid hex
+    let hex_part = &term_id[2..];
+    if hex_part.is_empty() || !hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(ApiError::InvalidTermId(term_id.to_string()));
+    }
+
+    Ok(())
+}
+
+/// Validate the curve_id parameter
+///
+/// curve_id should be a valid numeric string
+///
+/// # Arguments
+///
+/// * `curve_id` - The curve_id to validate
+///
+/// # Returns
+///
+/// Returns `Ok(())` if valid, `Err(ApiError::InvalidCurveId)` if invalid
+pub fn validate_curve_id(curve_id: &str) -> Result<(), ApiError> {
+    if curve_id.is_empty() {
+        return Err(ApiError::InvalidCurveId(curve_id.to_string()));
+    }
+
+    // Validate that the string is a valid number (can parse as u64 or i64)
+    if curve_id.parse::<i64>().is_err() {
+        return Err(ApiError::InvalidCurveId(curve_id.to_string()));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::DateTime;
+
+    #[test]
+    fn test_validate_count_valid() {
+        assert!(validate_count(1).is_ok());
+        assert!(validate_count(100).is_ok());
+        assert!(validate_count(1000).is_ok());
+    }
+
+    #[test]
+    fn test_validate_count_invalid() {
+        assert!(validate_count(0).is_err());
+        assert!(validate_count(1001).is_err());
+        assert!(validate_count(10000).is_err());
+    }
+
+    #[test]
+    fn test_parse_timestamp_unix_seconds() {
+        let ts = "1700000000";
+        let parsed = parse_timestamp(ts);
+        assert!(parsed.is_some());
+    }
+
+    #[test]
+    fn test_parse_timestamp_unix_millis() {
+        let ts = "1700000000000";
+        let parsed = parse_timestamp(ts);
+        assert!(parsed.is_some());
+    }
+
+    #[test]
+    fn test_parse_timestamp_rfc3339() {
+        let ts = "2026-01-01T00:00:00Z";
+        let parsed = parse_timestamp(ts);
+        assert!(parsed.is_some());
+    }
+
+    #[test]
+    fn test_validate_time_range_invalid() {
+        let start = "2026-01-02T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let end = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        assert!(validate_time_range(start, end).is_err());
+    }
+
+    #[test]
+    fn test_validate_term_id_valid() {
+        assert!(validate_term_id("0x1234").is_ok());
+        assert!(validate_term_id("0xabcdef").is_ok());
+        assert!(validate_term_id("0xABCDEF").is_ok());
+        assert!(validate_term_id("0x0").is_ok());
+    }
+
+    #[test]
+    fn test_validate_term_id_invalid() {
+        assert!(validate_term_id("1234").is_err()); // Missing 0x
+        assert!(validate_term_id("0x").is_err()); // Empty hex part
+        assert!(validate_term_id("0xghij").is_err()); // Invalid hex chars
+        assert!(validate_term_id("").is_err()); // Empty string
+        assert!(validate_term_id("x1234").is_err()); // Wrong prefix
+    }
+
+    #[test]
+    fn test_validate_curve_id_valid() {
+        assert!(validate_curve_id("0").is_ok());
+        assert!(validate_curve_id("123").is_ok());
+        assert!(validate_curve_id("-123").is_ok());
+        assert!(validate_curve_id("9223372036854775807").is_ok()); // i64::MAX
+    }
+
+    #[test]
+    fn test_validate_curve_id_invalid() {
+        assert!(validate_curve_id("").is_err());
+        assert!(validate_curve_id("abc").is_err());
+        assert!(validate_curve_id("12.34").is_err());
+        assert!(validate_curve_id("0x123").is_err());
+    }
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,16 +25,18 @@ COPY . .
 # Build all binaries
 ENV SQLX_OFFLINE=true
 RUN cargo build --release --bin consumer
-RUN cargo build --release --bin rpc-proxy  
+RUN cargo build --release --bin rpc-proxy
 RUN cargo build --release --bin histocrawler
 RUN cargo build --release --bin image-guard
+RUN cargo build --release --bin chart-api
 
 # Move binaries to final location and set ownership
 RUN mv /app/target/release/consumer /app/consumer && \
     mv /app/target/release/rpc-proxy /app/rpc-proxy && \
     mv /app/target/release/histocrawler /app/histocrawler && \
     mv /app/target/release/image-guard /app/image-guard && \
-    chown nonroot:nonroot /app/consumer /app/rpc-proxy /app/histocrawler /app/image-guard
+    mv /app/target/release/chart-api /app/chart-api && \
+    chown nonroot:nonroot /app/consumer /app/rpc-proxy /app/histocrawler /app/image-guard /app/chart-api
 
 # Clean up build artifacts to reduce image size
 RUN rm -rf /app/target /app/Cargo.toml /app/Cargo.lock /app/apps /app/infrastructure /app/integration-tests /app/scripts /app/docker /app/architecture-def.json /app/CLAUDE.md /app/README.md /app/LICENSE /app/Makefile.toml

--- a/docker/docker-compose-apps.yml
+++ b/docker/docker-compose-apps.yml
@@ -135,6 +135,19 @@ services:
     ports:
       - 3008:3008
 
+  chart-api:
+    container_name: chart-api
+    image: ghcr.io/0xintuition/apps:latest
+    command: ./chart-api
+    environment:
+      CHART_API_PORT: '3010'
+      DATABASE_URL: 'postgres://postgres:postgres@database:5435/storage'
+      REDIS_URL: 'redis://redis:6379'
+      RUST_LOG: 'info'
+    restart: always
+    ports:
+      - 3010:3010
+
   histocrawler:
     container_name: histocrawler
     image: ghcr.io/0xintuition/apps:latest

--- a/infrastructure/hasura/metadata/actions.graphql
+++ b/infrastructure/hasura/metadata/actions.graphql
@@ -93,6 +93,15 @@ type Query {
   getChartSvg(
     input: GetChartSvgInput!
   ): ChartSvgOutput
+  getPositionPnlChart(
+    input: GetPositionPnlChartInput!
+  ): PositionPnlChartOutput
+  getAccountPnlChart(
+    input: GetAccountPnlChartInput!
+  ): AccountPnlChartOutput
+  getAccountPnlCurrent(
+    input: GetAccountPnlCurrentInput!
+  ): AccountPnlSnapshotOutput
 }
 
 input GetChartJsonInput {
@@ -135,3 +144,71 @@ type ChartSvgOutput {
   svg: String!
 }
 
+input GetPositionPnlChartInput {
+  account_id: String!
+  term_id: String!
+  curve_id: String!
+  interval: String!
+  start_time: String!
+  end_time: String!
+}
+
+input GetAccountPnlChartInput {
+  account_id: String!
+  interval: String!
+  start_time: String!
+  end_time: String!
+}
+
+input GetAccountPnlCurrentInput {
+  account_id: String!
+}
+
+type PositionPnlChartOutput {
+  account_id: String!
+  term_id: String!
+  curve_id: String!
+  interval: String!
+  count: Int!
+  data: [PositionPnlChartPoint!]!
+}
+
+type PositionPnlChartPoint {
+  timestamp: String!
+  shares_total: String!
+  share_price: String!
+  equity_value: String!
+  total_assets_in: String!
+  total_assets_out: String!
+  net_invested: String!
+  total_pnl: String!
+  pnl_pct: String!
+}
+
+type AccountPnlChartOutput {
+  account_id: String!
+  interval: String!
+  count: Int!
+  data: [AccountPnlChartPoint!]!
+}
+
+type AccountPnlChartPoint {
+  timestamp: String!
+  equity_value: String!
+  total_assets_in: String!
+  total_assets_out: String!
+  net_invested: String!
+  total_pnl: String!
+  pnl_pct: String!
+}
+
+type AccountPnlSnapshotOutput {
+  account_id: String!
+  timestamp: String!
+  equity_value: String!
+  total_assets_in: String!
+  total_assets_out: String!
+  net_invested: String!
+  total_pnl: String!
+  pnl_pct: String!
+}

--- a/infrastructure/hasura/metadata/actions.graphql
+++ b/infrastructure/hasura/metadata/actions.graphql
@@ -86,3 +86,52 @@ type UploadJsonToIpfsOutput {
   size: String!
 }
 
+type Query {
+  getChartJson(
+    input: GetChartJsonInput!
+  ): ChartDataOutput
+  getChartSvg(
+    input: GetChartSvgInput!
+  ): ChartSvgOutput
+}
+
+input GetChartJsonInput {
+  term_id: String!
+  curve_id: String!
+  interval: String!
+  start_time: String!
+  end_time: String!
+  graph_type: String
+}
+
+input GetChartSvgInput {
+  term_id: String!
+  curve_id: String!
+  interval: String!
+  start_time: String!
+  end_time: String!
+  graph_type: String
+  width: Int
+  height: Int
+  line_color: String
+  background_color: String
+}
+
+type ChartDataOutput {
+  term_id: String!
+  curve_id: String
+  graph_type: String!
+  interval: String!
+  count: Int!
+  data: [ChartDataPoint!]!
+}
+
+type ChartDataPoint {
+  timestamp: String!
+  value: String!
+}
+
+type ChartSvgOutput {
+  svg: String!
+}
+

--- a/infrastructure/hasura/metadata/actions.yaml
+++ b/infrastructure/hasura/metadata/actions.yaml
@@ -211,6 +211,48 @@ actions:
       - role: anonymous
       - role: frontend
     comment: "Uploads and classifies an image file using image-guard. Accepts base64-encoded image data. Note: The original /upload endpoint requires multipart/form-data which Hasura actions cannot construct directly. This mutation uses upload_image_from_url with a data URL workaround. For direct file uploads, use the image-guard API directly or create a wrapper endpoint."
+  - name: getChartJson
+    definition:
+      kind: synchronous
+      handler: '{{chartApiUrl}}'
+      request_transform:
+        method: GET
+        url: '{{$base_url}}/api/v1/curve/{{$body.input.input.curve_id}}/term/{{$body.input.input.term_id}}/data'
+        query_params:
+          interval: '{{$body.input.input.interval}}'
+          format: 'json'
+          start: '{{$body.input.input.start_time}}'
+          end: '{{$body.input.input.end_time}}'
+          graph_type: '{{$body.input.input?.graph_type}}'
+        template_engine: Kriti
+        version: 2
+    permissions:
+      - role: anonymous
+      - role: frontend
+    comment: Fetches chart data (JSON) for a term/curve combination
+  - name: getChartSvg
+    definition:
+      kind: synchronous
+      handler: '{{chartApiUrl}}'
+      request_transform:
+        method: GET
+        url: '{{$base_url}}/api/v1/curve/{{$body.input.input.curve_id}}/term/{{$body.input.input.term_id}}/data'
+        query_params:
+          interval: '{{$body.input.input.interval}}'
+          format: 'svg_json'
+          start: '{{$body.input.input.start_time}}'
+          end: '{{$body.input.input.end_time}}'
+          graph_type: '{{$body.input.input?.graph_type}}'
+          width: '{{$body.input.input?.width}}'
+          height: '{{$body.input.input?.height}}'
+          line_color: '{{$body.input.input?.line_color}}'
+          background_color: '{{$body.input.input?.background_color}}'
+        template_engine: Kriti
+        version: 2
+    permissions:
+      - role: anonymous
+      - role: frontend
+    comment: Fetches chart SVG for a term/curve combination
 custom_types:
   enums: []
   input_objects:
@@ -220,9 +262,14 @@ custom_types:
     - name: PinJsonInput
     - name: UploadImageFromUrlInput
     - name: UploadImageInput
+    - name: GetChartJsonInput
+    - name: GetChartSvgInput
   objects:
     - name: PinOutput
     - name: UploadImageFromUrlOutput
     - name: CachedImage
     - name: UploadJsonToIpfsOutput
+    - name: ChartDataOutput
+    - name: ChartDataPoint
+    - name: ChartSvgOutput
   scalars: []

--- a/infrastructure/hasura/metadata/actions.yaml
+++ b/infrastructure/hasura/metadata/actions.yaml
@@ -253,6 +253,53 @@ actions:
       - role: anonymous
       - role: frontend
     comment: Fetches chart SVG for a term/curve combination
+  - name: getPositionPnlChart
+    definition:
+      kind: synchronous
+      handler: '{{chartApiUrl}}'
+      request_transform:
+        method: GET
+        url: '{{$base_url}}/api/v1/accounts/{{$body.input.input.account_id}}/positions/{{$body.input.input.term_id}}/{{$body.input.input.curve_id}}/pnl'
+        query_params:
+          interval: '{{$body.input.input.interval}}'
+          start: '{{$body.input.input.start_time}}'
+          end: '{{$body.input.input.end_time}}'
+        template_engine: Kriti
+        version: 2
+    permissions:
+      - role: anonymous
+      - role: frontend
+    comment: Fetches position PnL chart data
+  - name: getAccountPnlChart
+    definition:
+      kind: synchronous
+      handler: '{{chartApiUrl}}'
+      request_transform:
+        method: GET
+        url: '{{$base_url}}/api/v1/accounts/{{$body.input.input.account_id}}/pnl'
+        query_params:
+          interval: '{{$body.input.input.interval}}'
+          start: '{{$body.input.input.start_time}}'
+          end: '{{$body.input.input.end_time}}'
+        template_engine: Kriti
+        version: 2
+    permissions:
+      - role: anonymous
+      - role: frontend
+    comment: Fetches account-level PnL chart data
+  - name: getAccountPnlCurrent
+    definition:
+      kind: synchronous
+      handler: '{{chartApiUrl}}'
+      request_transform:
+        method: GET
+        url: '{{$base_url}}/api/v1/accounts/{{$body.input.input.account_id}}/pnl/current'
+        template_engine: Kriti
+        version: 2
+    permissions:
+      - role: anonymous
+      - role: frontend
+    comment: Fetches current account PnL snapshot
 custom_types:
   enums: []
   input_objects:
@@ -264,6 +311,9 @@ custom_types:
     - name: UploadImageInput
     - name: GetChartJsonInput
     - name: GetChartSvgInput
+    - name: GetPositionPnlChartInput
+    - name: GetAccountPnlChartInput
+    - name: GetAccountPnlCurrentInput
   objects:
     - name: PinOutput
     - name: UploadImageFromUrlOutput
@@ -272,4 +322,9 @@ custom_types:
     - name: ChartDataOutput
     - name: ChartDataPoint
     - name: ChartSvgOutput
+    - name: PositionPnlChartOutput
+    - name: PositionPnlChartPoint
+    - name: AccountPnlChartOutput
+    - name: AccountPnlChartPoint
+    - name: AccountPnlSnapshotOutput
   scalars: []


### PR DESCRIPTION
Add position and account PnL endpoints to chart-api with supporting models and services. Expose new PnL actions in Hasura metadata for chart-api integration. Includes required types and OpenAPI updates.