### PR TITLE
Luis/eng 8227 pnl leaderboard

### DIFF
--- a/infrastructure/hasura/metadata/databases/intuition/functions.yaml
+++ b/infrastructure/hasura/metadata/databases/intuition/functions.yaml
@@ -61,4 +61,28 @@ functions:
           allow: true
       - role: frontend
         definition:
-          allow: true 
+          allow: true
+  - function:
+      name: get_pnl_leaderboard_period
+      schema: public
+    configuration:
+      exposed_as: query
+    permissions:
+      - role: anonymous
+        definition:
+          allow: true
+      - role: frontend
+        definition:
+          allow: true
+  - function:
+      name: get_vault_leaderboard_period
+      schema: public
+    configuration:
+      exposed_as: query
+    permissions:
+      - role: anonymous
+        definition:
+          allow: true
+      - role: frontend
+        definition:
+          allow: true

--- a/infrastructure/hasura/metadata/databases/intuition/tables/public_position_with_value.yaml
+++ b/infrastructure/hasura/metadata/databases/intuition/tables/public_position_with_value.yaml
@@ -56,6 +56,7 @@ select_permissions:
         - theoretical_value
         - pnl
         - pnl_pct
+        - redeemable_assets
       filter: {}
       limit: 100
       allow_aggregations: true
@@ -79,6 +80,7 @@ select_permissions:
         - theoretical_value
         - pnl
         - pnl_pct
+        - redeemable_assets
       filter: {}
       limit: 100
       allow_aggregations: true

--- a/infrastructure/hasura/migrations/intuition/1767883120000_add_position_assets_function/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1767883120000_add_position_assets_function/up.sql
@@ -1,4 +1,5 @@
 -- Add position_with_value view for efficient querying of position values
+-- All monetary values are normalized to ETH (divided by 1e18)
 
 CREATE OR REPLACE VIEW public.position_with_value AS
 SELECT
@@ -15,14 +16,15 @@ SELECT
   p.transaction_index,
   p.created_at,
   p.updated_at,
-  p.shares * v.current_share_price AS theoretical_value,
-  -- PnL = equity_value + redemptions - deposits
-  ((p.shares * v.current_share_price / 1e18) + p.total_redeem_assets_for_receiver - p.total_deposit_assets_after_total_fees)::NUMERIC AS pnl,
+  -- Theoretical value (equity) in ETH
+  (p.shares * v.current_share_price / 1e36)::NUMERIC AS theoretical_value,
+  -- PnL = equity_value + redemptions - deposits (all in ETH)
+  ((p.shares * v.current_share_price / 1e36) + (p.total_redeem_assets_for_receiver / 1e18) - (p.total_deposit_assets_after_total_fees / 1e18))::NUMERIC AS pnl,
   -- PnL percentage (ROI)
   CASE
     WHEN (p.total_deposit_assets_after_total_fees - p.total_redeem_assets_for_receiver) > 0
-    THEN (((p.shares * v.current_share_price / 1e18) + p.total_redeem_assets_for_receiver - p.total_deposit_assets_after_total_fees) * 100.0
-          / (p.total_deposit_assets_after_total_fees - p.total_redeem_assets_for_receiver))::NUMERIC(20, 4)
+    THEN (((p.shares * v.current_share_price / 1e36) + (p.total_redeem_assets_for_receiver / 1e18) - (p.total_deposit_assets_after_total_fees / 1e18)) * 100.0
+          / ((p.total_deposit_assets_after_total_fees - p.total_redeem_assets_for_receiver) / 1e18))::NUMERIC(20, 4)
     ELSE 0::NUMERIC(20, 4)
   END AS pnl_pct
 FROM position p

--- a/infrastructure/hasura/migrations/intuition/1767883120000_add_position_assets_function/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1767883120000_add_position_assets_function/up.sql
@@ -26,6 +26,35 @@ SELECT
     THEN (((p.shares * v.current_share_price / 1e36) + (p.total_redeem_assets_for_receiver / 1e18) - (p.total_deposit_assets_after_total_fees / 1e18)) * 100.0
           / ((p.total_deposit_assets_after_total_fees - p.total_redeem_assets_for_receiver) / 1e18))::NUMERIC(20, 4)
     ELSE 0::NUMERIC(20, 4)
-  END AS pnl_pct
+  END AS pnl_pct,
+  -- Redeemable assets (previewRedeem value after fees) in ETH
+  -- Calculates what the position holder would receive if they redeemed all shares now
+  CASE
+    WHEN p.shares = 0 THEN 0::NUMERIC
+    -- Linear curve (curve_id = 1): rawAssets = shares * totalAssets / totalShares
+    WHEN p.curve_id = 1 THEN
+      GREATEST(
+        (p.shares * v.total_assets / NULLIF(v.total_shares, 0))
+        - ((p.shares * v.total_assets / NULLIF(v.total_shares, 0)) * 125 + 9999) / 10000  -- protocol fee 1.25%
+        - ((p.shares * v.total_assets / NULLIF(v.total_shares, 0)) * 75 + 9999) / 10000   -- exit fee 0.75%
+      , 0) / 1e18
+    -- Offset Progressive curve (curve_id = 2): Quadratic bonding curve
+    WHEN p.curve_id = 2 THEN
+      (SELECT
+        GREATEST(
+          raw_assets - ((raw_assets * 125 + 9999) / 10000) - ((raw_assets * 75 + 9999) / 10000)
+        , 0) / 1e18
+      FROM (
+        SELECT (
+          (
+            ((v.total_shares + 30000000000000000000::NUMERIC) * (v.total_shares + 30000000000000000000::NUMERIC) / 1e18)::NUMERIC
+            -
+            (((v.total_shares + 30000000000000000000::NUMERIC - p.shares) * (v.total_shares + 30000000000000000000::NUMERIC - p.shares) + 1e18 - 1) / 1e18)::NUMERIC
+          )
+          * 50000000000000000::NUMERIC / 1e18
+        )::NUMERIC AS raw_assets
+      ) curve_calc)
+    ELSE 0::NUMERIC
+  END AS redeemable_assets
 FROM position p
 JOIN vault v ON v.term_id = p.term_id AND v.curve_id = p.curve_id;

--- a/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/README.md
+++ b/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/README.md
@@ -4,7 +4,7 @@ Season 2 Leaderboard feature for ranking accounts by PnL metrics, enabling users
 
 ## Overview
 
-This migration adds four PostgreSQL functions exposed via Hasura GraphQL:
+This migration adds six PostgreSQL functions exposed via Hasura GraphQL:
 
 | Function | Description |
 |----------|-------------|
@@ -12,6 +12,8 @@ This migration adds four PostgreSQL functions exposed via Hasura GraphQL:
 | `get_account_pnl_rank` | Individual account rank and percentile lookup |
 | `get_pnl_leaderboard_stats` | Aggregate statistics (total traders, median PnL, profitability) |
 | `get_vault_leaderboard` | Vault-specific leaderboard with `redeemable_assets` calculation |
+| `get_pnl_leaderboard_period` | **Period-specific** leaderboard showing metrics ONLY for a date range |
+| `get_vault_leaderboard_period` | **Period-specific** vault leaderboard with historical `redeemable_assets` |
 
 ## Key Features
 
@@ -365,9 +367,134 @@ redeemable_assets = rawAssets - protocolFee - exitFee
   - `idx_position_account_shares` - for account aggregation on active positions
   - `idx_position_vault_account` - composite index for vault joins
 
+## Period-Specific Functions
+
+The `_period` functions calculate metrics **only for the specified date range**, not cumulative values. They use the `share_price_change` table for accurate historical valuations.
+
+### Key Differences from Standard Functions
+
+| Aspect | Standard Functions | Period Functions |
+|--------|-------------------|------------------|
+| PnL | Cumulative all-time | Only for the specified period |
+| Share Prices | Current prices | Historical prices at period boundaries |
+| Position Count | Total positions ever | Positions with activity in period |
+| Redeemable Assets | Current vault state | Historical vault state at period end |
+
+### How Period PnL is Calculated
+
+```
+Period Total PnL = (Equity at End - Equity at Start) + (Redemptions - Deposits)
+
+Where:
+- Equity at Start = Shares at start × Share price at start
+- Equity at End = Shares at end × Share price at end
+- Redemptions/Deposits = Activity during the period only
+```
+
+### get_pnl_leaderboard_period Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `p_start_date` | TIMESTAMPTZ | required | Period start date |
+| `p_end_date` | TIMESTAMPTZ | required | Period end date |
+| `p_limit` | INTEGER | 100 | Number of results (1-10000) |
+| `p_offset` | INTEGER | 0 | Pagination offset |
+| `p_sort_by` | TEXT | 'total_pnl' | Sort field |
+| `p_sort_order` | TEXT | 'DESC' | Sort direction |
+| `p_exclude_protocol_accounts` | BOOLEAN | TRUE | Exclude protocol accounts |
+| `p_min_positions` | INTEGER | 1 | Minimum positions in period |
+| `p_min_volume` | NUMERIC | 0 | Minimum volume in period (ETH) |
+| `p_term_id` | TEXT | NULL | Filter to specific vault |
+
+### get_vault_leaderboard_period Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `p_term_id` | TEXT | required | Vault term ID |
+| `p_start_date` | TIMESTAMPTZ | required | Period start date |
+| `p_end_date` | TIMESTAMPTZ | required | Period end date |
+| `p_curve_id` | NUMERIC | NULL | Optional curve ID filter |
+| `p_limit` | INTEGER | 100 | Number of results (1-10000) |
+| `p_offset` | INTEGER | 0 | Pagination offset |
+| `p_sort_by` | TEXT | 'total_pnl' | Sort field |
+| `p_sort_order` | TEXT | 'DESC' | Sort direction |
+
+### Period Query Examples
+
+#### 11. Period Leaderboard (Jan 20-27, 2026)
+
+```graphql
+{
+  get_pnl_leaderboard_period(args: {
+    p_start_date: "2026-01-20T00:00:00Z"
+    p_end_date: "2026-01-27T23:59:59Z"
+    p_limit: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    realized_pnl_formatted
+    unrealized_pnl_formatted
+    pnl_pct
+    total_volume_formatted
+    total_position_count
+    win_rate
+  }
+}
+```
+
+#### 12. Vault Period Leaderboard with Historical Redeemable Assets
+
+```graphql
+{
+  get_vault_leaderboard_period(args: {
+    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
+    p_start_date: "2026-01-20T00:00:00Z"
+    p_end_date: "2026-01-27T23:59:59Z"
+    p_limit: 10
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    realized_pnl_formatted
+    unrealized_pnl_formatted
+    redeemable_assets_formatted
+    current_equity_value_formatted
+    pnl_pct
+    win_rate
+  }
+}
+```
+
+#### 13. Weekly Competition (Sort by Period PnL %)
+
+```graphql
+{
+  get_pnl_leaderboard_period(args: {
+    p_start_date: "2026-01-27T00:00:00Z"
+    p_end_date: "2026-02-03T23:59:59Z"
+    p_limit: 50
+    p_sort_by: "pnl_pct"
+    p_min_volume: 1
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    pnl_pct
+    total_volume_formatted
+  }
+}
+```
+
 ## Notes
 
-- `redeemable_assets` is only calculated for `get_vault_leaderboard` (returns NULL for main leaderboard)
+- `redeemable_assets` is only calculated for vault leaderboards (returns NULL for main leaderboard)
 - Protocol accounts (`ProtocolVault`, `AtomWallet`) are excluded by default
 - Input validation: limits clamped 1-10000, offsets must be non-negative
 - Division by zero protection using `NULLIF()` throughout
+- Period functions use `share_price_change` table for historical valuations
+- If no share price exists before a date, equity is calculated as 0

--- a/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/README.md
+++ b/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/README.md
@@ -125,7 +125,9 @@ redeemable_assets = rawAssets - protocolFee - exitFee
 
 ## Query Examples
 
-### 1. Top 10 Traders by Total PnL (All Time)
+### get_pnl_leaderboard
+
+#### 1. Top 10 Traders by Total PnL (All Time)
 
 ```graphql
 {
@@ -139,13 +141,17 @@ redeemable_assets = rawAssets - protocolFee - exitFee
     account_id
     account_label
     total_pnl_formatted
+    realized_pnl_formatted
+    unrealized_pnl_formatted
     pnl_pct
     win_rate
+    total_volume_formatted
+    total_position_count
   }
 }
 ```
 
-### 2. Top 10 by ROI (Last 7 Days)
+#### 2. Top 10 by ROI % (Last 7 Days)
 
 ```graphql
 {
@@ -163,7 +169,7 @@ redeemable_assets = rawAssets - protocolFee - exitFee
 }
 ```
 
-### 3. Newest Traders (Last 30 Days)
+#### 3. Newest Traders (Last 30 Days)
 
 ```graphql
 {
@@ -181,7 +187,7 @@ redeemable_assets = rawAssets - protocolFee - exitFee
 }
 ```
 
-### 4. Most Improved Traders (Last 7 Days)
+#### 4. Most Improved Traders (Last 7 Days)
 
 ```graphql
 {
@@ -199,82 +205,7 @@ redeemable_assets = rawAssets - protocolFee - exitFee
 }
 ```
 
-### 5. Get My Rank
-
-```graphql
-{
-  get_account_pnl_rank(args: {
-    p_account_id: "0x91814fB52546fbFe050556c41Bdb56D9704f37D4"
-    p_sort_by: "total_pnl"
-    p_time_filter: "all_time"
-  }) {
-    rank
-    percentile
-    total_pnl_formatted
-    pnl_pct
-    win_rate
-  }
-}
-```
-
-### 6. Leaderboard Statistics
-
-```graphql
-{
-  get_pnl_leaderboard_stats(args: {
-    p_time_filter: "30d"
-  }) {
-    total_traders
-    avg_pnl_formatted
-    median_pnl_formatted
-    profitable_traders
-    unprofitable_traders
-    profitable_pct
-  }
-}
-```
-
-### 7. Vault Leaderboard with Redeemable Assets (Linear Curve)
-
-```graphql
-{
-  get_vault_leaderboard(args: {
-    p_term_id: "0x7ec36d201c842dc787b45cb5bb753bea4cf849be3908fb1b0a7d067c3c3cc1f5"
-    p_curve_id: "1"
-    p_limit: 10
-    p_sort_by: "total_pnl"
-  }) {
-    rank
-    account_id
-    account_label
-    total_pnl_formatted
-    current_equity_value_formatted
-    redeemable_assets_formatted
-  }
-}
-```
-
-### 8. Vault Leaderboard (Offset Progressive Curve)
-
-```graphql
-{
-  get_vault_leaderboard(args: {
-    p_term_id: "0x5fb82a9ddd34419ac698e2b45c75cc1fda458b026c136dfe021342f77c4be4e3"
-    p_curve_id: "2"
-    p_limit: 10
-    p_sort_by: "total_pnl"
-  }) {
-    rank
-    account_id
-    account_label
-    total_pnl_formatted
-    current_equity_value_formatted
-    redeemable_assets_formatted
-  }
-}
-```
-
-### 9. Filter by Minimum Volume and Positions
+#### 5. Filter by Minimum Volume and Positions
 
 ```graphql
 {
@@ -294,15 +225,15 @@ redeemable_assets = rawAssets - protocolFee - exitFee
 }
 ```
 
-### 10. Custom Date Range
+#### 6. Custom Date Range
 
 ```graphql
 {
   get_pnl_leaderboard(args: {
     p_limit: 20
     p_time_filter: "custom"
-    p_start_time: "2025-01-01T00:00:00Z"
-    p_end_time: "2025-01-31T23:59:59Z"
+    p_start_time: "2026-01-01T00:00:00Z"
+    p_end_time: "2026-01-31T23:59:59Z"
     p_sort_by: "total_pnl"
   }) {
     rank
@@ -310,6 +241,384 @@ redeemable_assets = rawAssets - protocolFee - exitFee
     account_label
     total_pnl_formatted
     pnl_change_formatted
+  }
+}
+```
+
+#### 7. Pagination (Page 3, 10 per page)
+
+```graphql
+{
+  get_pnl_leaderboard(args: {
+    p_limit: 10
+    p_offset: 20
+    p_sort_by: "total_pnl"
+    p_time_filter: "all_time"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+  }
+}
+```
+
+---
+
+### get_account_pnl_rank
+
+#### 8. Get My Rank (All Time)
+
+```graphql
+{
+  get_account_pnl_rank(args: {
+    p_account_id: "0x91814fB52546fbFe050556c41Bdb56D9704f37D4"
+    p_sort_by: "total_pnl"
+    p_time_filter: "all_time"
+  }) {
+    rank
+    total_accounts
+    percentile
+    account_id
+    account_label
+    total_pnl_formatted
+    pnl_pct
+    win_rate
+    total_position_count
+    total_volume_formatted
+  }
+}
+```
+
+#### 9. Get My Rank in a Specific Vault
+
+```graphql
+{
+  get_account_pnl_rank(args: {
+    p_account_id: "0x91814fB52546fbFe050556c41Bdb56D9704f37D4"
+    p_sort_by: "pnl_pct"
+    p_time_filter: "7d"
+    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
+  }) {
+    rank
+    percentile
+    total_pnl_formatted
+    pnl_pct
+  }
+}
+```
+
+---
+
+### get_pnl_leaderboard_stats
+
+#### 10. Global Stats (Last 30 Days)
+
+```graphql
+{
+  get_pnl_leaderboard_stats(args: {
+    p_time_filter: "30d"
+  }) {
+    total_traders
+    total_pnl_sum_formatted
+    avg_pnl_formatted
+    median_pnl_formatted
+    total_volume_formatted
+    avg_volume_formatted
+    profitable_traders
+    unprofitable_traders
+    profitable_pct
+  }
+}
+```
+
+#### 11. Stats for a Specific Vault
+
+```graphql
+{
+  get_pnl_leaderboard_stats(args: {
+    p_time_filter: "all_time"
+    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
+  }) {
+    total_traders
+    avg_pnl_formatted
+    profitable_pct
+  }
+}
+```
+
+---
+
+### get_vault_leaderboard
+
+#### 12. Vault Leaderboard with Redeemable Assets (Linear Curve)
+
+```graphql
+{
+  get_vault_leaderboard(args: {
+    p_term_id: "0x7ec36d201c842dc787b45cb5bb753bea4cf849be3908fb1b0a7d067c3c3cc1f5"
+    p_curve_id: "1"
+    p_limit: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    realized_pnl_formatted
+    unrealized_pnl_formatted
+    current_equity_value_formatted
+    redeemable_assets_formatted
+    pnl_pct
+    win_rate
+    total_volume_formatted
+  }
+}
+```
+
+#### 13. Vault Leaderboard (Offset Progressive Curve)
+
+```graphql
+{
+  get_vault_leaderboard(args: {
+    p_term_id: "0x5fb82a9ddd34419ac698e2b45c75cc1fda458b026c136dfe021342f77c4be4e3"
+    p_curve_id: "2"
+    p_limit: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    current_equity_value_formatted
+    redeemable_assets_formatted
+  }
+}
+```
+
+#### 14. Vault Sorted by Volume
+
+```graphql
+{
+  get_vault_leaderboard(args: {
+    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
+    p_limit: 10
+    p_sort_by: "total_volume"
+    p_sort_order: "DESC"
+  }) {
+    rank
+    account_id
+    account_label
+    redeemable_assets_formatted
+    total_volume_formatted
+    total_position_count
+  }
+}
+```
+
+---
+
+### get_pnl_leaderboard_period
+
+#### 15. Period Leaderboard (Specific Week)
+
+```graphql
+{
+  get_pnl_leaderboard_period(args: {
+    p_start_date: "2026-01-20T00:00:00Z"
+    p_end_date: "2026-01-27T23:59:59Z"
+    p_limit: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    realized_pnl_formatted
+    unrealized_pnl_formatted
+    pnl_pct
+    total_volume_formatted
+    total_position_count
+    win_rate
+  }
+}
+```
+
+#### 16. Period Leaderboard Sorted by ROI %
+
+```graphql
+{
+  get_pnl_leaderboard_period(args: {
+    p_start_date: "2026-01-27T00:00:00Z"
+    p_end_date: "2026-02-03T23:59:59Z"
+    p_limit: 20
+    p_sort_by: "pnl_pct"
+    p_min_volume: 1
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    pnl_pct
+    total_volume_formatted
+  }
+}
+```
+
+#### 17. Period for a Specific Vault
+
+```graphql
+{
+  get_pnl_leaderboard_period(args: {
+    p_start_date: "2026-01-20T00:00:00Z"
+    p_end_date: "2026-01-27T23:59:59Z"
+    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
+    p_limit: 10
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    pnl_pct
+    current_equity_value_formatted
+  }
+}
+```
+
+#### 18. Period with Pagination
+
+```graphql
+{
+  get_pnl_leaderboard_period(args: {
+    p_start_date: "2026-01-20T00:00:00Z"
+    p_end_date: "2026-02-03T23:59:59Z"
+    p_limit: 10
+    p_offset: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    total_pnl_formatted
+  }
+}
+```
+
+---
+
+### get_vault_leaderboard_period
+
+#### 19. Vault Period Leaderboard with Historical Redeemable Assets
+
+```graphql
+{
+  get_vault_leaderboard_period(args: {
+    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
+    p_start_date: "2026-01-20T00:00:00Z"
+    p_end_date: "2026-01-27T23:59:59Z"
+    p_limit: 10
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    realized_pnl_formatted
+    unrealized_pnl_formatted
+    redeemable_assets_formatted
+    current_equity_value_formatted
+    pnl_pct
+    win_rate
+    total_volume_formatted
+  }
+}
+```
+
+#### 20. Vault Period Sorted by Redeemable Assets
+
+```graphql
+{
+  get_vault_leaderboard_period(args: {
+    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
+    p_start_date: "2026-01-20T00:00:00Z"
+    p_end_date: "2026-01-27T23:59:59Z"
+    p_limit: 10
+    p_sort_by: "redeemable_assets"
+  }) {
+    rank
+    account_id
+    account_label
+    redeemable_assets_formatted
+    current_equity_value_formatted
+    total_pnl_formatted
+  }
+}
+```
+
+#### 21. Vault Period with Curve Filter
+
+```graphql
+{
+  get_vault_leaderboard_period(args: {
+    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
+    p_curve_id: "2"
+    p_start_date: "2026-01-20T00:00:00Z"
+    p_end_date: "2026-01-27T23:59:59Z"
+    p_limit: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    total_pnl_formatted
+    redeemable_assets_formatted
+    pnl_pct
+  }
+}
+```
+
+---
+
+### positions_with_value (View with redeemable_assets)
+
+#### 22. Query Positions with Redeemable Assets
+
+```graphql
+{
+  positions_with_value(
+    where: { shares: { _gt: "0" } }
+    limit: 5
+  ) {
+    account_id
+    term_id
+    curve_id
+    shares
+    theoretical_value
+    pnl
+    pnl_pct
+    redeemable_assets
+  }
+}
+```
+
+#### 23. Positions for a Specific Account
+
+```graphql
+{
+  positions_with_value(
+    where: {
+      account_id: { _eq: "0x91814fB52546fbFe050556c41Bdb56D9704f37D4" }
+      shares: { _gt: "0" }
+    }
+  ) {
+    term_id
+    curve_id
+    shares
+    theoretical_value
+    pnl
+    pnl_pct
+    redeemable_assets
+    vault {
+      total_shares
+      total_assets
+    }
   }
 }
 ```
@@ -416,79 +725,8 @@ Where:
 | `p_curve_id` | NUMERIC | NULL | Optional curve ID filter |
 | `p_limit` | INTEGER | 100 | Number of results (1-10000) |
 | `p_offset` | INTEGER | 0 | Pagination offset |
-| `p_sort_by` | TEXT | 'total_pnl' | Sort field |
+| `p_sort_by` | TEXT | 'total_pnl' | Sort field (also supports `redeemable_assets`) |
 | `p_sort_order` | TEXT | 'DESC' | Sort direction |
-
-### Period Query Examples
-
-#### 11. Period Leaderboard (Jan 20-27, 2026)
-
-```graphql
-{
-  get_pnl_leaderboard_period(args: {
-    p_start_date: "2026-01-20T00:00:00Z"
-    p_end_date: "2026-01-27T23:59:59Z"
-    p_limit: 10
-    p_sort_by: "total_pnl"
-  }) {
-    rank
-    account_id
-    account_label
-    total_pnl_formatted
-    realized_pnl_formatted
-    unrealized_pnl_formatted
-    pnl_pct
-    total_volume_formatted
-    total_position_count
-    win_rate
-  }
-}
-```
-
-#### 12. Vault Period Leaderboard with Historical Redeemable Assets
-
-```graphql
-{
-  get_vault_leaderboard_period(args: {
-    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
-    p_start_date: "2026-01-20T00:00:00Z"
-    p_end_date: "2026-01-27T23:59:59Z"
-    p_limit: 10
-  }) {
-    rank
-    account_id
-    account_label
-    total_pnl_formatted
-    realized_pnl_formatted
-    unrealized_pnl_formatted
-    redeemable_assets_formatted
-    current_equity_value_formatted
-    pnl_pct
-    win_rate
-  }
-}
-```
-
-#### 13. Weekly Competition (Sort by Period PnL %)
-
-```graphql
-{
-  get_pnl_leaderboard_period(args: {
-    p_start_date: "2026-01-27T00:00:00Z"
-    p_end_date: "2026-02-03T23:59:59Z"
-    p_limit: 50
-    p_sort_by: "pnl_pct"
-    p_min_volume: 1
-  }) {
-    rank
-    account_id
-    account_label
-    total_pnl_formatted
-    pnl_pct
-    total_volume_formatted
-  }
-}
-```
 
 ## Notes
 

--- a/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/README.md
+++ b/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/README.md
@@ -1,0 +1,373 @@
+# PnL Leaderboard Functions
+
+Season 2 Leaderboard feature for ranking accounts by PnL metrics, enabling users to discover top performers, track their own ranking, and analyze aggregate market statistics.
+
+## Overview
+
+This migration adds four PostgreSQL functions exposed via Hasura GraphQL:
+
+| Function | Description |
+|----------|-------------|
+| `get_pnl_leaderboard` | Main ranked leaderboard with filtering, sorting, and pagination |
+| `get_account_pnl_rank` | Individual account rank and percentile lookup |
+| `get_pnl_leaderboard_stats` | Aggregate statistics (total traders, median PnL, profitability) |
+| `get_vault_leaderboard` | Vault-specific leaderboard with `redeemable_assets` calculation |
+
+## Key Features
+
+### Dual Value Format
+All monetary fields are returned in two formats:
+- `*_raw`: Base-10 integer (wei, 18 decimals) for precise calculations
+- `*_formatted`: Human-readable decimal (ETH, max 4 decimal places) for display
+
+### Time Filters
+- `24h` - Last 24 hours
+- `7d` - Last 7 days
+- `30d` - Last 30 days
+- `90d` - Last 90 days
+- `all_time` - All historical data
+- `custom` - Custom date range via `p_start_time` and `p_end_time`
+
+### Sort Options
+- `total_pnl` - Total profit/loss (default)
+- `pnl_pct` - ROI percentage
+- `win_rate` - Percentage of winning positions
+- `total_volume` - Total trading volume
+- `position_count` - Number of positions
+- `newest` - Most recent traders (by first position date)
+- `most_improved` - Biggest PnL change in the time period
+
+### Redeemable Assets Calculation
+The `get_vault_leaderboard` function calculates the actual redemption value using bonding curve math:
+
+**Linear Curve (curve_id = 1):**
+```
+rawAssets = shares * totalAssets / totalShares
+```
+
+**Offset Progressive Curve (curve_id = 2):**
+```
+s = totalShares + OFFSET (3e19)
+sNext = s - shares
+area = (s² - sNext²) / 1e18
+rawAssets = area * HALF_SLOPE (5e16) / 1e18
+```
+
+**Fees Applied:**
+- Protocol fee: 1.25% (always)
+- Exit fee: 0.75% (conservatively always applied)
+
+```
+redeemable_assets = rawAssets - protocolFee - exitFee
+```
+
+## Returned Fields
+
+### Leaderboard Entry Fields
+
+| Field | Description |
+|-------|-------------|
+| `rank` | Position in the leaderboard |
+| `account_id` | Unique account identifier |
+| `account_label` | Human-readable account name/label |
+| `account_image` | Account avatar/image URL |
+| `total_pnl_raw/formatted` | Combined realized + unrealized PnL |
+| `realized_pnl_raw/formatted` | PnL from closed positions (shares = 0) |
+| `unrealized_pnl_raw/formatted` | PnL from open positions (shares > 0) |
+| `pnl_pct` | ROI percentage |
+| `pnl_change_raw/formatted` | Change in PnL for the time period |
+| `total_position_count` | Total number of positions ever held |
+| `active_position_count` | Number of positions currently open |
+| `winning_positions` | Count of positions with positive PnL |
+| `losing_positions` | Count of positions with negative PnL |
+| `win_rate` | Percentage of winning positions |
+| `total_deposits_raw/formatted` | Sum of all deposit amounts |
+| `total_redemptions_raw/formatted` | Sum of all redemption amounts |
+| `total_volume_raw/formatted` | total_deposits + total_redemptions |
+| `current_equity_value_raw/formatted` | Current market value of all open positions |
+| `best_trade_pnl_raw/formatted` | Highest PnL from a single position |
+| `worst_trade_pnl_raw/formatted` | Lowest PnL from a single position |
+| `redeemable_assets_raw/formatted` | Actual redemption value after fees (vault leaderboard only) |
+| `first_position_at` | Timestamp of first position creation |
+| `last_activity_at` | Timestamp of most recent position update |
+
+### Account Rank Fields
+
+| Field | Description |
+|-------|-------------|
+| `rank` | Account's position in leaderboard |
+| `total_accounts` | Total number of accounts in leaderboard |
+| `percentile` | Account's percentile (higher = better) |
+| `account_id` | Account identifier |
+| `account_label` | Account name/label |
+| `account_image` | Account avatar URL |
+| `total_pnl_raw/formatted` | Account's total PnL |
+| `pnl_pct` | Account's ROI percentage |
+| `win_rate` | Account's win rate |
+| `total_position_count` | Account's total positions |
+| `total_volume_raw/formatted` | Account's total trading volume |
+
+### Leaderboard Stats Fields
+
+| Field | Description |
+|-------|-------------|
+| `total_traders` | Count of accounts in leaderboard |
+| `total_pnl_sum_raw/formatted` | Sum of all traders' PnL |
+| `avg_pnl_raw/formatted` | Average PnL per trader |
+| `median_pnl_raw/formatted` | Median PnL (50th percentile) |
+| `total_volume_raw/formatted` | Sum of all trading volume |
+| `avg_volume_raw/formatted` | Average volume per trader |
+| `profitable_traders` | Count of traders with positive PnL |
+| `unprofitable_traders` | Count of traders with non-positive PnL |
+| `profitable_pct` | Percentage of profitable traders |
+
+## Query Examples
+
+### 1. Top 10 Traders by Total PnL (All Time)
+
+```graphql
+{
+  get_pnl_leaderboard(args: {
+    p_limit: 10
+    p_sort_by: "total_pnl"
+    p_sort_order: "DESC"
+    p_time_filter: "all_time"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    pnl_pct
+    win_rate
+  }
+}
+```
+
+### 2. Top 10 by ROI (Last 7 Days)
+
+```graphql
+{
+  get_pnl_leaderboard(args: {
+    p_limit: 10
+    p_time_filter: "7d"
+    p_sort_by: "pnl_pct"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    pnl_pct
+  }
+}
+```
+
+### 3. Newest Traders (Last 30 Days)
+
+```graphql
+{
+  get_pnl_leaderboard(args: {
+    p_limit: 10
+    p_time_filter: "30d"
+    p_sort_by: "newest"
+  }) {
+    rank
+    account_id
+    account_label
+    first_position_at
+    total_pnl_formatted
+  }
+}
+```
+
+### 4. Most Improved Traders (Last 7 Days)
+
+```graphql
+{
+  get_pnl_leaderboard(args: {
+    p_limit: 10
+    p_time_filter: "7d"
+    p_sort_by: "most_improved"
+  }) {
+    rank
+    account_id
+    account_label
+    pnl_change_formatted
+    total_pnl_formatted
+  }
+}
+```
+
+### 5. Get My Rank
+
+```graphql
+{
+  get_account_pnl_rank(args: {
+    p_account_id: "0x91814fB52546fbFe050556c41Bdb56D9704f37D4"
+    p_sort_by: "total_pnl"
+    p_time_filter: "all_time"
+  }) {
+    rank
+    percentile
+    total_pnl_formatted
+    pnl_pct
+    win_rate
+  }
+}
+```
+
+### 6. Leaderboard Statistics
+
+```graphql
+{
+  get_pnl_leaderboard_stats(args: {
+    p_time_filter: "30d"
+  }) {
+    total_traders
+    avg_pnl_formatted
+    median_pnl_formatted
+    profitable_traders
+    unprofitable_traders
+    profitable_pct
+  }
+}
+```
+
+### 7. Vault Leaderboard with Redeemable Assets (Linear Curve)
+
+```graphql
+{
+  get_vault_leaderboard(args: {
+    p_term_id: "0x7ec36d201c842dc787b45cb5bb753bea4cf849be3908fb1b0a7d067c3c3cc1f5"
+    p_curve_id: "1"
+    p_limit: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    current_equity_value_formatted
+    redeemable_assets_formatted
+  }
+}
+```
+
+### 8. Vault Leaderboard (Offset Progressive Curve)
+
+```graphql
+{
+  get_vault_leaderboard(args: {
+    p_term_id: "0x5fb82a9ddd34419ac698e2b45c75cc1fda458b026c136dfe021342f77c4be4e3"
+    p_curve_id: "2"
+    p_limit: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    current_equity_value_formatted
+    redeemable_assets_formatted
+  }
+}
+```
+
+### 9. Filter by Minimum Volume and Positions
+
+```graphql
+{
+  get_pnl_leaderboard(args: {
+    p_limit: 50
+    p_min_positions: 5
+    p_min_volume: 10
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    total_position_count
+    total_volume_formatted
+  }
+}
+```
+
+### 10. Custom Date Range
+
+```graphql
+{
+  get_pnl_leaderboard(args: {
+    p_limit: 20
+    p_time_filter: "custom"
+    p_start_time: "2025-01-01T00:00:00Z"
+    p_end_time: "2025-01-31T23:59:59Z"
+    p_sort_by: "total_pnl"
+  }) {
+    rank
+    account_id
+    account_label
+    total_pnl_formatted
+    pnl_change_formatted
+  }
+}
+```
+
+## Function Parameters
+
+### get_pnl_leaderboard
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `p_limit` | INTEGER | 100 | Number of results (1-10000) |
+| `p_offset` | INTEGER | 0 | Pagination offset |
+| `p_time_filter` | TEXT | 'all_time' | Time filter preset |
+| `p_start_time` | TIMESTAMPTZ | NULL | Custom start time |
+| `p_end_time` | TIMESTAMPTZ | NULL | Custom end time |
+| `p_sort_by` | TEXT | 'total_pnl' | Sort field |
+| `p_sort_order` | TEXT | 'DESC' | Sort direction |
+| `p_exclude_protocol_accounts` | BOOLEAN | TRUE | Exclude protocol accounts |
+| `p_min_positions` | INTEGER | 1 | Minimum position count |
+| `p_min_volume` | NUMERIC | 0 | Minimum volume (ETH) |
+| `p_term_id` | TEXT | NULL | Filter to specific vault |
+
+### get_account_pnl_rank
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `p_account_id` | TEXT | required | Account address |
+| `p_sort_by` | TEXT | 'total_pnl' | Sort field for ranking |
+| `p_time_filter` | TEXT | 'all_time' | Time filter preset |
+| `p_term_id` | TEXT | NULL | Filter to specific vault |
+
+### get_pnl_leaderboard_stats
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `p_time_filter` | TEXT | 'all_time' | Time filter preset |
+| `p_term_id` | TEXT | NULL | Filter to specific vault |
+
+### get_vault_leaderboard
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `p_term_id` | TEXT | required | Vault term ID |
+| `p_curve_id` | NUMERIC | NULL | Optional curve ID filter |
+| `p_limit` | INTEGER | 100 | Number of results (1-10000) |
+| `p_offset` | INTEGER | 0 | Pagination offset |
+| `p_sort_by` | TEXT | 'total_pnl' | Sort field |
+| `p_sort_order` | TEXT | 'DESC' | Sort direction |
+
+## Performance Optimizations
+
+- Uses `position_change_daily` continuous aggregate for time-filtered queries
+- Early filtering of accounts with activity in time window before full position scan
+- New indexes:
+  - `idx_position_account_shares` - for account aggregation on active positions
+  - `idx_position_vault_account` - composite index for vault joins
+
+## Notes
+
+- `redeemable_assets` is only calculated for `get_vault_leaderboard` (returns NULL for main leaderboard)
+- Protocol accounts (`ProtocolVault`, `AtomWallet`) are excluded by default
+- Input validation: limits clamped 1-10000, offsets must be non-negative
+- Division by zero protection using `NULLIF()` throughout

--- a/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/up.sql
@@ -1,56 +1,85 @@
 -- PnL Leaderboard Functions
 -- Season 2 Leaderboard feature for ranking accounts by PnL metrics
+-- All monetary values are returned in two formats:
+--   *_raw: Base-10 integer (wei, 18 decimals) for precise calculations
+--   *_formatted: Human-readable decimal (ETH, max 4 decimal places) for display
 
 -- ========================================
 -- RETURN TYPE TABLES FOR HASURA TRACKING
 -- ========================================
 
-CREATE TABLE IF NOT EXISTS pnl_leaderboard_entry (
+-- Drop and recreate to update schema
+DROP TABLE IF EXISTS pnl_leaderboard_entry CASCADE;
+DROP TABLE IF EXISTS account_pnl_rank CASCADE;
+DROP TABLE IF EXISTS pnl_leaderboard_stats CASCADE;
+
+CREATE TABLE pnl_leaderboard_entry (
   rank BIGINT,
   account_id TEXT,
   account_label TEXT,
   account_image TEXT,
-  total_pnl NUMERIC,
-  realized_pnl NUMERIC,
-  unrealized_pnl NUMERIC,
+  -- PnL values (raw = wei, formatted = ETH with 4 decimals)
+  total_pnl_raw NUMERIC,
+  total_pnl_formatted NUMERIC(30, 4),
+  realized_pnl_raw NUMERIC,
+  realized_pnl_formatted NUMERIC(30, 4),
+  unrealized_pnl_raw NUMERIC,
+  unrealized_pnl_formatted NUMERIC(30, 4),
   pnl_pct NUMERIC(20, 4),
-  pnl_change NUMERIC,
+  pnl_change_raw NUMERIC,
+  pnl_change_formatted NUMERIC(30, 4),
+  -- Position counts
   total_position_count BIGINT,
   active_position_count BIGINT,
   winning_positions BIGINT,
   losing_positions BIGINT,
   win_rate NUMERIC(10, 2),
-  total_deposits NUMERIC,
-  total_redemptions NUMERIC,
-  total_volume NUMERIC,
-  current_equity_value NUMERIC,
-  best_trade_pnl NUMERIC,
-  worst_trade_pnl NUMERIC,
+  -- Volume values (raw = wei, formatted = ETH with 4 decimals)
+  total_deposits_raw NUMERIC,
+  total_deposits_formatted NUMERIC(30, 4),
+  total_redemptions_raw NUMERIC,
+  total_redemptions_formatted NUMERIC(30, 4),
+  total_volume_raw NUMERIC,
+  total_volume_formatted NUMERIC(30, 4),
+  current_equity_value_raw NUMERIC,
+  current_equity_value_formatted NUMERIC(30, 4),
+  best_trade_pnl_raw NUMERIC,
+  best_trade_pnl_formatted NUMERIC(30, 4),
+  worst_trade_pnl_raw NUMERIC,
+  worst_trade_pnl_formatted NUMERIC(30, 4),
+  -- Timestamps
   first_position_at TIMESTAMPTZ,
   last_activity_at TIMESTAMPTZ
 );
 
-CREATE TABLE IF NOT EXISTS account_pnl_rank (
+CREATE TABLE account_pnl_rank (
   rank BIGINT,
   total_accounts BIGINT,
   percentile NUMERIC(10, 4),
   account_id TEXT,
   account_label TEXT,
   account_image TEXT,
-  total_pnl NUMERIC,
+  total_pnl_raw NUMERIC,
+  total_pnl_formatted NUMERIC(30, 4),
   pnl_pct NUMERIC(20, 4),
   win_rate NUMERIC(10, 2),
   total_position_count BIGINT,
-  total_volume NUMERIC
+  total_volume_raw NUMERIC,
+  total_volume_formatted NUMERIC(30, 4)
 );
 
-CREATE TABLE IF NOT EXISTS pnl_leaderboard_stats (
+CREATE TABLE pnl_leaderboard_stats (
   total_traders BIGINT,
-  total_pnl_sum NUMERIC,
-  avg_pnl NUMERIC,
-  median_pnl NUMERIC,
-  total_volume NUMERIC,
-  avg_volume NUMERIC,
+  total_pnl_sum_raw NUMERIC,
+  total_pnl_sum_formatted NUMERIC(30, 4),
+  avg_pnl_raw NUMERIC,
+  avg_pnl_formatted NUMERIC(30, 4),
+  median_pnl_raw NUMERIC,
+  median_pnl_formatted NUMERIC(30, 4),
+  total_volume_raw NUMERIC,
+  total_volume_formatted NUMERIC(30, 4),
+  avg_volume_raw NUMERIC,
+  avg_volume_formatted NUMERIC(30, 4),
   profitable_traders BIGINT,
   unprofitable_traders BIGINT,
   profitable_pct NUMERIC(10, 2)
@@ -115,20 +144,33 @@ BEGIN
       AND pc.bucket <= v_end_time
       AND (p_term_id IS NULL OR pc.term_id = p_term_id)
   ),
+  -- Calculate period PnL change from position_change_daily (for most_improved sorting)
+  -- Keep raw values (wei)
+  period_pnl_change AS (
+    SELECT
+      pc.account_id,
+      SUM(COALESCE(pc.assets_out_period, 0) - COALESCE(pc.assets_in_period, 0))::NUMERIC AS period_realized_change_raw
+    FROM position_change_daily pc
+    WHERE pc.bucket >= v_start_time
+      AND pc.bucket <= v_end_time
+      AND (p_term_id IS NULL OR pc.term_id = p_term_id)
+    GROUP BY pc.account_id
+  ),
   -- Only get positions for active accounts (OPTIMIZED - avoids scanning all 3M+ positions)
+  -- All monetary values kept as raw (wei)
   current_positions AS (
     SELECT
       p.account_id,
       p.term_id,
       p.curve_id,
       p.shares,
-      p.total_deposit_assets_after_total_fees AS total_deposits,
-      p.total_redeem_assets_for_receiver AS total_redemptions,
+      p.total_deposit_assets_after_total_fees AS total_deposits_raw,
+      p.total_redeem_assets_for_receiver AS total_redemptions_raw,
       p.created_at AS position_created_at,
       p.updated_at AS position_updated_at,
       v.current_share_price,
-      (p.shares * v.current_share_price / 1e18)::NUMERIC AS equity_value,
-      ((p.shares * v.current_share_price / 1e18) + p.total_redeem_assets_for_receiver - p.total_deposit_assets_after_total_fees)::NUMERIC AS position_pnl
+      (p.shares * v.current_share_price / 1e18)::NUMERIC AS equity_value_raw,
+      ((p.shares * v.current_share_price / 1e18) + p.total_redeem_assets_for_receiver - p.total_deposit_assets_after_total_fees)::NUMERIC AS position_pnl_raw
     FROM position p
     JOIN vault v ON p.term_id = v.term_id AND p.curve_id = v.curve_id
     WHERE (p_time_filter = 'all_time' OR p.account_id IN (SELECT account_id FROM active_accounts))
@@ -139,37 +181,41 @@ BEGIN
       cp.account_id,
       COUNT(DISTINCT (cp.term_id, cp.curve_id)) AS total_position_count,
       COUNT(DISTINCT (cp.term_id, cp.curve_id)) FILTER (WHERE cp.shares > 0) AS active_position_count,
-      COUNT(*) FILTER (WHERE cp.position_pnl > 0) AS winning_positions,
-      COUNT(*) FILTER (WHERE cp.position_pnl < 0) AS losing_positions,
-      SUM(cp.total_deposits)::NUMERIC AS total_deposits,
-      SUM(cp.total_redemptions)::NUMERIC AS total_redemptions,
-      SUM(cp.equity_value)::NUMERIC AS current_equity_value,
-      SUM(cp.position_pnl)::NUMERIC AS total_pnl,
-      SUM(cp.position_pnl) FILTER (WHERE cp.shares = 0)::NUMERIC AS realized_pnl,
-      SUM(cp.position_pnl) FILTER (WHERE cp.shares > 0)::NUMERIC AS unrealized_pnl,
-      MAX(cp.position_pnl) AS best_trade_pnl,
-      MIN(cp.position_pnl) AS worst_trade_pnl,
+      COUNT(*) FILTER (WHERE cp.position_pnl_raw > 0) AS winning_positions,
+      COUNT(*) FILTER (WHERE cp.position_pnl_raw < 0) AS losing_positions,
+      SUM(cp.total_deposits_raw)::NUMERIC AS total_deposits_raw,
+      SUM(cp.total_redemptions_raw)::NUMERIC AS total_redemptions_raw,
+      SUM(cp.equity_value_raw)::NUMERIC AS current_equity_value_raw,
+      SUM(cp.position_pnl_raw)::NUMERIC AS total_pnl_raw,
+      SUM(cp.position_pnl_raw) FILTER (WHERE cp.shares = 0)::NUMERIC AS realized_pnl_raw,
+      SUM(cp.position_pnl_raw) FILTER (WHERE cp.shares > 0)::NUMERIC AS unrealized_pnl_raw,
+      MAX(cp.position_pnl_raw) AS best_trade_pnl_raw,
+      MIN(cp.position_pnl_raw) AS worst_trade_pnl_raw,
       MIN(cp.position_created_at) AS first_position_at,
       MAX(cp.position_updated_at) AS last_activity_at
     FROM current_positions cp
     GROUP BY cp.account_id
     HAVING COUNT(DISTINCT (cp.term_id, cp.curve_id)) >= GREATEST(p_min_positions, 1)
-      AND (SUM(cp.total_deposits) + SUM(cp.total_redemptions)) >= COALESCE(p_min_volume, 0)
+      AND (SUM(cp.total_deposits_raw) + SUM(cp.total_redemptions_raw)) >= COALESCE(p_min_volume * 1e18, 0)
   ),
   enriched AS (
     SELECT
       am.account_id,
       a.label AS account_label,
       a.image AS account_image,
-      am.total_pnl,
-      COALESCE(am.realized_pnl, 0) AS realized_pnl,
-      COALESCE(am.unrealized_pnl, 0) AS unrealized_pnl,
-      -- Must Fix: Division by zero - use NULLIF to safely handle zero/negative denominators
+      am.total_pnl_raw,
+      COALESCE(am.realized_pnl_raw, 0) AS realized_pnl_raw,
+      COALESCE(am.unrealized_pnl_raw, 0) AS unrealized_pnl_raw,
+      -- PnL percentage (works on raw values since ratio cancels out)
       COALESCE(
-        (am.total_pnl * 100.0 / NULLIF(am.total_deposits - am.total_redemptions, 0))::NUMERIC(20, 4),
+        (am.total_pnl_raw * 100.0 / NULLIF(am.total_deposits_raw - am.total_redemptions_raw, 0))::NUMERIC(20, 4),
         0::NUMERIC(20, 4)
       ) AS pnl_pct,
-      am.total_pnl AS pnl_change,
+      -- pnl_change: For time-filtered queries, use period change; for all_time, use total_pnl
+      CASE
+        WHEN p_time_filter = 'all_time' THEN am.total_pnl_raw
+        ELSE COALESCE(ppc.period_realized_change_raw, 0)
+      END AS pnl_change_raw,
       am.total_position_count,
       am.active_position_count,
       am.winning_positions,
@@ -178,37 +224,77 @@ BEGIN
         (am.winning_positions * 100.0 / NULLIF(am.total_position_count, 0))::NUMERIC(10, 2),
         0::NUMERIC(10, 2)
       ) AS win_rate,
-      am.total_deposits,
-      am.total_redemptions,
-      (am.total_deposits + am.total_redemptions)::NUMERIC AS total_volume,
-      am.current_equity_value,
-      am.best_trade_pnl,
-      am.worst_trade_pnl,
+      am.total_deposits_raw,
+      am.total_redemptions_raw,
+      (am.total_deposits_raw + am.total_redemptions_raw)::NUMERIC AS total_volume_raw,
+      am.current_equity_value_raw,
+      am.best_trade_pnl_raw,
+      am.worst_trade_pnl_raw,
       am.first_position_at,
       am.last_activity_at
     FROM account_metrics am
     JOIN account a ON am.account_id = a.id
+    LEFT JOIN period_pnl_change ppc ON am.account_id = ppc.account_id
     WHERE NOT p_exclude_protocol_accounts OR a.type NOT IN ('ProtocolVault', 'AtomWallet')
   ),
   ranked AS (
     SELECT e.*,
       CASE p_sort_by
-        WHEN 'total_pnl' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl DESC NULLS LAST) END
+        WHEN 'total_pnl' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST) END
         WHEN 'pnl_pct' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_pct ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.pnl_pct DESC NULLS LAST) END
         WHEN 'win_rate' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.win_rate ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.win_rate DESC NULLS LAST) END
-        WHEN 'total_volume' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_volume DESC NULLS LAST) END
-        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl DESC NULLS LAST)
+        WHEN 'total_volume' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_volume_raw DESC NULLS LAST) END
+        WHEN 'position_count' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_position_count ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_position_count DESC NULLS LAST) END
+        WHEN 'newest' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.first_position_at ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.first_position_at DESC NULLS LAST) END
+        WHEN 'most_improved' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_change_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.pnl_change_raw DESC NULLS LAST) END
+        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
       END AS rank
     FROM enriched e
   )
-  SELECT r.rank, r.account_id, r.account_label, r.account_image, r.total_pnl, r.realized_pnl, r.unrealized_pnl, r.pnl_pct, r.pnl_change, r.total_position_count, r.active_position_count, r.winning_positions, r.losing_positions, r.win_rate, r.total_deposits, r.total_redemptions, r.total_volume, r.current_equity_value, r.best_trade_pnl, r.worst_trade_pnl, r.first_position_at, r.last_activity_at
+  SELECT
+    r.rank,
+    r.account_id,
+    r.account_label,
+    r.account_image,
+    -- PnL values: raw (wei) and formatted (ETH, 4 decimals)
+    r.total_pnl_raw,
+    ROUND(r.total_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS total_pnl_formatted,
+    r.realized_pnl_raw,
+    ROUND(r.realized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS realized_pnl_formatted,
+    r.unrealized_pnl_raw,
+    ROUND(r.unrealized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS unrealized_pnl_formatted,
+    r.pnl_pct,
+    r.pnl_change_raw,
+    ROUND(r.pnl_change_raw / 1e18, 4)::NUMERIC(30, 4) AS pnl_change_formatted,
+    -- Position counts
+    r.total_position_count,
+    r.active_position_count,
+    r.winning_positions,
+    r.losing_positions,
+    r.win_rate,
+    -- Volume values: raw (wei) and formatted (ETH, 4 decimals)
+    r.total_deposits_raw,
+    ROUND(r.total_deposits_raw / 1e18, 4)::NUMERIC(30, 4) AS total_deposits_formatted,
+    r.total_redemptions_raw,
+    ROUND(r.total_redemptions_raw / 1e18, 4)::NUMERIC(30, 4) AS total_redemptions_formatted,
+    r.total_volume_raw,
+    ROUND(r.total_volume_raw / 1e18, 4)::NUMERIC(30, 4) AS total_volume_formatted,
+    r.current_equity_value_raw,
+    ROUND(r.current_equity_value_raw / 1e18, 4)::NUMERIC(30, 4) AS current_equity_value_formatted,
+    r.best_trade_pnl_raw,
+    ROUND(r.best_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
+    r.worst_trade_pnl_raw,
+    ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    -- Timestamps
+    r.first_position_at,
+    r.last_activity_at
   FROM ranked r
   ORDER BY r.rank
   LIMIT v_limit OFFSET v_offset;
 END;
 $$ LANGUAGE plpgsql STABLE;
 
-COMMENT ON FUNCTION get_pnl_leaderboard IS 'Returns a ranked leaderboard of accounts by PnL metrics with configurable time filters, sorting options, and filters for minimum positions/volume.';
+COMMENT ON FUNCTION get_pnl_leaderboard IS 'Returns a ranked leaderboard of accounts by PnL metrics with configurable time filters and sorting options (total_pnl, pnl_pct, win_rate, total_volume, position_count, newest, most_improved).';
 
 -- ========================================
 -- ACCOUNT RANK HELPER FUNCTION
@@ -227,14 +313,13 @@ BEGIN
     RETURN;
   END IF;
 
-  -- Must Fix: Refactor to avoid double computation - single query with window function
   RETURN QUERY
   WITH leaderboard AS (
     SELECT
       l.*,
       COUNT(*) OVER () AS total_accounts
     FROM get_pnl_leaderboard(
-      p_limit := 10000,  -- Reasonable limit for rank calculation
+      p_limit := 10000,
       p_offset := 0,
       p_time_filter := p_time_filter,
       p_sort_by := p_sort_by,
@@ -244,7 +329,6 @@ BEGIN
   SELECT
     lb.rank,
     lb.total_accounts,
-    -- Should Fix: NULL handling in percentile - use COALESCE
     COALESCE(
       ((lb.total_accounts - lb.rank + 1) * 100.0 / NULLIF(lb.total_accounts, 0))::NUMERIC(10, 4),
       0::NUMERIC(10, 4)
@@ -252,11 +336,13 @@ BEGIN
     lb.account_id,
     lb.account_label,
     lb.account_image,
-    lb.total_pnl,
+    lb.total_pnl_raw,
+    lb.total_pnl_formatted,
     lb.pnl_pct,
     lb.win_rate,
     lb.total_position_count,
-    lb.total_volume
+    lb.total_volume_raw,
+    lb.total_volume_formatted
   FROM leaderboard lb
   WHERE lb.account_id = p_account_id;
 END;
@@ -277,20 +363,30 @@ BEGIN
   RETURN QUERY
   SELECT
     COALESCE(COUNT(*), 0)::BIGINT AS total_traders,
-    COALESCE(SUM(l.total_pnl), 0) AS total_pnl_sum,
-    COALESCE(AVG(l.total_pnl), 0) AS avg_pnl,
-    -- Should Fix: NULL handling in percentile - returns NULL if no rows
-    COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY l.total_pnl)::NUMERIC, 0) AS median_pnl,
-    COALESCE(SUM(l.total_volume), 0) AS total_volume,
-    COALESCE(AVG(l.total_volume), 0) AS avg_volume,
-    COALESCE(COUNT(*) FILTER (WHERE l.total_pnl > 0), 0)::BIGINT AS profitable_traders,
-    COALESCE(COUNT(*) FILTER (WHERE l.total_pnl <= 0), 0)::BIGINT AS unprofitable_traders,
+    -- Total PnL sum
+    COALESCE(SUM(l.total_pnl_raw), 0) AS total_pnl_sum_raw,
+    ROUND(COALESCE(SUM(l.total_pnl_raw), 0) / 1e18, 4)::NUMERIC(30, 4) AS total_pnl_sum_formatted,
+    -- Average PnL
+    COALESCE(AVG(l.total_pnl_raw), 0) AS avg_pnl_raw,
+    ROUND(COALESCE(AVG(l.total_pnl_raw), 0) / 1e18, 4)::NUMERIC(30, 4) AS avg_pnl_formatted,
+    -- Median PnL
+    COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY l.total_pnl_raw)::NUMERIC, 0) AS median_pnl_raw,
+    ROUND(COALESCE(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY l.total_pnl_raw)::NUMERIC, 0) / 1e18, 4)::NUMERIC(30, 4) AS median_pnl_formatted,
+    -- Total volume
+    COALESCE(SUM(l.total_volume_raw), 0) AS total_volume_raw,
+    ROUND(COALESCE(SUM(l.total_volume_raw), 0) / 1e18, 4)::NUMERIC(30, 4) AS total_volume_formatted,
+    -- Average volume
+    COALESCE(AVG(l.total_volume_raw), 0) AS avg_volume_raw,
+    ROUND(COALESCE(AVG(l.total_volume_raw), 0) / 1e18, 4)::NUMERIC(30, 4) AS avg_volume_formatted,
+    -- Profitability stats
+    COALESCE(COUNT(*) FILTER (WHERE l.total_pnl_raw > 0), 0)::BIGINT AS profitable_traders,
+    COALESCE(COUNT(*) FILTER (WHERE l.total_pnl_raw <= 0), 0)::BIGINT AS unprofitable_traders,
     COALESCE(
-      (COUNT(*) FILTER (WHERE l.total_pnl > 0) * 100.0 / NULLIF(COUNT(*), 0))::NUMERIC(10, 2),
+      (COUNT(*) FILTER (WHERE l.total_pnl_raw > 0) * 100.0 / NULLIF(COUNT(*), 0))::NUMERIC(10, 2),
       0::NUMERIC(10, 2)
     ) AS profitable_pct
   FROM get_pnl_leaderboard(
-    p_limit := 10000,  -- Reasonable limit for stats calculation
+    p_limit := 10000,
     p_offset := 0,
     p_time_filter := p_time_filter,
     p_term_id := p_term_id
@@ -327,21 +423,22 @@ BEGIN
   v_offset := GREATEST(COALESCE(p_offset, 0), 0);
 
   RETURN QUERY
+  -- All monetary values kept as raw (wei)
   WITH vault_positions AS (
     SELECT
       p.account_id,
       p.term_id,
       p.curve_id,
       p.shares,
-      p.total_deposit_assets_after_total_fees AS total_deposits,
-      p.total_redeem_assets_for_receiver AS total_redemptions,
+      p.total_deposit_assets_after_total_fees AS total_deposits_raw,
+      p.total_redeem_assets_for_receiver AS total_redemptions_raw,
       p.created_at AS position_created_at,
       p.updated_at AS position_updated_at,
       v.current_share_price,
-      (p.shares * v.current_share_price / 1e18)::NUMERIC AS equity_value,
+      (p.shares * v.current_share_price / 1e18)::NUMERIC AS equity_value_raw,
       ((p.shares * v.current_share_price / 1e18)
         + p.total_redeem_assets_for_receiver
-        - p.total_deposit_assets_after_total_fees)::NUMERIC AS position_pnl
+        - p.total_deposit_assets_after_total_fees)::NUMERIC AS position_pnl_raw
     FROM position p
     JOIN vault v ON p.term_id = v.term_id AND p.curve_id = v.curve_id
     WHERE p.term_id = p_term_id
@@ -352,16 +449,16 @@ BEGIN
       vp.account_id,
       COUNT(*) AS total_position_count,
       COUNT(*) FILTER (WHERE vp.shares > 0) AS active_position_count,
-      COUNT(*) FILTER (WHERE vp.position_pnl > 0) AS winning_positions,
-      COUNT(*) FILTER (WHERE vp.position_pnl < 0) AS losing_positions,
-      SUM(vp.total_deposits)::NUMERIC AS total_deposits,
-      SUM(vp.total_redemptions)::NUMERIC AS total_redemptions,
-      SUM(vp.equity_value)::NUMERIC AS current_equity_value,
-      SUM(vp.position_pnl)::NUMERIC AS total_pnl,
-      SUM(vp.position_pnl) FILTER (WHERE vp.shares = 0)::NUMERIC AS realized_pnl,
-      SUM(vp.position_pnl) FILTER (WHERE vp.shares > 0)::NUMERIC AS unrealized_pnl,
-      MAX(vp.position_pnl) AS best_trade_pnl,
-      MIN(vp.position_pnl) AS worst_trade_pnl,
+      COUNT(*) FILTER (WHERE vp.position_pnl_raw > 0) AS winning_positions,
+      COUNT(*) FILTER (WHERE vp.position_pnl_raw < 0) AS losing_positions,
+      SUM(vp.total_deposits_raw)::NUMERIC AS total_deposits_raw,
+      SUM(vp.total_redemptions_raw)::NUMERIC AS total_redemptions_raw,
+      SUM(vp.equity_value_raw)::NUMERIC AS current_equity_value_raw,
+      SUM(vp.position_pnl_raw)::NUMERIC AS total_pnl_raw,
+      SUM(vp.position_pnl_raw) FILTER (WHERE vp.shares = 0)::NUMERIC AS realized_pnl_raw,
+      SUM(vp.position_pnl_raw) FILTER (WHERE vp.shares > 0)::NUMERIC AS unrealized_pnl_raw,
+      MAX(vp.position_pnl_raw) AS best_trade_pnl_raw,
+      MIN(vp.position_pnl_raw) AS worst_trade_pnl_raw,
       MIN(vp.position_created_at) AS first_position_at,
       MAX(vp.position_updated_at) AS last_activity_at
     FROM vault_positions vp
@@ -372,15 +469,14 @@ BEGIN
       am.account_id,
       a.label AS account_label,
       a.image AS account_image,
-      am.total_pnl,
-      COALESCE(am.realized_pnl, 0) AS realized_pnl,
-      COALESCE(am.unrealized_pnl, 0) AS unrealized_pnl,
-      -- Must Fix: Division by zero - use NULLIF
+      am.total_pnl_raw,
+      COALESCE(am.realized_pnl_raw, 0) AS realized_pnl_raw,
+      COALESCE(am.unrealized_pnl_raw, 0) AS unrealized_pnl_raw,
       COALESCE(
-        (am.total_pnl * 100.0 / NULLIF(am.total_deposits - am.total_redemptions, 0))::NUMERIC(20, 4),
+        (am.total_pnl_raw * 100.0 / NULLIF(am.total_deposits_raw - am.total_redemptions_raw, 0))::NUMERIC(20, 4),
         0::NUMERIC(20, 4)
       ) AS pnl_pct,
-      am.total_pnl AS pnl_change,
+      am.total_pnl_raw AS pnl_change_raw,
       am.total_position_count,
       am.active_position_count,
       am.winning_positions,
@@ -389,12 +485,12 @@ BEGIN
         (am.winning_positions * 100.0 / NULLIF(am.total_position_count, 0))::NUMERIC(10, 2),
         0::NUMERIC(10, 2)
       ) AS win_rate,
-      am.total_deposits,
-      am.total_redemptions,
-      (am.total_deposits + am.total_redemptions)::NUMERIC AS total_volume,
-      am.current_equity_value,
-      am.best_trade_pnl,
-      am.worst_trade_pnl,
+      am.total_deposits_raw,
+      am.total_redemptions_raw,
+      (am.total_deposits_raw + am.total_redemptions_raw)::NUMERIC AS total_volume_raw,
+      am.current_equity_value_raw,
+      am.best_trade_pnl_raw,
+      am.worst_trade_pnl_raw,
       am.first_position_at,
       am.last_activity_at
     FROM account_metrics am
@@ -405,22 +501,61 @@ BEGIN
     SELECT
       e.*,
       CASE p_sort_by
-        WHEN 'total_pnl' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl DESC NULLS LAST) END
+        WHEN 'total_pnl' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST) END
         WHEN 'pnl_pct' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_pct ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.pnl_pct DESC NULLS LAST) END
         WHEN 'win_rate' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.win_rate ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.win_rate DESC NULLS LAST) END
-        WHEN 'total_volume' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_volume DESC NULLS LAST) END
-        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl DESC NULLS LAST)
+        WHEN 'total_volume' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_volume_raw DESC NULLS LAST) END
+        WHEN 'position_count' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_position_count ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_position_count DESC NULLS LAST) END
+        WHEN 'newest' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.first_position_at ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.first_position_at DESC NULLS LAST) END
+        WHEN 'most_improved' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_change_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.pnl_change_raw DESC NULLS LAST) END
+        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
       END AS rank
     FROM enriched e
   )
-  SELECT r.rank, r.account_id, r.account_label, r.account_image, r.total_pnl, r.realized_pnl, r.unrealized_pnl, r.pnl_pct, r.pnl_change, r.total_position_count, r.active_position_count, r.winning_positions, r.losing_positions, r.win_rate, r.total_deposits, r.total_redemptions, r.total_volume, r.current_equity_value, r.best_trade_pnl, r.worst_trade_pnl, r.first_position_at, r.last_activity_at
+  SELECT
+    r.rank,
+    r.account_id,
+    r.account_label,
+    r.account_image,
+    -- PnL values: raw (wei) and formatted (ETH, 4 decimals)
+    r.total_pnl_raw,
+    ROUND(r.total_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS total_pnl_formatted,
+    r.realized_pnl_raw,
+    ROUND(r.realized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS realized_pnl_formatted,
+    r.unrealized_pnl_raw,
+    ROUND(r.unrealized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS unrealized_pnl_formatted,
+    r.pnl_pct,
+    r.pnl_change_raw,
+    ROUND(r.pnl_change_raw / 1e18, 4)::NUMERIC(30, 4) AS pnl_change_formatted,
+    -- Position counts
+    r.total_position_count,
+    r.active_position_count,
+    r.winning_positions,
+    r.losing_positions,
+    r.win_rate,
+    -- Volume values: raw (wei) and formatted (ETH, 4 decimals)
+    r.total_deposits_raw,
+    ROUND(r.total_deposits_raw / 1e18, 4)::NUMERIC(30, 4) AS total_deposits_formatted,
+    r.total_redemptions_raw,
+    ROUND(r.total_redemptions_raw / 1e18, 4)::NUMERIC(30, 4) AS total_redemptions_formatted,
+    r.total_volume_raw,
+    ROUND(r.total_volume_raw / 1e18, 4)::NUMERIC(30, 4) AS total_volume_formatted,
+    r.current_equity_value_raw,
+    ROUND(r.current_equity_value_raw / 1e18, 4)::NUMERIC(30, 4) AS current_equity_value_formatted,
+    r.best_trade_pnl_raw,
+    ROUND(r.best_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
+    r.worst_trade_pnl_raw,
+    ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    -- Timestamps
+    r.first_position_at,
+    r.last_activity_at
   FROM ranked r
   ORDER BY r.rank
   LIMIT v_limit OFFSET v_offset;
 END;
 $$ LANGUAGE plpgsql STABLE;
 
-COMMENT ON FUNCTION get_vault_leaderboard IS 'Returns a leaderboard for a specific vault (term_id) with optional curve_id filter. Optimized for vault-specific queries.';
+COMMENT ON FUNCTION get_vault_leaderboard IS 'Returns a leaderboard for a specific vault (term_id) with optional curve_id filter and sorting options (total_pnl, pnl_pct, win_rate, total_volume, position_count, newest, most_improved).';
 
 -- ========================================
 -- INDEXES FOR PERFORMANCE

--- a/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1767883121000_add_pnl_leaderboard/up.sql
@@ -47,6 +47,9 @@ CREATE TABLE pnl_leaderboard_entry (
   best_trade_pnl_formatted NUMERIC(30, 4),
   worst_trade_pnl_raw NUMERIC,
   worst_trade_pnl_formatted NUMERIC(30, 4),
+  -- Redeemable assets (previewRedeem value after fees)
+  redeemable_assets_raw NUMERIC,
+  redeemable_assets_formatted NUMERIC(30, 4),
   -- Timestamps
   first_position_at TIMESTAMPTZ,
   last_activity_at TIMESTAMPTZ
@@ -285,6 +288,9 @@ BEGIN
     ROUND(r.best_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
     r.worst_trade_pnl_raw,
     ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    -- Redeemable assets (not calculated for main leaderboard - use get_vault_leaderboard for this)
+    NULL::NUMERIC AS redeemable_assets_raw,
+    NULL::NUMERIC(30, 4) AS redeemable_assets_formatted,
     -- Timestamps
     r.first_position_at,
     r.last_activity_at
@@ -424,6 +430,9 @@ BEGIN
 
   RETURN QUERY
   -- All monetary values kept as raw (wei)
+  -- Curve constants (hardcoded, immutable in contracts)
+  -- SLOPE = 1e17, OFFSET = 3e19, HALF_SLOPE = 5e16
+  -- Fee constants: PROTOCOL_FEE = 125 (1.25%), EXIT_FEE = 75 (0.75%), FEE_DENOMINATOR = 10000
   WITH vault_positions AS (
     SELECT
       p.account_id,
@@ -435,14 +444,61 @@ BEGIN
       p.created_at AS position_created_at,
       p.updated_at AS position_updated_at,
       v.current_share_price,
+      v.total_shares AS vault_total_shares,
+      v.total_assets AS vault_total_assets,
       (p.shares * v.current_share_price / 1e18)::NUMERIC AS equity_value_raw,
       ((p.shares * v.current_share_price / 1e18)
         + p.total_redeem_assets_for_receiver
-        - p.total_deposit_assets_after_total_fees)::NUMERIC AS position_pnl_raw
+        - p.total_deposit_assets_after_total_fees)::NUMERIC AS position_pnl_raw,
+      -- Calculate raw assets from curve (before fees)
+      CASE
+        WHEN p.shares = 0 THEN 0::NUMERIC
+        -- Linear curve (curve_id = 1): rawAssets = shares * totalAssets / totalShares
+        WHEN p.curve_id = 1 THEN
+          CASE WHEN v.total_shares > 0
+            THEN (p.shares * v.total_assets / v.total_shares)::NUMERIC
+            ELSE 0::NUMERIC
+          END
+        -- Offset Progressive curve (curve_id = 2): Quadratic bonding curve
+        -- s = totalShares + OFFSET, sNext = s - shares
+        -- area = (s^2 - sNext^2) / 1e18, rawAssets = area * HALF_SLOPE / 1e18
+        WHEN p.curve_id = 2 THEN
+          (
+            SELECT (
+              (
+                -- sSquared (rounds down)
+                ((v.total_shares + 30000000000000000000::NUMERIC) * (v.total_shares + 30000000000000000000::NUMERIC) / 1e18)::NUMERIC
+                -
+                -- sNextSquared (rounds up)
+                (((v.total_shares + 30000000000000000000::NUMERIC - p.shares) * (v.total_shares + 30000000000000000000::NUMERIC - p.shares) + 1e18 - 1) / 1e18)::NUMERIC
+              )
+              * 50000000000000000::NUMERIC / 1e18  -- HALF_SLOPE
+            )::NUMERIC
+          )
+        ELSE 0::NUMERIC
+      END AS raw_assets_from_curve
     FROM position p
     JOIN vault v ON p.term_id = v.term_id AND p.curve_id = v.curve_id
     WHERE p.term_id = p_term_id
       AND (p_curve_id IS NULL OR p.curve_id = p_curve_id)
+  ),
+  -- Apply fees to get redeemable assets
+  vault_positions_with_fees AS (
+    SELECT
+      vp.*,
+      -- Protocol fee (1.25%, rounds up): (rawAssets * 125 + 9999) / 10000
+      ((vp.raw_assets_from_curve * 125 + 9999) / 10000)::NUMERIC AS protocol_fee,
+      -- Exit fee (0.75%, rounds up): (rawAssets * 75 + 9999) / 10000
+      -- Note: Exit fee is conditional on default vault having >= 1e18 shares, but we conservatively always apply it
+      ((vp.raw_assets_from_curve * 75 + 9999) / 10000)::NUMERIC AS exit_fee
+    FROM vault_positions vp
+  ),
+  vault_positions_final AS (
+    SELECT
+      vpf.*,
+      -- redeemable_assets = rawAssets - protocolFee - exitFee
+      GREATEST(vpf.raw_assets_from_curve - vpf.protocol_fee - vpf.exit_fee, 0)::NUMERIC AS redeemable_assets_raw
+    FROM vault_positions_with_fees vpf
   ),
   account_metrics AS (
     SELECT
@@ -459,9 +515,11 @@ BEGIN
       SUM(vp.position_pnl_raw) FILTER (WHERE vp.shares > 0)::NUMERIC AS unrealized_pnl_raw,
       MAX(vp.position_pnl_raw) AS best_trade_pnl_raw,
       MIN(vp.position_pnl_raw) AS worst_trade_pnl_raw,
+      -- Sum of redeemable assets for all open positions (shares > 0)
+      SUM(vp.redeemable_assets_raw) FILTER (WHERE vp.shares > 0)::NUMERIC AS redeemable_assets_raw,
       MIN(vp.position_created_at) AS first_position_at,
       MAX(vp.position_updated_at) AS last_activity_at
-    FROM vault_positions vp
+    FROM vault_positions_final vp
     GROUP BY vp.account_id
   ),
   enriched AS (
@@ -491,6 +549,7 @@ BEGIN
       am.current_equity_value_raw,
       am.best_trade_pnl_raw,
       am.worst_trade_pnl_raw,
+      COALESCE(am.redeemable_assets_raw, 0) AS redeemable_assets_raw,
       am.first_position_at,
       am.last_activity_at
     FROM account_metrics am
@@ -546,6 +605,9 @@ BEGIN
     ROUND(r.best_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
     r.worst_trade_pnl_raw,
     ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    -- Redeemable assets (previewRedeem value after fees)
+    r.redeemable_assets_raw,
+    ROUND(r.redeemable_assets_raw / 1e18, 4)::NUMERIC(30, 4) AS redeemable_assets_formatted,
     -- Timestamps
     r.first_position_at,
     r.last_activity_at
@@ -555,7 +617,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql STABLE;
 
-COMMENT ON FUNCTION get_vault_leaderboard IS 'Returns a leaderboard for a specific vault (term_id) with optional curve_id filter and sorting options (total_pnl, pnl_pct, win_rate, total_volume, position_count, newest, most_improved).';
+COMMENT ON FUNCTION get_vault_leaderboard IS 'Returns a leaderboard for a specific vault (term_id) with optional curve_id filter, sorting options, and redeemable_assets calculated using previewRedeem math with fees.';
 
 -- ========================================
 -- INDEXES FOR PERFORMANCE

--- a/infrastructure/hasura/migrations/intuition/1767883122000_add_pnl_leaderboard_period/down.sql
+++ b/infrastructure/hasura/migrations/intuition/1767883122000_add_pnl_leaderboard_period/down.sql
@@ -1,0 +1,6 @@
+-- Down migration for PnL Leaderboard Period Functions
+
+DROP FUNCTION IF EXISTS get_pnl_leaderboard_period(TIMESTAMPTZ, TIMESTAMPTZ, INTEGER, INTEGER, TEXT, TEXT, BOOLEAN, INTEGER, NUMERIC, TEXT);
+DROP FUNCTION IF EXISTS get_vault_leaderboard_period(TEXT, TIMESTAMPTZ, TIMESTAMPTZ, NUMERIC, INTEGER, INTEGER, TEXT, TEXT);
+
+DROP INDEX IF EXISTS idx_share_price_change_term_curve_block_timestamp;

--- a/infrastructure/hasura/migrations/intuition/1767883122000_add_pnl_leaderboard_period/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1767883122000_add_pnl_leaderboard_period/up.sql
@@ -1,0 +1,685 @@
+-- PnL Leaderboard Period Functions
+-- Period-specific leaderboard functions that calculate metrics ONLY for the specified date range
+-- Uses share_price_change table for accurate historical valuations
+
+-- ========================================
+-- DROP EXISTING FUNCTIONS (if any)
+-- ========================================
+
+DROP FUNCTION IF EXISTS get_pnl_leaderboard_period(TIMESTAMPTZ, TIMESTAMPTZ, INTEGER, INTEGER, TEXT, TEXT, BOOLEAN, INTEGER, NUMERIC, TEXT);
+DROP FUNCTION IF EXISTS get_vault_leaderboard_period(TEXT, TIMESTAMPTZ, TIMESTAMPTZ, NUMERIC, INTEGER, INTEGER, TEXT, TEXT);
+
+-- ========================================
+-- PERIOD-SPECIFIC GLOBAL LEADERBOARD
+-- ========================================
+
+CREATE OR REPLACE FUNCTION get_pnl_leaderboard_period(
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ,
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0,
+  p_sort_by TEXT DEFAULT 'total_pnl',
+  p_sort_order TEXT DEFAULT 'DESC',
+  p_exclude_protocol_accounts BOOLEAN DEFAULT TRUE,
+  p_min_positions INTEGER DEFAULT 1,
+  p_min_volume NUMERIC DEFAULT 0,
+  p_term_id TEXT DEFAULT NULL
+)
+RETURNS SETOF pnl_leaderboard_entry AS $$
+DECLARE
+  v_start_timestamp BIGINT;
+  v_end_timestamp BIGINT;
+  v_limit INTEGER;
+  v_offset INTEGER;
+BEGIN
+  -- Input validation
+  IF p_start_date IS NULL OR p_end_date IS NULL THEN
+    RAISE EXCEPTION 'p_start_date and p_end_date are required';
+  END IF;
+
+  IF p_start_date >= p_end_date THEN
+    RAISE EXCEPTION 'p_start_date must be before p_end_date';
+  END IF;
+
+  -- Input validation for limits
+  v_limit := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 10000);
+  v_offset := GREATEST(COALESCE(p_offset, 0), 0);
+
+  -- Convert timestamps to Unix seconds for share_price_change lookup
+  v_start_timestamp := EXTRACT(EPOCH FROM p_start_date)::BIGINT;
+  v_end_timestamp := EXTRACT(EPOCH FROM p_end_date)::BIGINT;
+
+  RETURN QUERY
+  WITH
+  -- Get accounts with activity in the period (FAST - uses continuous aggregate)
+  active_accounts AS (
+    SELECT DISTINCT pc.account_id
+    FROM position_change_daily pc
+    WHERE pc.bucket >= p_start_date
+      AND pc.bucket <= p_end_date
+      AND (p_term_id IS NULL OR pc.term_id = p_term_id)
+  ),
+
+  -- Get historical share prices at period START for each vault
+  -- Uses the most recent price record before the start date
+  prices_at_start AS (
+    SELECT DISTINCT ON (term_id, curve_id)
+      term_id,
+      curve_id,
+      share_price,
+      total_assets,
+      total_shares
+    FROM share_price_change
+    WHERE block_timestamp <= v_start_timestamp
+    ORDER BY term_id, curve_id, block_timestamp DESC, log_index DESC
+  ),
+
+  -- Get historical share prices at period END for each vault
+  prices_at_end AS (
+    SELECT DISTINCT ON (term_id, curve_id)
+      term_id,
+      curve_id,
+      share_price,
+      total_assets,
+      total_shares
+    FROM share_price_change
+    WHERE block_timestamp <= v_end_timestamp
+    ORDER BY term_id, curve_id, block_timestamp DESC, log_index DESC
+  ),
+
+  -- Calculate position state at period START using cumulative sums
+  -- (sum of all position changes before the period)
+  position_state_start AS (
+    SELECT
+      pc.account_id,
+      pc.term_id,
+      pc.curve_id,
+      SUM(pc.shares_delta_period)::NUMERIC AS shares_at_start,
+      SUM(pc.assets_in_period)::NUMERIC AS cumulative_deposits_before,
+      SUM(pc.assets_out_period)::NUMERIC AS cumulative_redemptions_before
+    FROM position_change_daily pc
+    WHERE pc.bucket < p_start_date
+      AND (p_term_id IS NULL OR pc.term_id = p_term_id)
+    GROUP BY pc.account_id, pc.term_id, pc.curve_id
+  ),
+
+  -- Calculate position state at period END
+  position_state_end AS (
+    SELECT
+      pc.account_id,
+      pc.term_id,
+      pc.curve_id,
+      SUM(pc.shares_delta_period)::NUMERIC AS shares_at_end,
+      SUM(pc.assets_in_period)::NUMERIC AS cumulative_deposits_through,
+      SUM(pc.assets_out_period)::NUMERIC AS cumulative_redemptions_through
+    FROM position_change_daily pc
+    WHERE pc.bucket <= p_end_date
+      AND (p_term_id IS NULL OR pc.term_id = p_term_id)
+    GROUP BY pc.account_id, pc.term_id, pc.curve_id
+  ),
+
+  -- Calculate period activity (deposits and redemptions DURING the period)
+  period_activity AS (
+    SELECT
+      pc.account_id,
+      pc.term_id,
+      pc.curve_id,
+      SUM(pc.assets_in_period)::NUMERIC AS period_deposits,
+      SUM(pc.assets_out_period)::NUMERIC AS period_redemptions,
+      SUM(pc.shares_delta_period)::NUMERIC AS period_shares_delta
+    FROM position_change_daily pc
+    WHERE pc.bucket >= p_start_date
+      AND pc.bucket <= p_end_date
+      AND (p_term_id IS NULL OR pc.term_id = p_term_id)
+    GROUP BY pc.account_id, pc.term_id, pc.curve_id
+  ),
+
+  -- Combine all position data with historical prices
+  position_period_metrics AS (
+    SELECT
+      COALESCE(pss.account_id, pse.account_id, pa.account_id) AS account_id,
+      COALESCE(pss.term_id, pse.term_id, pa.term_id) AS term_id,
+      COALESCE(pss.curve_id, pse.curve_id, pa.curve_id) AS curve_id,
+      -- Shares at boundaries
+      COALESCE(pss.shares_at_start, 0) AS shares_at_start,
+      COALESCE(pse.shares_at_end, 0) AS shares_at_end,
+      -- Period activity
+      COALESCE(pa.period_deposits, 0) AS period_deposits,
+      COALESCE(pa.period_redemptions, 0) AS period_redemptions,
+      -- Historical prices
+      COALESCE(ps.share_price, 0) AS price_at_start,
+      COALESCE(pe.share_price, 0) AS price_at_end,
+      -- Equity values at boundaries
+      (COALESCE(pss.shares_at_start, 0) * COALESCE(ps.share_price, 0) / 1e18)::NUMERIC AS equity_at_start,
+      (COALESCE(pse.shares_at_end, 0) * COALESCE(pe.share_price, 0) / 1e18)::NUMERIC AS equity_at_end,
+      -- Was there any activity during the period?
+      CASE WHEN pa.account_id IS NOT NULL THEN TRUE ELSE FALSE END AS had_activity
+    FROM position_state_start pss
+    FULL OUTER JOIN position_state_end pse
+      ON pss.account_id = pse.account_id
+      AND pss.term_id = pse.term_id
+      AND pss.curve_id = pse.curve_id
+    FULL OUTER JOIN period_activity pa
+      ON COALESCE(pss.account_id, pse.account_id) = pa.account_id
+      AND COALESCE(pss.term_id, pse.term_id) = pa.term_id
+      AND COALESCE(pss.curve_id, pse.curve_id) = pa.curve_id
+    LEFT JOIN prices_at_start ps
+      ON COALESCE(pss.term_id, pse.term_id, pa.term_id) = ps.term_id
+      AND COALESCE(pss.curve_id, pse.curve_id, pa.curve_id) = ps.curve_id
+    LEFT JOIN prices_at_end pe
+      ON COALESCE(pss.term_id, pse.term_id, pa.term_id) = pe.term_id
+      AND COALESCE(pss.curve_id, pse.curve_id, pa.curve_id) = pe.curve_id
+    WHERE COALESCE(pss.account_id, pse.account_id, pa.account_id) IN (SELECT account_id FROM active_accounts)
+  ),
+
+  -- Calculate period-specific PnL for each position
+  position_pnl AS (
+    SELECT
+      ppm.*,
+      -- Realized PnL during period = redemptions - deposits
+      (ppm.period_redemptions - ppm.period_deposits)::NUMERIC AS period_realized_pnl,
+      -- Unrealized PnL change = (equity at end) - (equity at start) - (net new investment during period)
+      -- Net new investment = deposits - redemptions (what was added/removed)
+      -- Unrealized change = equity_end - equity_start - (deposits - redemptions)
+      (ppm.equity_at_end - ppm.equity_at_start - (ppm.period_deposits - ppm.period_redemptions))::NUMERIC AS period_unrealized_pnl,
+      -- Total period PnL = realized + unrealized change
+      -- Simplified: (equity_end - equity_start) + (redemptions - deposits) - (deposits - redemptions) + (redemptions - deposits)
+      -- = equity_end - equity_start + 2*(redemptions - deposits) - (deposits - redemptions)
+      -- Actually simpler: equity_end - equity_start + (net cash out)
+      -- Period PnL = final equity - initial equity + cash withdrawn - cash deposited
+      (ppm.equity_at_end - ppm.equity_at_start + ppm.period_redemptions - ppm.period_deposits)::NUMERIC AS period_total_pnl,
+      -- Position was profitable if period PnL > 0
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start + ppm.period_redemptions - ppm.period_deposits) > 0 THEN 1 ELSE 0 END AS is_winning,
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start + ppm.period_redemptions - ppm.period_deposits) < 0 THEN 1 ELSE 0 END AS is_losing
+    FROM position_period_metrics ppm
+  ),
+
+  -- Aggregate by account
+  account_metrics AS (
+    SELECT
+      pp.account_id,
+      -- Position counts (positions with activity during period)
+      COUNT(DISTINCT (pp.term_id, pp.curve_id)) FILTER (WHERE pp.had_activity) AS period_position_count,
+      -- Active positions at end of period
+      COUNT(DISTINCT (pp.term_id, pp.curve_id)) FILTER (WHERE pp.shares_at_end > 0) AS active_position_count,
+      -- Win/loss counts based on period PnL
+      SUM(pp.is_winning) AS winning_positions,
+      SUM(pp.is_losing) AS losing_positions,
+      -- Period volumes
+      SUM(pp.period_deposits)::NUMERIC AS period_deposits_raw,
+      SUM(pp.period_redemptions)::NUMERIC AS period_redemptions_raw,
+      -- Period PnL values
+      SUM(pp.period_total_pnl)::NUMERIC AS total_pnl_raw,
+      SUM(pp.period_realized_pnl)::NUMERIC AS realized_pnl_raw,
+      SUM(pp.period_unrealized_pnl)::NUMERIC AS unrealized_pnl_raw,
+      -- Equity at period boundaries
+      SUM(pp.equity_at_start)::NUMERIC AS equity_at_start,
+      SUM(pp.equity_at_end)::NUMERIC AS equity_at_end,
+      -- Best/worst trades during period
+      MAX(pp.period_total_pnl) AS best_trade_pnl_raw,
+      MIN(pp.period_total_pnl) AS worst_trade_pnl_raw
+    FROM position_pnl pp
+    GROUP BY pp.account_id
+    HAVING COUNT(DISTINCT (pp.term_id, pp.curve_id)) FILTER (WHERE pp.had_activity) >= GREATEST(p_min_positions, 1)
+      AND (SUM(pp.period_deposits) + SUM(pp.period_redemptions)) >= COALESCE(p_min_volume * 1e18, 0)
+  ),
+
+  -- Enrich with account info
+  enriched AS (
+    SELECT
+      am.account_id,
+      a.label AS account_label,
+      a.image AS account_image,
+      am.total_pnl_raw,
+      COALESCE(am.realized_pnl_raw, 0) AS realized_pnl_raw,
+      COALESCE(am.unrealized_pnl_raw, 0) AS unrealized_pnl_raw,
+      -- PnL percentage: period PnL / equity at start (or deposits if no starting equity)
+      COALESCE(
+        (am.total_pnl_raw * 100.0 / NULLIF(
+          CASE WHEN am.equity_at_start > 0 THEN am.equity_at_start
+               ELSE am.period_deposits_raw - am.period_redemptions_raw
+          END, 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS pnl_pct,
+      am.total_pnl_raw AS pnl_change_raw,  -- For period queries, pnl_change = total_pnl
+      am.period_position_count AS total_position_count,
+      am.active_position_count,
+      am.winning_positions,
+      am.losing_positions,
+      COALESCE(
+        (am.winning_positions * 100.0 / NULLIF(am.period_position_count, 0))::NUMERIC(10, 2),
+        0::NUMERIC(10, 2)
+      ) AS win_rate,
+      am.period_deposits_raw AS total_deposits_raw,
+      am.period_redemptions_raw AS total_redemptions_raw,
+      (am.period_deposits_raw + am.period_redemptions_raw)::NUMERIC AS total_volume_raw,
+      am.equity_at_end AS current_equity_value_raw,
+      am.best_trade_pnl_raw,
+      am.worst_trade_pnl_raw,
+      -- Get first/last activity timestamps for period
+      p_start_date AS first_position_at,  -- For period queries, use period boundaries
+      p_end_date AS last_activity_at
+    FROM account_metrics am
+    JOIN account a ON am.account_id = a.id
+    WHERE NOT p_exclude_protocol_accounts OR a.type NOT IN ('ProtocolVault', 'AtomWallet')
+  ),
+
+  -- Apply ranking
+  ranked AS (
+    SELECT
+      e.*,
+      CASE p_sort_by
+        WHEN 'total_pnl' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST) END
+        WHEN 'pnl_pct' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_pct ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.pnl_pct DESC NULLS LAST) END
+        WHEN 'win_rate' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.win_rate ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.win_rate DESC NULLS LAST) END
+        WHEN 'total_volume' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_volume_raw DESC NULLS LAST) END
+        WHEN 'position_count' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_position_count ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_position_count DESC NULLS LAST) END
+        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
+      END AS rank
+    FROM enriched e
+  )
+
+  SELECT
+    r.rank,
+    r.account_id,
+    r.account_label,
+    r.account_image,
+    -- PnL values: raw (wei) and formatted (ETH, 4 decimals)
+    r.total_pnl_raw,
+    ROUND(r.total_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS total_pnl_formatted,
+    r.realized_pnl_raw,
+    ROUND(r.realized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS realized_pnl_formatted,
+    r.unrealized_pnl_raw,
+    ROUND(r.unrealized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS unrealized_pnl_formatted,
+    r.pnl_pct,
+    r.pnl_change_raw,
+    ROUND(r.pnl_change_raw / 1e18, 4)::NUMERIC(30, 4) AS pnl_change_formatted,
+    -- Position counts
+    r.total_position_count,
+    r.active_position_count,
+    r.winning_positions,
+    r.losing_positions,
+    r.win_rate,
+    -- Volume values: raw (wei) and formatted (ETH, 4 decimals)
+    r.total_deposits_raw,
+    ROUND(r.total_deposits_raw / 1e18, 4)::NUMERIC(30, 4) AS total_deposits_formatted,
+    r.total_redemptions_raw,
+    ROUND(r.total_redemptions_raw / 1e18, 4)::NUMERIC(30, 4) AS total_redemptions_formatted,
+    r.total_volume_raw,
+    ROUND(r.total_volume_raw / 1e18, 4)::NUMERIC(30, 4) AS total_volume_formatted,
+    r.current_equity_value_raw,
+    ROUND(r.current_equity_value_raw / 1e18, 4)::NUMERIC(30, 4) AS current_equity_value_formatted,
+    r.best_trade_pnl_raw,
+    ROUND(r.best_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
+    r.worst_trade_pnl_raw,
+    ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    -- Redeemable assets (not calculated for main leaderboard - use get_vault_leaderboard_period)
+    NULL::NUMERIC AS redeemable_assets_raw,
+    NULL::NUMERIC(30, 4) AS redeemable_assets_formatted,
+    -- Timestamps (period boundaries for period queries)
+    r.first_position_at,
+    r.last_activity_at
+  FROM ranked r
+  ORDER BY r.rank
+  LIMIT v_limit OFFSET v_offset;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION get_pnl_leaderboard_period IS 'Returns a period-specific leaderboard showing PnL metrics ONLY for the specified date range. Uses historical share prices for accurate valuations.';
+
+-- ========================================
+-- PERIOD-SPECIFIC VAULT LEADERBOARD
+-- ========================================
+
+CREATE OR REPLACE FUNCTION get_vault_leaderboard_period(
+  p_term_id TEXT,
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ,
+  p_curve_id NUMERIC(78, 0) DEFAULT NULL,
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0,
+  p_sort_by TEXT DEFAULT 'total_pnl',
+  p_sort_order TEXT DEFAULT 'DESC'
+)
+RETURNS SETOF pnl_leaderboard_entry AS $$
+DECLARE
+  v_start_timestamp BIGINT;
+  v_end_timestamp BIGINT;
+  v_limit INTEGER;
+  v_offset INTEGER;
+BEGIN
+  -- Input validation
+  IF p_term_id IS NULL OR p_term_id = '' THEN
+    RAISE EXCEPTION 'p_term_id is required';
+  END IF;
+
+  IF p_start_date IS NULL OR p_end_date IS NULL THEN
+    RAISE EXCEPTION 'p_start_date and p_end_date are required';
+  END IF;
+
+  IF p_start_date >= p_end_date THEN
+    RAISE EXCEPTION 'p_start_date must be before p_end_date';
+  END IF;
+
+  -- Input validation for limits
+  v_limit := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 10000);
+  v_offset := GREATEST(COALESCE(p_offset, 0), 0);
+
+  -- Convert timestamps to Unix seconds for share_price_change lookup
+  v_start_timestamp := EXTRACT(EPOCH FROM p_start_date)::BIGINT;
+  v_end_timestamp := EXTRACT(EPOCH FROM p_end_date)::BIGINT;
+
+  RETURN QUERY
+  WITH
+  -- Get accounts with activity in the period for this vault
+  active_accounts AS (
+    SELECT DISTINCT pc.account_id
+    FROM position_change_daily pc
+    WHERE pc.bucket >= p_start_date
+      AND pc.bucket <= p_end_date
+      AND pc.term_id = p_term_id
+      AND (p_curve_id IS NULL OR pc.curve_id = p_curve_id)
+  ),
+
+  -- Get historical vault state at period START
+  vault_state_start AS (
+    SELECT DISTINCT ON (term_id, curve_id)
+      term_id,
+      curve_id,
+      share_price,
+      total_assets,
+      total_shares
+    FROM share_price_change
+    WHERE term_id = p_term_id
+      AND (p_curve_id IS NULL OR curve_id = p_curve_id)
+      AND block_timestamp <= v_start_timestamp
+    ORDER BY term_id, curve_id, block_timestamp DESC, log_index DESC
+  ),
+
+  -- Get historical vault state at period END
+  vault_state_end AS (
+    SELECT DISTINCT ON (term_id, curve_id)
+      term_id,
+      curve_id,
+      share_price,
+      total_assets,
+      total_shares
+    FROM share_price_change
+    WHERE term_id = p_term_id
+      AND (p_curve_id IS NULL OR curve_id = p_curve_id)
+      AND block_timestamp <= v_end_timestamp
+    ORDER BY term_id, curve_id, block_timestamp DESC, log_index DESC
+  ),
+
+  -- Calculate position state at period START
+  position_state_start AS (
+    SELECT
+      pc.account_id,
+      pc.term_id,
+      pc.curve_id,
+      SUM(pc.shares_delta_period)::NUMERIC AS shares_at_start,
+      SUM(pc.assets_in_period)::NUMERIC AS cumulative_deposits_before,
+      SUM(pc.assets_out_period)::NUMERIC AS cumulative_redemptions_before
+    FROM position_change_daily pc
+    WHERE pc.bucket < p_start_date
+      AND pc.term_id = p_term_id
+      AND (p_curve_id IS NULL OR pc.curve_id = p_curve_id)
+    GROUP BY pc.account_id, pc.term_id, pc.curve_id
+  ),
+
+  -- Calculate position state at period END
+  position_state_end AS (
+    SELECT
+      pc.account_id,
+      pc.term_id,
+      pc.curve_id,
+      SUM(pc.shares_delta_period)::NUMERIC AS shares_at_end,
+      SUM(pc.assets_in_period)::NUMERIC AS cumulative_deposits_through,
+      SUM(pc.assets_out_period)::NUMERIC AS cumulative_redemptions_through
+    FROM position_change_daily pc
+    WHERE pc.bucket <= p_end_date
+      AND pc.term_id = p_term_id
+      AND (p_curve_id IS NULL OR pc.curve_id = p_curve_id)
+    GROUP BY pc.account_id, pc.term_id, pc.curve_id
+  ),
+
+  -- Calculate period activity
+  period_activity AS (
+    SELECT
+      pc.account_id,
+      pc.term_id,
+      pc.curve_id,
+      SUM(pc.assets_in_period)::NUMERIC AS period_deposits,
+      SUM(pc.assets_out_period)::NUMERIC AS period_redemptions,
+      SUM(pc.shares_delta_period)::NUMERIC AS period_shares_delta
+    FROM position_change_daily pc
+    WHERE pc.bucket >= p_start_date
+      AND pc.bucket <= p_end_date
+      AND pc.term_id = p_term_id
+      AND (p_curve_id IS NULL OR pc.curve_id = p_curve_id)
+    GROUP BY pc.account_id, pc.term_id, pc.curve_id
+  ),
+
+  -- Combine position data with historical prices and vault states
+  position_period_metrics AS (
+    SELECT
+      COALESCE(pss.account_id, pse.account_id, pa.account_id) AS account_id,
+      COALESCE(pss.term_id, pse.term_id, pa.term_id) AS term_id,
+      COALESCE(pss.curve_id, pse.curve_id, pa.curve_id) AS curve_id,
+      -- Shares at boundaries
+      COALESCE(pss.shares_at_start, 0) AS shares_at_start,
+      COALESCE(pse.shares_at_end, 0) AS shares_at_end,
+      -- Period activity
+      COALESCE(pa.period_deposits, 0) AS period_deposits,
+      COALESCE(pa.period_redemptions, 0) AS period_redemptions,
+      -- Historical prices
+      COALESCE(vs.share_price, 0) AS price_at_start,
+      COALESCE(ve.share_price, 0) AS price_at_end,
+      -- Vault states for redeemable_assets calculation
+      COALESCE(ve.total_assets, 0) AS vault_total_assets_end,
+      COALESCE(ve.total_shares, 0) AS vault_total_shares_end,
+      -- Equity values at boundaries
+      (COALESCE(pss.shares_at_start, 0) * COALESCE(vs.share_price, 0) / 1e18)::NUMERIC AS equity_at_start,
+      (COALESCE(pse.shares_at_end, 0) * COALESCE(ve.share_price, 0) / 1e18)::NUMERIC AS equity_at_end,
+      -- Had activity during period?
+      CASE WHEN pa.account_id IS NOT NULL THEN TRUE ELSE FALSE END AS had_activity
+    FROM position_state_start pss
+    FULL OUTER JOIN position_state_end pse
+      ON pss.account_id = pse.account_id
+      AND pss.term_id = pse.term_id
+      AND pss.curve_id = pse.curve_id
+    FULL OUTER JOIN period_activity pa
+      ON COALESCE(pss.account_id, pse.account_id) = pa.account_id
+      AND COALESCE(pss.term_id, pse.term_id) = pa.term_id
+      AND COALESCE(pss.curve_id, pse.curve_id) = pa.curve_id
+    LEFT JOIN vault_state_start vs
+      ON COALESCE(pss.term_id, pse.term_id, pa.term_id) = vs.term_id
+      AND COALESCE(pss.curve_id, pse.curve_id, pa.curve_id) = vs.curve_id
+    LEFT JOIN vault_state_end ve
+      ON COALESCE(pss.term_id, pse.term_id, pa.term_id) = ve.term_id
+      AND COALESCE(pss.curve_id, pse.curve_id, pa.curve_id) = ve.curve_id
+    WHERE COALESCE(pss.account_id, pse.account_id, pa.account_id) IN (SELECT account_id FROM active_accounts)
+  ),
+
+  -- Calculate period PnL and redeemable assets at period end
+  position_pnl AS (
+    SELECT
+      ppm.*,
+      -- Period PnL calculations
+      (ppm.period_redemptions - ppm.period_deposits)::NUMERIC AS period_realized_pnl,
+      (ppm.equity_at_end - ppm.equity_at_start - (ppm.period_deposits - ppm.period_redemptions))::NUMERIC AS period_unrealized_pnl,
+      (ppm.equity_at_end - ppm.equity_at_start + ppm.period_redemptions - ppm.period_deposits)::NUMERIC AS period_total_pnl,
+      -- Win/loss determination
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start + ppm.period_redemptions - ppm.period_deposits) > 0 THEN 1 ELSE 0 END AS is_winning,
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start + ppm.period_redemptions - ppm.period_deposits) < 0 THEN 1 ELSE 0 END AS is_losing,
+      -- Calculate redeemable assets at period end using historical vault state
+      -- Uses the same bonding curve math as get_vault_leaderboard
+      CASE
+        WHEN ppm.shares_at_end = 0 THEN 0::NUMERIC
+        -- Linear curve (curve_id = 1)
+        WHEN ppm.curve_id = 1 THEN
+          CASE WHEN ppm.vault_total_shares_end > 0
+            THEN (ppm.shares_at_end * ppm.vault_total_assets_end / ppm.vault_total_shares_end)::NUMERIC
+            ELSE 0::NUMERIC
+          END
+        -- Offset Progressive curve (curve_id = 2)
+        WHEN ppm.curve_id = 2 THEN
+          (
+            SELECT (
+              (
+                ((ppm.vault_total_shares_end + 30000000000000000000::NUMERIC) * (ppm.vault_total_shares_end + 30000000000000000000::NUMERIC) / 1e18)::NUMERIC
+                -
+                (((ppm.vault_total_shares_end + 30000000000000000000::NUMERIC - ppm.shares_at_end) * (ppm.vault_total_shares_end + 30000000000000000000::NUMERIC - ppm.shares_at_end) + 1e18 - 1) / 1e18)::NUMERIC
+              )
+              * 50000000000000000::NUMERIC / 1e18
+            )::NUMERIC
+          )
+        ELSE 0::NUMERIC
+      END AS raw_assets_from_curve
+    FROM position_period_metrics ppm
+  ),
+
+  -- Apply fees to get redeemable assets
+  position_with_fees AS (
+    SELECT
+      pp.*,
+      -- Protocol fee (1.25%, rounds up)
+      ((pp.raw_assets_from_curve * 125 + 9999) / 10000)::NUMERIC AS protocol_fee,
+      -- Exit fee (0.75%, rounds up)
+      ((pp.raw_assets_from_curve * 75 + 9999) / 10000)::NUMERIC AS exit_fee
+    FROM position_pnl pp
+  ),
+
+  position_final AS (
+    SELECT
+      pwf.*,
+      GREATEST(pwf.raw_assets_from_curve - pwf.protocol_fee - pwf.exit_fee, 0)::NUMERIC AS redeemable_assets_raw
+    FROM position_with_fees pwf
+  ),
+
+  -- Aggregate by account
+  account_metrics AS (
+    SELECT
+      pf.account_id,
+      COUNT(DISTINCT (pf.term_id, pf.curve_id)) FILTER (WHERE pf.had_activity) AS period_position_count,
+      COUNT(DISTINCT (pf.term_id, pf.curve_id)) FILTER (WHERE pf.shares_at_end > 0) AS active_position_count,
+      SUM(pf.is_winning) AS winning_positions,
+      SUM(pf.is_losing) AS losing_positions,
+      SUM(pf.period_deposits)::NUMERIC AS period_deposits_raw,
+      SUM(pf.period_redemptions)::NUMERIC AS period_redemptions_raw,
+      SUM(pf.period_total_pnl)::NUMERIC AS total_pnl_raw,
+      SUM(pf.period_realized_pnl)::NUMERIC AS realized_pnl_raw,
+      SUM(pf.period_unrealized_pnl)::NUMERIC AS unrealized_pnl_raw,
+      SUM(pf.equity_at_start)::NUMERIC AS equity_at_start,
+      SUM(pf.equity_at_end)::NUMERIC AS equity_at_end,
+      MAX(pf.period_total_pnl) AS best_trade_pnl_raw,
+      MIN(pf.period_total_pnl) AS worst_trade_pnl_raw,
+      SUM(pf.redeemable_assets_raw) FILTER (WHERE pf.shares_at_end > 0)::NUMERIC AS redeemable_assets_raw
+    FROM position_final pf
+    GROUP BY pf.account_id
+  ),
+
+  -- Enrich with account info
+  enriched AS (
+    SELECT
+      am.account_id,
+      a.label AS account_label,
+      a.image AS account_image,
+      am.total_pnl_raw,
+      COALESCE(am.realized_pnl_raw, 0) AS realized_pnl_raw,
+      COALESCE(am.unrealized_pnl_raw, 0) AS unrealized_pnl_raw,
+      COALESCE(
+        (am.total_pnl_raw * 100.0 / NULLIF(
+          CASE WHEN am.equity_at_start > 0 THEN am.equity_at_start
+               ELSE am.period_deposits_raw - am.period_redemptions_raw
+          END, 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS pnl_pct,
+      am.total_pnl_raw AS pnl_change_raw,
+      am.period_position_count AS total_position_count,
+      am.active_position_count,
+      am.winning_positions,
+      am.losing_positions,
+      COALESCE(
+        (am.winning_positions * 100.0 / NULLIF(am.period_position_count, 0))::NUMERIC(10, 2),
+        0::NUMERIC(10, 2)
+      ) AS win_rate,
+      am.period_deposits_raw AS total_deposits_raw,
+      am.period_redemptions_raw AS total_redemptions_raw,
+      (am.period_deposits_raw + am.period_redemptions_raw)::NUMERIC AS total_volume_raw,
+      am.equity_at_end AS current_equity_value_raw,
+      am.best_trade_pnl_raw,
+      am.worst_trade_pnl_raw,
+      COALESCE(am.redeemable_assets_raw, 0) AS redeemable_assets_raw,
+      p_start_date AS first_position_at,
+      p_end_date AS last_activity_at
+    FROM account_metrics am
+    JOIN account a ON am.account_id = a.id
+    WHERE a.type NOT IN ('ProtocolVault', 'AtomWallet')
+  ),
+
+  ranked AS (
+    SELECT
+      e.*,
+      CASE p_sort_by
+        WHEN 'total_pnl' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST) END
+        WHEN 'pnl_pct' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_pct ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.pnl_pct DESC NULLS LAST) END
+        WHEN 'win_rate' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.win_rate ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.win_rate DESC NULLS LAST) END
+        WHEN 'total_volume' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_volume_raw DESC NULLS LAST) END
+        WHEN 'position_count' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_position_count ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.total_position_count DESC NULLS LAST) END
+        WHEN 'redeemable_assets' THEN CASE p_sort_order WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.redeemable_assets_raw ASC NULLS LAST) ELSE ROW_NUMBER() OVER (ORDER BY e.redeemable_assets_raw DESC NULLS LAST) END
+        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
+      END AS rank
+    FROM enriched e
+  )
+
+  SELECT
+    r.rank,
+    r.account_id,
+    r.account_label,
+    r.account_image,
+    r.total_pnl_raw,
+    ROUND(r.total_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS total_pnl_formatted,
+    r.realized_pnl_raw,
+    ROUND(r.realized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS realized_pnl_formatted,
+    r.unrealized_pnl_raw,
+    ROUND(r.unrealized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS unrealized_pnl_formatted,
+    r.pnl_pct,
+    r.pnl_change_raw,
+    ROUND(r.pnl_change_raw / 1e18, 4)::NUMERIC(30, 4) AS pnl_change_formatted,
+    r.total_position_count,
+    r.active_position_count,
+    r.winning_positions,
+    r.losing_positions,
+    r.win_rate,
+    r.total_deposits_raw,
+    ROUND(r.total_deposits_raw / 1e18, 4)::NUMERIC(30, 4) AS total_deposits_formatted,
+    r.total_redemptions_raw,
+    ROUND(r.total_redemptions_raw / 1e18, 4)::NUMERIC(30, 4) AS total_redemptions_formatted,
+    r.total_volume_raw,
+    ROUND(r.total_volume_raw / 1e18, 4)::NUMERIC(30, 4) AS total_volume_formatted,
+    r.current_equity_value_raw,
+    ROUND(r.current_equity_value_raw / 1e18, 4)::NUMERIC(30, 4) AS current_equity_value_formatted,
+    r.best_trade_pnl_raw,
+    ROUND(r.best_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
+    r.worst_trade_pnl_raw,
+    ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    r.redeemable_assets_raw,
+    ROUND(r.redeemable_assets_raw / 1e18, 4)::NUMERIC(30, 4) AS redeemable_assets_formatted,
+    r.first_position_at,
+    r.last_activity_at
+  FROM ranked r
+  ORDER BY r.rank
+  LIMIT v_limit OFFSET v_offset;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+COMMENT ON FUNCTION get_vault_leaderboard_period IS 'Returns a period-specific leaderboard for a specific vault showing PnL metrics and redeemable_assets calculated at the end of the specified date range using historical share prices.';
+
+-- ========================================
+-- INDEXES FOR PERFORMANCE
+-- ========================================
+
+-- Index for efficient historical price lookups
+CREATE INDEX IF NOT EXISTS idx_share_price_change_term_curve_block_timestamp
+  ON share_price_change (term_id, curve_id, block_timestamp DESC, log_index DESC);


### PR DESCRIPTION
# PnL Leaderboard Functions

Season 2 Leaderboard feature for ranking accounts by PnL metrics, enabling users to discover top performers, track their own ranking, and analyze aggregate market statistics.

## Overview

This migration adds six PostgreSQL functions exposed via Hasura GraphQL:

| Function | Description |
|----------|-------------|
| `get_pnl_leaderboard` | Main ranked leaderboard with filtering, sorting, and pagination |
| `get_account_pnl_rank` | Individual account rank and percentile lookup |
| `get_pnl_leaderboard_stats` | Aggregate statistics (total traders, median PnL, profitability) |
| `get_vault_leaderboard` | Vault-specific leaderboard with `redeemable_assets` calculation |
| `get_pnl_leaderboard_period` | **Period-specific** leaderboard showing metrics ONLY for a date range |
| `get_vault_leaderboard_period` | **Period-specific** vault leaderboard with historical `redeemable_assets` |

## Key Features

### Dual Value Format
All monetary fields are returned in two formats:
- `*_raw`: Base-10 integer (wei, 18 decimals) for precise calculations
- `*_formatted`: Human-readable decimal (ETH, max 4 decimal places) for display

### Time Filters
- `24h` - Last 24 hours
- `7d` - Last 7 days
- `30d` - Last 30 days
- `90d` - Last 90 days
- `all_time` - All historical data
- `custom` - Custom date range via `p_start_time` and `p_end_time`

### Sort Options
- `total_pnl` - Total profit/loss (default)
- `pnl_pct` - ROI percentage
- `win_rate` - Percentage of winning positions
- `total_volume` - Total trading volume
- `position_count` - Number of positions
- `newest` - Most recent traders (by first position date)
- `most_improved` - Biggest PnL change in the time period

### Redeemable Assets Calculation
The `get_vault_leaderboard` function calculates the actual redemption value using bonding curve math:

**Linear Curve (curve_id = 1):**
```
rawAssets = shares * totalAssets / totalShares
```

**Offset Progressive Curve (curve_id = 2):**
```
s = totalShares + OFFSET (3e19)
sNext = s - shares
area = (s² - sNext²) / 1e18
rawAssets = area * HALF_SLOPE (5e16) / 1e18
```

**Fees Applied:**
- Protocol fee: 1.25% (always)
- Exit fee: 0.75% (conservatively always applied)

```
redeemable_assets = rawAssets - protocolFee - exitFee
```

## Returned Fields

### Leaderboard Entry Fields

| Field | Description |
|-------|-------------|
| `rank` | Position in the leaderboard |
| `account_id` | Unique account identifier |
| `account_label` | Human-readable account name/label |
| `account_image` | Account avatar/image URL |
| `total_pnl_raw/formatted` | Combined realized + unrealized PnL |
| `realized_pnl_raw/formatted` | PnL from closed positions (shares = 0) |
| `unrealized_pnl_raw/formatted` | PnL from open positions (shares > 0) |
| `pnl_pct` | ROI percentage |
| `pnl_change_raw/formatted` | Change in PnL for the time period |
| `total_position_count` | Total number of positions ever held |
| `active_position_count` | Number of positions currently open |
| `winning_positions` | Count of positions with positive PnL |
| `losing_positions` | Count of positions with negative PnL |
| `win_rate` | Percentage of winning positions |
| `total_deposits_raw/formatted` | Sum of all deposit amounts |
| `total_redemptions_raw/formatted` | Sum of all redemption amounts |
| `total_volume_raw/formatted` | total_deposits + total_redemptions |
| `current_equity_value_raw/formatted` | Current market value of all open positions |
| `best_trade_pnl_raw/formatted` | Highest PnL from a single position |
| `worst_trade_pnl_raw/formatted` | Lowest PnL from a single position |
| `redeemable_assets_raw/formatted` | Actual redemption value after fees (vault leaderboard only) |
| `first_position_at` | Timestamp of first position creation |
| `last_activity_at` | Timestamp of most recent position update |

### Account Rank Fields

| Field | Description |
|-------|-------------|
| `rank` | Account's position in leaderboard |
| `total_accounts` | Total number of accounts in leaderboard |
| `percentile` | Account's percentile (higher = better) |
| `account_id` | Account identifier |
| `account_label` | Account name/label |
| `account_image` | Account avatar URL |
| `total_pnl_raw/formatted` | Account's total PnL |
| `pnl_pct` | Account's ROI percentage |
| `win_rate` | Account's win rate |
| `total_position_count` | Account's total positions |
| `total_volume_raw/formatted` | Account's total trading volume |

### Leaderboard Stats Fields

| Field | Description |
|-------|-------------|
| `total_traders` | Count of accounts in leaderboard |
| `total_pnl_sum_raw/formatted` | Sum of all traders' PnL |
| `avg_pnl_raw/formatted` | Average PnL per trader |
| `median_pnl_raw/formatted` | Median PnL (50th percentile) |
| `total_volume_raw/formatted` | Sum of all trading volume |
| `avg_volume_raw/formatted` | Average volume per trader |
| `profitable_traders` | Count of traders with positive PnL |
| `unprofitable_traders` | Count of traders with non-positive PnL |
| `profitable_pct` | Percentage of profitable traders |

## Query Examples

### get_pnl_leaderboard

#### 1. Top 10 Traders by Total PnL (All Time)

```graphql
{
  get_pnl_leaderboard(args: {
    p_limit: 10
    p_sort_by: "total_pnl"
    p_sort_order: "DESC"
    p_time_filter: "all_time"
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    realized_pnl_formatted
    unrealized_pnl_formatted
    pnl_pct
    win_rate
    total_volume_formatted
    total_position_count
  }
}
```

#### 2. Top 10 by ROI % (Last 7 Days)

```graphql
{
  get_pnl_leaderboard(args: {
    p_limit: 10
    p_time_filter: "7d"
    p_sort_by: "pnl_pct"
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    pnl_pct
  }
}
```

#### 3. Newest Traders (Last 30 Days)

```graphql
{
  get_pnl_leaderboard(args: {
    p_limit: 10
    p_time_filter: "30d"
    p_sort_by: "newest"
  }) {
    rank
    account_id
    account_label
    first_position_at
    total_pnl_formatted
  }
}
```

#### 4. Most Improved Traders (Last 7 Days)

```graphql
{
  get_pnl_leaderboard(args: {
    p_limit: 10
    p_time_filter: "7d"
    p_sort_by: "most_improved"
  }) {
    rank
    account_id
    account_label
    pnl_change_formatted
    total_pnl_formatted
  }
}
```

#### 5. Filter by Minimum Volume and Positions

```graphql
{
  get_pnl_leaderboard(args: {
    p_limit: 50
    p_min_positions: 5
    p_min_volume: 10
    p_sort_by: "total_pnl"
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    total_position_count
    total_volume_formatted
  }
}
```

#### 6. Custom Date Range

```graphql
{
  get_pnl_leaderboard(args: {
    p_limit: 20
    p_time_filter: "custom"
    p_start_time: "2026-01-01T00:00:00Z"
    p_end_time: "2026-01-31T23:59:59Z"
    p_sort_by: "total_pnl"
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    pnl_change_formatted
  }
}
```

#### 7. Pagination (Page 3, 10 per page)

```graphql
{
  get_pnl_leaderboard(args: {
    p_limit: 10
    p_offset: 20
    p_sort_by: "total_pnl"
    p_time_filter: "all_time"
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
  }
}
```

---

### get_account_pnl_rank

#### 8. Get My Rank (All Time)

```graphql
{
  get_account_pnl_rank(args: {
    p_account_id: "0x91814fB52546fbFe050556c41Bdb56D9704f37D4"
    p_sort_by: "total_pnl"
    p_time_filter: "all_time"
  }) {
    rank
    total_accounts
    percentile
    account_id
    account_label
    total_pnl_formatted
    pnl_pct
    win_rate
    total_position_count
    total_volume_formatted
  }
}
```

#### 9. Get My Rank in a Specific Vault

```graphql
{
  get_account_pnl_rank(args: {
    p_account_id: "0x91814fB52546fbFe050556c41Bdb56D9704f37D4"
    p_sort_by: "pnl_pct"
    p_time_filter: "7d"
    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
  }) {
    rank
    percentile
    total_pnl_formatted
    pnl_pct
  }
}
```

---

### get_pnl_leaderboard_stats

#### 10. Global Stats (Last 30 Days)

```graphql
{
  get_pnl_leaderboard_stats(args: {
    p_time_filter: "30d"
  }) {
    total_traders
    total_pnl_sum_formatted
    avg_pnl_formatted
    median_pnl_formatted
    total_volume_formatted
    avg_volume_formatted
    profitable_traders
    unprofitable_traders
    profitable_pct
  }
}
```

#### 11. Stats for a Specific Vault

```graphql
{
  get_pnl_leaderboard_stats(args: {
    p_time_filter: "all_time"
    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
  }) {
    total_traders
    avg_pnl_formatted
    profitable_pct
  }
}
```

---

### get_vault_leaderboard

#### 12. Vault Leaderboard with Redeemable Assets (Linear Curve)

```graphql
{
  get_vault_leaderboard(args: {
    p_term_id: "0x7ec36d201c842dc787b45cb5bb753bea4cf849be3908fb1b0a7d067c3c3cc1f5"
    p_curve_id: "1"
    p_limit: 10
    p_sort_by: "total_pnl"
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    realized_pnl_formatted
    unrealized_pnl_formatted
    current_equity_value_formatted
    redeemable_assets_formatted
    pnl_pct
    win_rate
    total_volume_formatted
  }
}
```

#### 13. Vault Leaderboard (Offset Progressive Curve)

```graphql
{
  get_vault_leaderboard(args: {
    p_term_id: "0x5fb82a9ddd34419ac698e2b45c75cc1fda458b026c136dfe021342f77c4be4e3"
    p_curve_id: "2"
    p_limit: 10
    p_sort_by: "total_pnl"
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    current_equity_value_formatted
    redeemable_assets_formatted
  }
}
```

#### 14. Vault Sorted by Volume

```graphql
{
  get_vault_leaderboard(args: {
    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
    p_limit: 10
    p_sort_by: "total_volume"
    p_sort_order: "DESC"
  }) {
    rank
    account_id
    account_label
    redeemable_assets_formatted
    total_volume_formatted
    total_position_count
  }
}
```

---

### get_pnl_leaderboard_period

#### 15. Period Leaderboard (Specific Week)

```graphql
{
  get_pnl_leaderboard_period(args: {
    p_start_date: "2026-01-20T00:00:00Z"
    p_end_date: "2026-01-27T23:59:59Z"
    p_limit: 10
    p_sort_by: "total_pnl"
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    realized_pnl_formatted
    unrealized_pnl_formatted
    pnl_pct
    total_volume_formatted
    total_position_count
    win_rate
  }
}
```

#### 16. Period Leaderboard Sorted by ROI %

```graphql
{
  get_pnl_leaderboard_period(args: {
    p_start_date: "2026-01-27T00:00:00Z"
    p_end_date: "2026-02-03T23:59:59Z"
    p_limit: 20
    p_sort_by: "pnl_pct"
    p_min_volume: 1
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    pnl_pct
    total_volume_formatted
  }
}
```

#### 17. Period for a Specific Vault

```graphql
{
  get_pnl_leaderboard_period(args: {
    p_start_date: "2026-01-20T00:00:00Z"
    p_end_date: "2026-01-27T23:59:59Z"
    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
    p_limit: 10
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    pnl_pct
    current_equity_value_formatted
  }
}
```

#### 18. Period with Pagination

```graphql
{
  get_pnl_leaderboard_period(args: {
    p_start_date: "2026-01-20T00:00:00Z"
    p_end_date: "2026-02-03T23:59:59Z"
    p_limit: 10
    p_offset: 10
    p_sort_by: "total_pnl"
  }) {
    rank
    account_id
    total_pnl_formatted
  }
}
```

---

### get_vault_leaderboard_period

#### 19. Vault Period Leaderboard with Historical Redeemable Assets

```graphql
{
  get_vault_leaderboard_period(args: {
    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
    p_start_date: "2026-01-20T00:00:00Z"
    p_end_date: "2026-01-27T23:59:59Z"
    p_limit: 10
  }) {
    rank
    account_id
    account_label
    total_pnl_formatted
    realized_pnl_formatted
    unrealized_pnl_formatted
    redeemable_assets_formatted
    current_equity_value_formatted
    pnl_pct
    win_rate
    total_volume_formatted
  }
}
```

#### 20. Vault Period Sorted by Redeemable Assets

```graphql
{
  get_vault_leaderboard_period(args: {
    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
    p_start_date: "2026-01-20T00:00:00Z"
    p_end_date: "2026-01-27T23:59:59Z"
    p_limit: 10
    p_sort_by: "redeemable_assets"
  }) {
    rank
    account_id
    account_label
    redeemable_assets_formatted
    current_equity_value_formatted
    total_pnl_formatted
  }
}
```

#### 21. Vault Period with Curve Filter

```graphql
{
  get_vault_leaderboard_period(args: {
    p_term_id: "0x2fdb5b04829d14fc2f4191524e02c850f50fd98b16b4084a87cad0a28a8ca627"
    p_curve_id: "2"
    p_start_date: "2026-01-20T00:00:00Z"
    p_end_date: "2026-01-27T23:59:59Z"
    p_limit: 10
    p_sort_by: "total_pnl"
  }) {
    rank
    account_id
    total_pnl_formatted
    redeemable_assets_formatted
    pnl_pct
  }
}
```

---

### positions_with_value (View with redeemable_assets)

#### 22. Query Positions with Redeemable Assets

```graphql
{
  positions_with_value(
    where: { shares: { _gt: "0" } }
    limit: 5
  ) {
    account_id
    term_id
    curve_id
    shares
    theoretical_value
    pnl
    pnl_pct
    redeemable_assets
  }
}
```

#### 23. Positions for a Specific Account

```graphql
{
  positions_with_value(
    where: {
      account_id: { _eq: "0x91814fB52546fbFe050556c41Bdb56D9704f37D4" }
      shares: { _gt: "0" }
    }
  ) {
    term_id
    curve_id
    shares
    theoretical_value
    pnl
    pnl_pct
    redeemable_assets
    vault {
      total_shares
      total_assets
    }
  }
}
```

## Function Parameters

### get_pnl_leaderboard

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `p_limit` | INTEGER | 100 | Number of results (1-10000) |
| `p_offset` | INTEGER | 0 | Pagination offset |
| `p_time_filter` | TEXT | 'all_time' | Time filter preset |
| `p_start_time` | TIMESTAMPTZ | NULL | Custom start time |
| `p_end_time` | TIMESTAMPTZ | NULL | Custom end time |
| `p_sort_by` | TEXT | 'total_pnl' | Sort field |
| `p_sort_order` | TEXT | 'DESC' | Sort direction |
| `p_exclude_protocol_accounts` | BOOLEAN | TRUE | Exclude protocol accounts |
| `p_min_positions` | INTEGER | 1 | Minimum position count |
| `p_min_volume` | NUMERIC | 0 | Minimum volume (ETH) |
| `p_term_id` | TEXT | NULL | Filter to specific vault |

### get_account_pnl_rank

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `p_account_id` | TEXT | required | Account address |
| `p_sort_by` | TEXT | 'total_pnl' | Sort field for ranking |
| `p_time_filter` | TEXT | 'all_time' | Time filter preset |
| `p_term_id` | TEXT | NULL | Filter to specific vault |

### get_pnl_leaderboard_stats

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `p_time_filter` | TEXT | 'all_time' | Time filter preset |
| `p_term_id` | TEXT | NULL | Filter to specific vault |

### get_vault_leaderboard

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `p_term_id` | TEXT | required | Vault term ID |
| `p_curve_id` | NUMERIC | NULL | Optional curve ID filter |
| `p_limit` | INTEGER | 100 | Number of results (1-10000) |
| `p_offset` | INTEGER | 0 | Pagination offset |
| `p_sort_by` | TEXT | 'total_pnl' | Sort field |
| `p_sort_order` | TEXT | 'DESC' | Sort direction |

## Performance Optimizations

- Uses `position_change_daily` continuous aggregate for time-filtered queries
- Early filtering of accounts with activity in time window before full position scan
- New indexes:
  - `idx_position_account_shares` - for account aggregation on active positions
  - `idx_position_vault_account` - composite index for vault joins

## Period-Specific Functions

The `_period` functions calculate metrics **only for the specified date range**, not cumulative values. They use the `share_price_change` table for accurate historical valuations.

### Key Differences from Standard Functions

| Aspect | Standard Functions | Period Functions |
|--------|-------------------|------------------|
| PnL | Cumulative all-time | Only for the specified period |
| Share Prices | Current prices | Historical prices at period boundaries |
| Position Count | Total positions ever | Positions with activity in period |
| Redeemable Assets | Current vault state | Historical vault state at period end |

### How Period PnL is Calculated

```
Period Total PnL = (Equity at End - Equity at Start) + (Redemptions - Deposits)

Where:
- Equity at Start = Shares at start × Share price at start
- Equity at End = Shares at end × Share price at end
- Redemptions/Deposits = Activity during the period only
```

### get_pnl_leaderboard_period Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `p_start_date` | TIMESTAMPTZ | required | Period start date |
| `p_end_date` | TIMESTAMPTZ | required | Period end date |
| `p_limit` | INTEGER | 100 | Number of results (1-10000) |
| `p_offset` | INTEGER | 0 | Pagination offset |
| `p_sort_by` | TEXT | 'total_pnl' | Sort field |
| `p_sort_order` | TEXT | 'DESC' | Sort direction |
| `p_exclude_protocol_accounts` | BOOLEAN | TRUE | Exclude protocol accounts |
| `p_min_positions` | INTEGER | 1 | Minimum positions in period |
| `p_min_volume` | NUMERIC | 0 | Minimum volume in period (ETH) |
| `p_term_id` | TEXT | NULL | Filter to specific vault |

### get_vault_leaderboard_period Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `p_term_id` | TEXT | required | Vault term ID |
| `p_start_date` | TIMESTAMPTZ | required | Period start date |
| `p_end_date` | TIMESTAMPTZ | required | Period end date |
| `p_curve_id` | NUMERIC | NULL | Optional curve ID filter |
| `p_limit` | INTEGER | 100 | Number of results (1-10000) |
| `p_offset` | INTEGER | 0 | Pagination offset |
| `p_sort_by` | TEXT | 'total_pnl' | Sort field (also supports `redeemable_assets`) |
| `p_sort_order` | TEXT | 'DESC' | Sort direction |

## Notes

- `redeemable_assets` is only calculated for vault leaderboards (returns NULL for main leaderboard)
- Protocol accounts (`ProtocolVault`, `AtomWallet`) are excluded by default
- Input validation: limits clamped 1-10000, offsets must be non-negative
- Division by zero protection using `NULLIF()` throughout
- Period functions use `share_price_change` table for historical valuations
- If no share price exists before a date, equity is calculated as 0
