### PR TITLE
feat: add ProtocolFeeAccrued event support

### DIFF
--- a/apps/consumer/src/mode/decoded/mod.rs
+++ b/apps/consumer/src/mode/decoded/mod.rs
@@ -1,6 +1,7 @@
 pub mod atom_created;
 pub mod deposited;
 pub mod initialized;
+pub mod protocol_fee_accrued;
 pub mod redeemed;
 pub mod share_price_changed;
 pub mod triple_created;

--- a/apps/consumer/src/mode/decoded/protocol_fee_accrued/event.rs
+++ b/apps/consumer/src/mode/decoded/protocol_fee_accrued/event.rs
@@ -1,0 +1,51 @@
+use crate::{
+    error::ConsumerError,
+    mode::{decoded::utils::get_block_timestamp, types::DecodedConsumerContext},
+    schemas::types::DecodedMessage,
+    supported_contracts::v2_contract::Multivault::ProtocolFeeAccrued,
+};
+use alloy::primitives::Uint;
+use models::{
+    protocol_fee_accrued::ProtocolFeeAccrued as ProtocolFeeAccruedModel, traits::SimpleCrud,
+    types::U256Wrapper,
+};
+
+pub trait ProtocolFeeAccruedEvent {
+    fn epoch(&self) -> Result<Uint<256, 4>, ConsumerError>;
+    fn sender(&self) -> Result<String, ConsumerError>;
+    fn amount(&self) -> Result<Uint<256, 4>, ConsumerError>;
+
+    async fn create_protocol_fee_accrued(
+        &self,
+        event: &DecodedMessage,
+        decoded_consumer_context: &DecodedConsumerContext,
+    ) -> Result<ProtocolFeeAccruedModel, ConsumerError> {
+        ProtocolFeeAccruedModel::builder()
+            .id(DecodedMessage::event_id(event))
+            .epoch(U256Wrapper::from(self.epoch()?))
+            .sender_id(self.sender()?)
+            .amount(U256Wrapper::from(self.amount()?))
+            .block_number(U256Wrapper::try_from(event.block_number)?)
+            .created_at(get_block_timestamp(event.block_timestamp)?)
+            .transaction_hash(event.transaction_hash.clone())
+            .build()
+            .upsert(
+                &decoded_consumer_context.backend_schema,
+                &decoded_consumer_context.pg_pool,
+            )
+            .await
+            .map_err(ConsumerError::ModelError)
+    }
+}
+
+impl ProtocolFeeAccruedEvent for &ProtocolFeeAccrued {
+    fn epoch(&self) -> Result<Uint<256, 4>, ConsumerError> {
+        Ok(self.epoch)
+    }
+    fn sender(&self) -> Result<String, ConsumerError> {
+        Ok(self.sender.to_string())
+    }
+    fn amount(&self) -> Result<Uint<256, 4>, ConsumerError> {
+        Ok(self.amount)
+    }
+}

--- a/apps/consumer/src/mode/decoded/protocol_fee_accrued/event_handler.rs
+++ b/apps/consumer/src/mode/decoded/protocol_fee_accrued/event_handler.rs
@@ -1,0 +1,94 @@
+use std::fmt::Debug;
+
+use models::{
+    event::{Event, EventType},
+    protocol_fee_accrued::ProtocolFeeAccrued,
+    traits::SimpleCrud,
+    types::U256Wrapper,
+};
+use tracing::{debug, info};
+
+use crate::{
+    error::ConsumerError,
+    mode::{
+        decoded::utils::{EventHandler, get_block_timestamp},
+        types::DecodedConsumerContext,
+        utils::get_or_create_account,
+    },
+    schemas::types::DecodedMessage,
+};
+
+use super::event::ProtocolFeeAccruedEvent;
+
+#[derive(Debug)]
+pub struct ProtocolFeeAccruedEventHandler<T>(pub T);
+
+impl<T> EventHandler for ProtocolFeeAccruedEventHandler<T>
+where
+    T: ProtocolFeeAccruedEvent + Debug + Sync + Send,
+{
+    async fn process_event(
+        &self,
+        decoded_consumer_context: &DecodedConsumerContext,
+        event: &DecodedMessage,
+    ) -> Result<(), ConsumerError> {
+        info!("Handling ProtocolFeeAccrued event: {self:#?}");
+
+        // Check if the protocol fee accrued already exists, skip if it does
+        match ProtocolFeeAccrued::find_by_id(
+            DecodedMessage::event_id(event),
+            &decoded_consumer_context.backend_schema,
+            &decoded_consumer_context.pg_pool,
+        )
+        .await?
+        {
+            Some(protocol_fee_accrued) => {
+                debug!(
+                    "ProtocolFeeAccrued already exists: {:?}",
+                    protocol_fee_accrued
+                );
+                return Ok(());
+            }
+            None => {
+                debug!("ProtocolFeeAccrued does not exist, creating it");
+            }
+        }
+
+        // Create or retrieve the sender account
+        let _sender =
+            get_or_create_account(self.0.sender()?, decoded_consumer_context, None).await?;
+
+        // Create the protocol fee accrued record
+        self.0
+            .create_protocol_fee_accrued(event, decoded_consumer_context)
+            .await?;
+
+        // Create the event record
+        self.create_event(decoded_consumer_context, event).await?;
+
+        Ok(())
+    }
+
+    async fn create_event(
+        &self,
+        decoded_consumer_context: &DecodedConsumerContext,
+        event: &DecodedMessage,
+    ) -> Result<(), ConsumerError> {
+        Event::builder()
+            .id(DecodedMessage::event_id(event))
+            .event_type(EventType::ProtocolFeeAccrued)
+            .protocol_fee_accrued_id(DecodedMessage::event_id(event))
+            .block_number(U256Wrapper::try_from(event.block_number)?)
+            .created_at(get_block_timestamp(event.block_timestamp)?)
+            .transaction_hash(event.transaction_hash.clone())
+            .build()
+            .upsert(
+                &decoded_consumer_context.backend_schema,
+                &decoded_consumer_context.pg_pool,
+            )
+            .await
+            .map_err(ConsumerError::ModelError)?;
+
+        Ok(())
+    }
+}

--- a/apps/consumer/src/mode/decoded/protocol_fee_accrued/mod.rs
+++ b/apps/consumer/src/mode/decoded/protocol_fee_accrued/mod.rs
@@ -1,0 +1,2 @@
+pub mod event;
+pub mod event_handler;

--- a/apps/consumer/src/supported_contracts/v2_contract.rs
+++ b/apps/consumer/src/supported_contracts/v2_contract.rs
@@ -18,6 +18,7 @@ use crate::{
             deposited::event_handler::DepositedEventHandler,
             // fee_transferred::event_handler::FeeTransferredEventHandler,
             initialized::event_handler::InitializeEventHandler,
+            protocol_fee_accrued::event_handler::ProtocolFeeAccruedEventHandler,
             redeemed::event_handler::RedeemedEventHandler,
             share_price_changed::event_handler::SharePriceChangedEventHandler,
             triple_created::event_handler::TripleCreatedEventHandler,
@@ -122,6 +123,16 @@ impl EventProcessor for &MultivaultEvents {
                     .start_timer();
                 debug!("Received: {share_price_changed_data:#?}");
                 SharePriceChangedEventHandler(share_price_changed_data)
+                    .process_event(context, message)
+                    .await?;
+                timer.observe_duration();
+            }
+            MultivaultEvents::ProtocolFeeAccrued(protocol_fee_accrued_data) => {
+                let timer = get_event_processing_histogram()
+                    .with_label_values(&["ProtocolFeeAccrued"])
+                    .start_timer();
+                debug!("Received: {protocol_fee_accrued_data:#?}");
+                ProtocolFeeAccruedEventHandler(protocol_fee_accrued_data)
                     .process_event(context, message)
                     .await?;
                 timer.observe_duration();

--- a/apps/models/src/error.rs
+++ b/apps/models/src/error.rs
@@ -70,6 +70,8 @@ pub enum ModelError {
     InsertError(String),
     #[error("Failed to insert data for fee transfer: {0}")]
     FeeTransferInsertError(String),
+    #[error("Failed to insert data for protocol fee accrued: {0}")]
+    ProtocolFeeAccruedInsertError(String),
     #[error("Failed to insert data for position: {0}")]
     PositionInsertError(String),
     #[error("Invalid atom type: {0}")]

--- a/apps/models/src/event.rs
+++ b/apps/models/src/event.rs
@@ -18,6 +18,7 @@ pub enum EventType {
     Deposited,
     Redeemed,
     FeesTransfered,
+    ProtocolFeeAccrued,
 }
 
 /// This struct represents an event in the database. Note that only one of the
@@ -33,6 +34,7 @@ pub struct Event {
     pub fee_transfer_id: Option<String>,
     pub deposit_id: Option<String>,
     pub redemption_id: Option<String>,
+    pub protocol_fee_accrued_id: Option<String>,
     pub block_number: U256Wrapper,
     pub created_at: DateTime<Utc>,
     pub transaction_hash: String,
@@ -54,8 +56,8 @@ impl SimpleCrud<String> for Event {
     {
         let query = format!(
             r#"
-            INSERT INTO {}.event (id, type, atom_id, triple_id, fee_transfer_id, deposit_id, redemption_id, block_number, created_at, transaction_hash)
-            VALUES ($1, $2::text::{}.event_type, $3, $4, $5, $6, $7, $8, $9, $10)
+            INSERT INTO {}.event (id, type, atom_id, triple_id, fee_transfer_id, deposit_id, redemption_id, protocol_fee_accrued_id, block_number, created_at, transaction_hash)
+            VALUES ($1, $2::text::{}.event_type, $3, $4, $5, $6, $7, $8, $9, $10, $11)
             ON CONFLICT (id) DO UPDATE SET
                 type = EXCLUDED.type,
                 atom_id = EXCLUDED.atom_id,
@@ -63,10 +65,11 @@ impl SimpleCrud<String> for Event {
                 fee_transfer_id = EXCLUDED.fee_transfer_id,
                 deposit_id = EXCLUDED.deposit_id,
                 redemption_id = EXCLUDED.redemption_id,
+                protocol_fee_accrued_id = EXCLUDED.protocol_fee_accrued_id,
                 block_number = EXCLUDED.block_number,
                 created_at = EXCLUDED.created_at,
                 transaction_hash = EXCLUDED.transaction_hash
-            RETURNING id, type as event_type, atom_id, triple_id, fee_transfer_id, deposit_id, redemption_id, block_number, created_at, transaction_hash
+            RETURNING id, type as event_type, atom_id, triple_id, fee_transfer_id, deposit_id, redemption_id, protocol_fee_accrued_id, block_number, created_at, transaction_hash
             "#,
             schema, schema
         );
@@ -79,6 +82,7 @@ impl SimpleCrud<String> for Event {
             .bind(self.fee_transfer_id.clone())
             .bind(self.deposit_id.clone())
             .bind(self.redemption_id.clone())
+            .bind(self.protocol_fee_accrued_id.clone())
             .bind(self.block_number.to_big_decimal()?)
             .bind(self.created_at)
             .bind(&self.transaction_hash)
@@ -104,6 +108,7 @@ impl SimpleCrud<String> for Event {
                    fee_transfer_id,
                    deposit_id,
                    redemption_id,
+                   protocol_fee_accrued_id,
                    block_number,
                    created_at,
                    transaction_hash

--- a/apps/models/src/lib.rs
+++ b/apps/models/src/lib.rs
@@ -17,6 +17,7 @@ pub mod json_object;
 pub mod organization;
 pub mod person;
 pub mod position;
+pub mod protocol_fee_accrued;
 pub mod raw_logs;
 pub mod redemption;
 pub mod share_price_change;

--- a/apps/models/src/protocol_fee_accrued.rs
+++ b/apps/models/src/protocol_fee_accrued.rs
@@ -1,0 +1,108 @@
+use crate::{
+    error::ModelError,
+    traits::{Model, SimpleCrud},
+    types::U256Wrapper,
+};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use sqlx::{Executor, Postgres};
+
+/// This struct represents a protocol fee accrued event in the database.
+/// Note that `sender_id` is a foreign key to the `account` table.
+#[derive(sqlx::FromRow, Debug, PartialEq, Clone, Builder)]
+#[sqlx(type_name = "protocol_fee_accrued")]
+pub struct ProtocolFeeAccrued {
+    pub id: String,
+    pub epoch: U256Wrapper,
+    pub sender_id: String,
+    pub amount: U256Wrapper,
+    pub block_number: U256Wrapper,
+    pub created_at: DateTime<Utc>,
+    pub transaction_hash: String,
+}
+
+/// This is a trait that all models must implement.
+impl Model for ProtocolFeeAccrued {}
+
+/// This trait works as a contract for all models that need to be upserted into the database.
+#[async_trait]
+impl SimpleCrud<String> for ProtocolFeeAccrued {
+    /// Upserts a protocol fee accrued record in the database.
+    /// If a record with the same ID exists, it will be updated, otherwise a new record will be created.
+    async fn upsert<'e, E>(&self, schema: &str, executor: E) -> Result<Self, ModelError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let query = format!(
+            r#"
+            INSERT INTO {}.protocol_fee_accrued (
+                id, epoch, sender_id, amount, block_number, created_at, transaction_hash
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (id) DO UPDATE SET
+                epoch = EXCLUDED.epoch,
+                sender_id = EXCLUDED.sender_id,
+                amount = EXCLUDED.amount,
+                block_number = EXCLUDED.block_number,
+                created_at = EXCLUDED.created_at,
+                transaction_hash = EXCLUDED.transaction_hash
+            WHERE
+                protocol_fee_accrued.epoch IS DISTINCT FROM EXCLUDED.epoch OR
+                protocol_fee_accrued.sender_id IS DISTINCT FROM EXCLUDED.sender_id OR
+                protocol_fee_accrued.amount IS DISTINCT FROM EXCLUDED.amount OR
+                protocol_fee_accrued.block_number IS DISTINCT FROM EXCLUDED.block_number OR
+                protocol_fee_accrued.created_at IS DISTINCT FROM EXCLUDED.created_at OR
+                protocol_fee_accrued.transaction_hash IS DISTINCT FROM EXCLUDED.transaction_hash
+            RETURNING
+                id, epoch, sender_id,
+                amount,
+                block_number,
+                created_at,
+                transaction_hash
+            "#,
+            schema,
+        );
+
+        sqlx::query_as::<_, ProtocolFeeAccrued>(&query)
+            .bind(self.id.clone())
+            .bind(self.epoch.to_big_decimal()?)
+            .bind(self.sender_id.clone())
+            .bind(self.amount.to_big_decimal()?)
+            .bind(self.block_number.to_big_decimal()?)
+            .bind(self.created_at)
+            .bind(self.transaction_hash.clone())
+            .fetch_one(executor)
+            .await
+            .map_err(|e| ModelError::ProtocolFeeAccruedInsertError(e.to_string()))
+    }
+
+    /// Finds a protocol fee accrued record by its ID.
+    /// Returns None if no record is found.
+    async fn find_by_id<'e, E>(
+        id: String,
+        schema: &str,
+        executor: E,
+    ) -> Result<Option<Self>, ModelError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let query = format!(
+            r#"
+            SELECT
+                id, epoch, sender_id,
+                amount,
+                block_number,
+                created_at,
+                transaction_hash
+            FROM {}.protocol_fee_accrued
+            WHERE id = $1
+            "#,
+            schema,
+        );
+
+        sqlx::query_as::<_, ProtocolFeeAccrued>(&query)
+            .bind(id)
+            .fetch_optional(executor)
+            .await
+            .map_err(|e| crate::error::ModelError::QueryError(e.to_string()))
+    }
+}

--- a/infrastructure/hasura/metadata/databases/intuition/tables/public_event.yaml
+++ b/infrastructure/hasura/metadata/databases/intuition/tables/public_event.yaml
@@ -44,6 +44,15 @@ object_relationships:
         remote_table:
           name: redemption
           schema: public
+  - name: protocol_fee_accrued
+    using:
+      manual_configuration:
+        column_mapping:
+          protocol_fee_accrued_id: id
+        insertion_order: null
+        remote_table:
+          name: protocol_fee_accrued
+          schema: public
   - name: triple
     using:
       manual_configuration:
@@ -65,6 +74,7 @@ select_permissions:
         - deposit_id
         - fee_transfer_id
         - id
+        - protocol_fee_accrued_id
         - redemption_id
         - type
       filter: {}
@@ -82,6 +92,7 @@ select_permissions:
         - deposit_id
         - fee_transfer_id
         - id
+        - protocol_fee_accrued_id
         - redemption_id
         - type
       filter: {}

--- a/infrastructure/hasura/metadata/databases/intuition/tables/public_protocol_fee_accrued.yaml
+++ b/infrastructure/hasura/metadata/databases/intuition/tables/public_protocol_fee_accrued.yaml
@@ -1,0 +1,48 @@
+table:
+  name: protocol_fee_accrued
+  schema: public
+configuration:
+  column_config: {}
+  custom_column_names: {}
+  custom_name: protocol_fee_accruals
+  custom_root_fields:
+    select_by_pk: protocol_fee_accrued
+object_relationships:
+  - name: sender
+    using:
+      manual_configuration:
+        column_mapping:
+          sender_id: id
+        insertion_order: null
+        remote_table:
+          name: account
+          schema: public
+select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+        - id
+        - epoch
+        - sender_id
+        - amount
+        - block_number
+        - created_at
+        - transaction_hash
+      filter: {}
+      limit: 250
+      allow_aggregations: true
+    comment: ""
+  - role: frontend
+    permission:
+      columns:
+        - id
+        - epoch
+        - sender_id
+        - amount
+        - block_number
+        - created_at
+        - transaction_hash
+      filter: {}
+      limit: 250
+      allow_aggregations: true
+    comment: ""

--- a/infrastructure/hasura/metadata/databases/intuition/tables/tables.yaml
+++ b/infrastructure/hasura/metadata/databases/intuition/tables/tables.yaml
@@ -16,6 +16,7 @@
 - "!include public_pnl_leaderboard_entry.yaml"
 - "!include public_pnl_leaderboard_stats.yaml"
 - "!include public_position.yaml"
+- "!include public_protocol_fee_accrued.yaml"
 - "!include public_position_change.yaml"
 - "!include public_position_change_daily.yaml"
 - "!include public_position_change_hourly.yaml"

--- a/infrastructure/hasura/migrations/intuition/1770384689000_add_protocol_fee_accrued/down.sql
+++ b/infrastructure/hasura/migrations/intuition/1770384689000_add_protocol_fee_accrued/down.sql
@@ -1,0 +1,10 @@
+-- Rollback ProtocolFeeAccrued event support
+
+-- Remove protocol_fee_accrued_id column from event table
+ALTER TABLE event DROP COLUMN IF EXISTS protocol_fee_accrued_id;
+
+-- Drop protocol_fee_accrued table and indexes
+DROP TABLE IF EXISTS protocol_fee_accrued;
+
+-- Note: PostgreSQL does not support removing values from enums.
+-- The 'ProtocolFeeAccrued' value will remain in the event_type enum.

--- a/infrastructure/hasura/migrations/intuition/1770384689000_add_protocol_fee_accrued/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1770384689000_add_protocol_fee_accrued/up.sql
@@ -1,0 +1,24 @@
+-- Add ProtocolFeeAccrued event support
+
+-- Add new value to event_type enum
+ALTER TYPE event_type ADD VALUE IF NOT EXISTS 'ProtocolFeeAccrued';
+
+-- Create protocol_fee_accrued table
+CREATE TABLE IF NOT EXISTS protocol_fee_accrued (
+  id TEXT PRIMARY KEY NOT NULL,
+  epoch NUMERIC(78, 0) NOT NULL,
+  sender_id TEXT NOT NULL,
+  amount NUMERIC(78, 0) NOT NULL,
+  block_number NUMERIC(78, 0) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  transaction_hash TEXT NOT NULL
+);
+
+-- Add indexes
+CREATE INDEX IF NOT EXISTS idx_protocol_fee_accrued_sender_id ON protocol_fee_accrued(sender_id);
+CREATE INDEX IF NOT EXISTS idx_protocol_fee_accrued_epoch ON protocol_fee_accrued(epoch);
+CREATE INDEX IF NOT EXISTS idx_protocol_fee_accrued_block_number ON protocol_fee_accrued(block_number);
+CREATE INDEX IF NOT EXISTS idx_protocol_fee_accrued_created_at ON protocol_fee_accrued(created_at);
+
+-- Add protocol_fee_accrued_id column to event table
+ALTER TABLE event ADD COLUMN IF NOT EXISTS protocol_fee_accrued_id TEXT;


### PR DESCRIPTION
## Summary
Adds new ProtocolFeeAccrued event type across the stack: database migration, model implementation, consumer event handler with account linking, and Hasura metadata configuration.

## Changes
- New database table with indexes for sender, epoch, block number, and timestamp
- Event model and trait with upsert logic
- Consumer event handler with duplicate detection and account linking
- Event table integration and Hasura GraphQL metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)