### PR TITLE
TNS integration

### DIFF
--- a/apps/consumer/src/config.rs
+++ b/apps/consumer/src/config.rs
@@ -21,6 +21,7 @@ pub struct Env {
     pub database_url: String,
     pub decoded_logs_stream: Option<String>,
     pub ens_contract_address: Option<String>,
+    pub universal_resolver_address: Option<String>,
     pub image_guard_url: Option<String>,
     pub indexing_source: Option<String>,
     pub intuition_contract_address: Option<String>,

--- a/apps/consumer/src/consumer_type/redis_streams.rs
+++ b/apps/consumer/src/consumer_type/redis_streams.rs
@@ -7,13 +7,43 @@ use crate::{
     traits::{BasicConsumer, Message},
 };
 use async_trait::async_trait;
-use redis::{Client as RedisClient, aio::ConnectionManager};
+use futures::future::join_all;
+use redis::{Client as RedisClient, Value as RedisValue, aio::ConnectionManager};
 use std::process;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tracing::{debug, info};
+use tokio::sync::Semaphore;
+use tracing::{debug, info, warn};
 
-/// Represents the Redis Streams consumer
+/// Min idle time (ms) before we claim a message from another consumer (e.g. dead pod).
+const PENDING_CLAIM_MIN_IDLE_MS: u64 = 30_000;
+
+const DEFAULT_BATCH_SIZE: usize = 100;
+const DEFAULT_CONCURRENCY: usize = 10;
+
+/// Messages that fail more than this many times are ACKed and skipped (poison pill protection).
+const MAX_DELIVERY_COUNT: usize = 5;
+
+/// Max messages to fetch per XREADGROUP call. Override with CONSUMER_BATCH_SIZE env var.
+fn batch_size() -> usize {
+    std::env::var("CONSUMER_BATCH_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_BATCH_SIZE)
+}
+
+/// Max concurrent message processing. Override with CONSUMER_CONCURRENCY env var.
+fn concurrency() -> usize {
+    std::env::var("CONSUMER_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_CONCURRENCY)
+}
+
+/// Redis Streams consumer. We never delete or remove stream entries:
+/// - XACK only marks a message as processed for the consumer group (removes from PEL); the entry stays in the stream.
+/// - XCLAIM only reassigns PEL ownership; the message is not removed.
+/// - We do not use XDEL, XTRIM, or any other command that would drop messages.
 pub struct RedisStreams {
     connection_manager: ConnectionManager,
     input_stream: Arc<String>,
@@ -45,7 +75,10 @@ impl RedisStreams {
             .query_async(&mut connection_manager.clone())
             .await;
 
-        info!("Starting Redis consumer with name: {}", consumer_name);
+        info!(
+            "Starting Redis consumer stream={} group={} name={}",
+            input_stream, consumer_group, consumer_name
+        );
 
         Ok(Self {
             // client,
@@ -133,13 +166,153 @@ impl RedisStreams {
         info!("Cleaned up consumer: {}", self.get_consumer_name());
         Ok(())
     }
+
+    /// Claims pending messages that have been idle longer than PENDING_CLAIM_MIN_IDLE_MS
+    /// (e.g. assigned to a consumer that crashed). This prevents messages from staying stuck.
+    async fn claim_stale_pending(
+        &self,
+        connection: &mut ConnectionManager,
+    ) -> Result<(), ConsumerError> {
+        // XPENDING stream group - + count  => list of [id, consumer, idle_ms, delivery_count]
+        let raw: Result<RedisValue, redis::RedisError> = redis::cmd("XPENDING")
+            .arg(&*self.get_input_stream())
+            .arg(&*self.get_consumer_group())
+            .arg("-")
+            .arg("+")
+            .arg(100)
+            .query_async(connection)
+            .await;
+
+        let list = match raw {
+            Ok(RedisValue::Array(entries)) => entries,
+            Ok(RedisValue::Nil) | Ok(_) => return Ok(()),
+            Err(e) => {
+                warn!("XPENDING failed (stream/group may not exist yet): {}", e);
+                return Ok(());
+            }
+        };
+
+        let our_name = self.get_consumer_name().to_string();
+        let stream = &*self.get_input_stream();
+        let group = &*self.get_consumer_group();
+        let mut claimed_count = 0usize;
+        let mut skipped_count = 0usize;
+
+        for entry in list {
+            // Each entry is [id, consumer, idle_ms, delivery_count]
+            let (id, consumer, idle_ms, delivery_count) =
+                match Self::parse_pending_entry(&entry) {
+                    Some(t) => t,
+                    None => continue,
+                };
+
+            // Poison pill: message has been retried too many times — XACK and skip it
+            if delivery_count >= MAX_DELIVERY_COUNT as i64 {
+                warn!(
+                    "Skipping poison pill message {} (delivery_count={}, owned by {})",
+                    id, delivery_count, consumer
+                );
+                let _: Result<i32, redis::RedisError> = redis::cmd("XACK")
+                    .arg(stream)
+                    .arg(group)
+                    .arg(&id)
+                    .query_async(connection)
+                    .await;
+                skipped_count += 1;
+                continue;
+            }
+
+            if idle_ms >= PENDING_CLAIM_MIN_IDLE_MS as i64 && consumer != our_name {
+                let result: Result<Vec<(String, Vec<(String, String)>)>, redis::RedisError> =
+                    redis::cmd("XCLAIM")
+                        .arg(stream)
+                        .arg(group)
+                        .arg(&our_name)
+                        .arg(PENDING_CLAIM_MIN_IDLE_MS)
+                        .arg(&id)
+                        .query_async(connection)
+                        .await;
+                match &result {
+                    Ok(claimed) => {
+                        claimed_count += claimed.len();
+                    }
+                    Err(e) => {
+                        warn!("XCLAIM failed for {}: {}", id, e);
+                    }
+                }
+            }
+        }
+
+        if claimed_count > 0 {
+            info!(
+                "Claimed {} stale pending message(s) from other consumers",
+                claimed_count
+            );
+        }
+        if skipped_count > 0 {
+            warn!(
+                "Skipped {} poison pill message(s) (exceeded {} deliveries)",
+                skipped_count, MAX_DELIVERY_COUNT
+            );
+        }
+        Ok(())
+    }
+
+    /// Parse one XPENDING entry: [id, consumer, idle_ms, delivery_count].
+    fn parse_pending_entry(entry: &RedisValue) -> Option<(String, String, i64, i64)> {
+        let arr = match entry {
+            RedisValue::Array(a) => a,
+            _ => return None,
+        };
+        if arr.len() < 4 {
+            return None;
+        }
+        let id = match &arr[0] {
+            RedisValue::BulkString(s) => String::from_utf8_lossy(s).into_owned(),
+            _ => return None,
+        };
+        let consumer = match &arr[1] {
+            RedisValue::BulkString(s) => String::from_utf8_lossy(s).into_owned(),
+            _ => return None,
+        };
+        let idle_ms: i64 = match &arr[2] {
+            RedisValue::Int(i) => *i,
+            RedisValue::BulkString(s) => String::from_utf8_lossy(s).parse::<i64>().ok()?,
+            _ => return None,
+        };
+        let delivery_count: i64 = match &arr[3] {
+            RedisValue::Int(i) => *i,
+            RedisValue::BulkString(s) => String::from_utf8_lossy(s).parse::<i64>().ok()?,
+            _ => 0,
+        };
+        Some((id, consumer, idle_ms, delivery_count))
+    }
+
+    fn parse_stream_entries(
+        stream_data: Vec<(String, Vec<(String, Vec<(String, String)>)>)>,
+    ) -> Vec<Message> {
+        let mut messages = Vec::new();
+        for (_, entries) in stream_data {
+            for (message_id, fields) in entries {
+                let mut message_body = String::new();
+                for (key, value) in fields {
+                    if key == "body" {
+                        message_body = value;
+                        break;
+                    }
+                }
+                messages.push(Message::new(message_id, message_body));
+            }
+        }
+        messages
+    }
 }
 
 #[async_trait]
 impl BasicConsumer for RedisStreams {
-    /// This function acknowledges a message by marking it as processed in the consumer group
+    /// Acknowledges a message after successful processing. XACK only removes it from the
+    /// group's PEL; the stream entry is never deleted. Only called after process_message succeeds.
     async fn consume_message(&self, message: Message) -> Result<(), ConsumerError> {
-        // For Redis streams, we need to acknowledge the message using XACK
         let mut connection = self.connection_manager.clone();
         let _: Result<i32, redis::RedisError> = redis::cmd("XACK")
             .arg(&*self.get_input_stream())
@@ -158,20 +331,54 @@ impl BasicConsumer for RedisStreams {
         let mut backoff_ms = 0;
         let max_backoff = 1000; // 1 second max delay
         let mut total_processed = 0u64;
+        let mut empty_count: u64 = 0;
 
         loop {
             debug!("awaiting for new messages from Redis stream...");
             let messages = self.receive_message().await?;
 
             if !messages.is_empty() {
-                // Reset backoff when messages are found
+                empty_count = 0;
                 backoff_ms = 0;
                 let batch_size = messages.len();
                 let start = std::time::Instant::now();
 
-                for message in messages {
-                    mode.process_message(message.body.clone()).await?;
-                    self.consume_message(message).await?
+                // Process up to concurrency() messages at a time (I/O-bound: IPFS, RPC, DB)
+                let sem = Arc::new(Semaphore::new(concurrency()));
+                let mode = mode.clone();
+                let tasks: Vec<_> = messages
+                    .into_iter()
+                    .map(|message| {
+                        let mode = mode.clone();
+                        let sem = sem.clone();
+                        tokio::spawn(async move {
+                            let _permit = sem.acquire().await;
+                            let res = mode.process_message(message.body.clone()).await;
+                            (message, res)
+                        })
+                    })
+                    .collect();
+                let results = join_all(tasks).await;
+
+                let mut failed_count = 0usize;
+                for join_result in results {
+                    let (message, process_result) = join_result.map_err(ConsumerError::from)?;
+                    match process_result {
+                        Ok(()) => self.consume_message(message).await?,
+                        Err(e) => {
+                            failed_count += 1;
+                            warn!(
+                                "Failed to process message {}: {}. Left in PEL for retry.",
+                                message.message_id, e
+                            );
+                        }
+                    }
+                }
+                if failed_count > 0 {
+                    warn!(
+                        "{} message(s) failed in batch, will retry from PEL next iteration",
+                        failed_count
+                    );
                 }
 
                 let elapsed = start.elapsed();
@@ -181,58 +388,93 @@ impl BasicConsumer for RedisStreams {
                     batch_size, elapsed, total_processed
                 );
             } else {
-                // Implement exponential backoff with max limit
+                empty_count += 1;
+                // Log periodically when we've never received any message (e.g. wrong Redis/stream)
+                if total_processed == 0 && empty_count > 0 && empty_count % 60 == 1 {
+                    info!(
+                        "Idle: no messages after {} tries (stream={} group={}); verify REDIS_URL and RESOLVER_STREAM match where messages are produced",
+                        empty_count,
+                        self.get_input_stream().as_ref(),
+                        self.get_consumer_group().as_ref()
+                    );
+                }
                 backoff_ms = (backoff_ms * 2 + 100).min(max_backoff);
                 tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
             }
         }
     }
 
-    /// This function reads messages from the Redis stream using XREADGROUP
+    /// This function reads messages from the Redis stream using XREADGROUP.
+    /// First claims stale pending messages (from dead consumers), then reads our pending (id "0"),
+    /// then new messages (">"). This prevents messages from getting stuck after pod restarts.
     async fn receive_message(&self) -> Result<Vec<Message>, ConsumerError> {
         let mut connection = self.connection_manager.clone();
+        let stream = &*self.get_input_stream();
+        let group = &*self.get_consumer_group();
+        let consumer = &*self.get_consumer_name();
 
-        // Use XREADGROUP to read messages from the stream
+        // Claim messages that have been pending on other consumers for too long (e.g. dead pods)
+        self.claim_stale_pending(&mut connection).await?;
+
+        // 1) Non-blocking read of our pending (including just-claimed)
+        let pending: Result<
+            Vec<(String, Vec<(String, Vec<(String, String)>)>)>,
+            redis::RedisError,
+        > = redis::cmd("XREADGROUP")
+            .arg("GROUP")
+            .arg(group)
+            .arg(consumer)
+            .arg("COUNT")
+            .arg(batch_size())
+            .arg("STREAMS")
+            .arg(stream)
+            .arg("0")
+            .query_async(&mut connection)
+            .await;
+
+        if let Ok(stream_data) = pending {
+            let messages = Self::parse_stream_entries(stream_data);
+            if !messages.is_empty() {
+                info!("Received {} message(s) from pending (PEL)", messages.len());
+                return Ok(messages);
+            }
+        } else if let Err(e) = &pending {
+            warn!("XREADGROUP pending (0) failed: {}", e);
+        }
+
+        // 2) Blocking read of new messages only
         let result: Result<Vec<(String, Vec<(String, Vec<(String, String)>)>)>, redis::RedisError> =
             redis::cmd("XREADGROUP")
                 .arg("GROUP")
-                .arg(&*self.get_consumer_group())
-                .arg(&*self.get_consumer_name())
+                .arg(group)
+                .arg(consumer)
                 .arg("COUNT")
-                .arg(10)
+                .arg(batch_size())
                 .arg("BLOCK")
                 .arg(1000)
                 .arg("STREAMS")
-                .arg(&*self.get_input_stream())
+                .arg(stream)
                 .arg(">")
                 .query_async(&mut connection)
                 .await;
 
         match result {
             Ok(stream_data) => {
-                let mut messages = Vec::<Message>::new();
-
-                for (_, entries) in stream_data {
-                    for (message_id, fields) in entries {
-                        // Convert Redis stream message to SQS-like Message format
-                        let mut message_body = String::new();
-                        for (key, value) in fields {
-                            if key == "body" {
-                                message_body = value;
-                                break;
-                            }
-                        }
-                        messages.push(Message::new(message_id, message_body));
-                    }
+                let messages = Self::parse_stream_entries(stream_data);
+                if !messages.is_empty() {
+                    info!("Received {} message(s) from new (>)", messages.len());
+                } else {
+                    debug!("XREADGROUP '>' returned empty batch");
                 }
-
                 Ok(messages)
             }
             Err(e) => {
-                if e.to_string().contains("timeout") {
-                    // No messages available, return empty result
-                    Ok(Vec::<Message>::new())
+                let msg = e.to_string();
+                if msg.contains("timeout") || msg.contains("timed out") {
+                    debug!("XREADGROUP '>' timeout (no new messages in 1s)");
+                    Ok(Vec::new())
                 } else {
+                    warn!("XREADGROUP '>' error: {}", e);
                     Err(ConsumerError::RedisError(e))
                 }
             }

--- a/apps/consumer/src/error.rs
+++ b/apps/consumer/src/error.rs
@@ -123,6 +123,8 @@ pub enum ConsumerError {
     RedisError(#[from] redis::RedisError),
     #[error("Term not found")]
     TermNotFound,
+    #[error("TNS resolution error: {0}")]
+    TnsError(String),
 }
 
 // Implement the Reject trait for ConsumerError

--- a/apps/consumer/src/main.rs
+++ b/apps/consumer/src/main.rs
@@ -16,22 +16,15 @@ mod traits;
 
 pub use supported_contracts::v2_contract::Multivault;
 
-// Codegen to interact with the ENS contract.
-sol!(
-    #[derive(Debug, Deserialize, Serialize)]
-    #[allow(missing_docs)]
-    #[sol(rpc)]
-    interface ENSRegistry {
-        function resolver(bytes32 node) external view returns (address);
-    }
-);
-
-// Codegen to interact with the ENSName contract.
+// Codegen to interact with the ENS Universal Resolver (ENSIP-23).
+// Handles L1 primary names, L2 primary names (Base/Optimism/Linea via CCIP-Read),
+// and offchain resolvers — in a single call.
 sol! {
     #[allow(missing_docs)]
     #[sol(rpc)]
-    interface ENSName {
-        function name(bytes32 node) external view returns (string);
+    interface UniversalResolver {
+        function reverse(bytes lookupAddress, uint256 coinType)
+            external view returns (string primary, address resolver, address reverseResolver);
     }
 }
 

--- a/apps/consumer/src/mode/resolver/atom_resolver.rs
+++ b/apps/consumer/src/mode/resolver/atom_resolver.rs
@@ -35,7 +35,7 @@ pub async fn try_to_resolve_ipfs_uri(
     resolver_consumer_context: &ResolverConsumerContext,
 ) -> Result<Option<Response>, ConsumerError> {
     // Handle IPFS URIs
-    warn!("Trying to resolve IPFS URI: {}", atom_data);
+    debug!("Trying to resolve IPFS URI: {}", atom_data);
     if let Some(ipfs_hash) = atom_data.strip_prefix("ipfs://") {
         if let Ok(ipfs_data) = resolver_consumer_context
             .ipfs_resolver
@@ -50,7 +50,7 @@ pub async fn try_to_resolve_ipfs_uri(
             Ok(None)
         }
     } else {
-        warn!("Atom data is not an IPFS URI: {}", atom_data);
+        debug!("Atom data is not an IPFS URI: {}", atom_data);
         Ok(None)
     }
 }

--- a/apps/consumer/src/mode/resolver/caip22_resolver.rs
+++ b/apps/consumer/src/mode/resolver/caip22_resolver.rs
@@ -15,9 +15,8 @@ use alloy::{
 };
 use models::{atom::Atom, traits::SimpleCrud};
 use serde_json::Value;
-use std::{net::IpAddr, str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration};
 use tracing::{debug, warn};
-use url::Url;
 
 /// Maximum response size for metadata fetches (1 MB)
 const MAX_RESPONSE_SIZE: usize = 1024 * 1024;
@@ -90,63 +89,18 @@ fn create_http_client() -> Result<reqwest::Client, ConsumerError> {
         .map_err(ConsumerError::from)
 }
 
-/// Validates that a URL does not point to internal/private networks (SSRF protection)
+/// Validates that a URL does not point to internal/private networks (SSRF protection).
+///
+/// Delegates to the canonical implementation in `shared_utils::ssrf` and maps
+/// its errors onto the consumer's error type so existing call sites and error
+/// handling are unchanged.
 fn validate_url_not_internal(url_str: &str) -> Result<(), ConsumerError> {
-    let url = Url::parse(url_str).map_err(|_| ConsumerError::UnsupportedTokenUri(url_str.to_string()))?;
-
-    // Get the host
-    let host = url.host_str().ok_or_else(|| ConsumerError::UnsupportedTokenUri(url_str.to_string()))?;
-
-    // Check for localhost variants
-    if host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]" {
-        return Err(ConsumerError::SsrfBlocked(url_str.to_string()));
-    }
-
-    // Try to parse as IP address and check for private ranges
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if is_private_ip(&ip) {
-            return Err(ConsumerError::SsrfBlocked(url_str.to_string()));
-        }
-    }
-
-    // Also check common internal hostnames
-    let host_lower = host.to_lowercase();
-    if host_lower.ends_with(".local")
-        || host_lower.ends_with(".internal")
-        || host_lower.ends_with(".localhost")
-        || host_lower == "metadata.google.internal"
-        || host_lower == "169.254.169.254"
-    {
-        return Err(ConsumerError::SsrfBlocked(url_str.to_string()));
-    }
-
-    Ok(())
-}
-
-/// Checks if an IP address is in a private/internal range
-fn is_private_ip(ip: &IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(ipv4) => {
-            // Private ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-            // Loopback: 127.0.0.0/8
-            // Link-local: 169.254.0.0/16
-            // Carrier-grade NAT: 100.64.0.0/10
-            ipv4.is_private()
-                || ipv4.is_loopback()
-                || ipv4.is_link_local()
-                || ipv4.octets()[0] == 100 && (ipv4.octets()[1] & 0xC0) == 64 // 100.64.0.0/10
-                || ipv4.is_broadcast()
-                || ipv4.is_documentation()
-        }
-        IpAddr::V6(ipv6) => {
-            ipv6.is_loopback()
-                || ipv6.is_unspecified()
-                // Unique local addresses (fc00::/7)
-                || (ipv6.segments()[0] & 0xfe00) == 0xfc00
-                // Link-local (fe80::/10)
-                || (ipv6.segments()[0] & 0xffc0) == 0xfe80
-        }
-    }
+    shared_utils::ssrf::validate_url_not_internal(url_str).map_err(|err| match err {
+        shared_utils::error::LibError::SsrfBlocked(url) => ConsumerError::SsrfBlocked(url),
+        // Unparseable URL or any other validation failure: surface as an
+        // unsupported token URI, matching prior behaviour.
+        _ => ConsumerError::UnsupportedTokenUri(url_str.to_string()),
+    })
 }
 
 /// Resolves a CAIP-22 atom by fetching tokenURI and parsing metadata
@@ -604,7 +558,8 @@ mod tests {
     /// Test private IP detection
     #[test]
     fn test_is_private_ip() {
-        use std::net::{Ipv4Addr, Ipv6Addr};
+        use shared_utils::ssrf::is_private_ip;
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
         // Private IPv4
         assert!(is_private_ip(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));

--- a/apps/consumer/src/mode/resolver/ens_resolver.rs
+++ b/apps/consumer/src/mode/resolver/ens_resolver.rs
@@ -1,43 +1,37 @@
 use crate::{
-    ENSName::ENSNameInstance,
-    ENSRegistry::ENSRegistryInstance,
+    UniversalResolver::UniversalResolverInstance,
     error::ConsumerError,
     mode::{ipfs_upload::types::IpfsUploadMessage, types::ResolverConsumerContext},
 };
 use alloy::{
-    primitives::{Address, FixedBytes, keccak256},
+    primitives::{Address, Bytes, U256},
     providers::DynProvider,
+    sol_types::SolValue,
 };
 use alloy_network::Ethereum;
-use tracing::debug;
+use tracing::{debug, warn};
 
-/// This struct represents the ENS name and avatar for an address.
+/// ENS name and avatar for an address.
 #[derive(Clone, Debug)]
 pub struct Ens {
     pub name: Option<String>,
     pub image: Option<String>,
 }
 
-impl Ens {
-    /// This function hashes the ENS name.
-    fn namehash(name: &str) -> Vec<u8> {
-        if name.is_empty() {
-            return vec![0u8; 32];
-        }
-        let mut hash = vec![0u8; 32];
-        for label in name.rsplit('.') {
-            hash.append(&mut keccak256(label.as_bytes()).to_vec());
-            hash = keccak256(hash.as_slice()).to_vec();
-        }
-        hash
-    }
+/// Ethereum L1 coin type per SLIP-44 — used with UniversalResolver.reverse().
+const COIN_TYPE_ETH: u64 = 60;
 
-    /// This function gets the ENS name and avatar for an address.
+impl Ens {
+    /// Resolves the ENS primary name and avatar for an address.
+    ///
+    /// Uses the ENS Universal Resolver (ENSIP-23) which handles L1 primary names,
+    /// L2 primary names (Base, Optimism, Linea — via CCIP-Read), and offchain
+    /// resolvers in a single call.
     pub async fn get_ens(
         address: Address,
         consumer_context: &ResolverConsumerContext,
     ) -> Result<Ens, ConsumerError> {
-        let name = Self::get_ens_name(address, &consumer_context.mainnet_client).await?;
+        let name = Self::get_ens_name(address, &consumer_context.universal_resolver).await?;
         let mut image = None;
         if let Some(name_str) = &name {
             image = Self::get_ens_avatar(name_str, consumer_context).await?;
@@ -45,7 +39,7 @@ impl Ens {
         Ok(Ens { name, image })
     }
 
-    /// Gets the ENS avatar URL for a given name
+    /// Gets the ENS avatar URL for a given name.
     async fn get_ens_avatar(
         name: &str,
         consumer_context: &ResolverConsumerContext,
@@ -71,75 +65,50 @@ impl Ens {
         }
     }
 
-    /// This function gets the ENS name for an address.
+    /// Reverse-resolves an address to its primary ENS name via the Universal Resolver.
+    ///
+    /// Calls `UniversalResolver.reverse(addr_bytes, 60)` which returns the primary
+    /// name regardless of whether it was set on L1 or L2. The RPC provider (Alchemy)
+    /// handles CCIP-Read transparently, so this is a single contract call for the
+    /// consumer — no client-side OffchainLookup handling needed.
+    ///
+    /// Returns `Ok(None)` if no primary name is set or if the lookup fails for any
+    /// reason (network error, unsupported UR version, etc.). Never panics or blocks
+    /// message processing.
     pub async fn get_ens_name(
         address: Address,
-        mainnet_client: &ENSRegistryInstance<DynProvider, Ethereum>,
+        universal_resolver: &UniversalResolverInstance<DynProvider, Ethereum>,
     ) -> Result<Option<String>, ConsumerError> {
-        debug!("Getting ENS name for {}", address);
-        let address_hash = Self::namehash(&Self::prepare_name(address));
-        let resolver_address =
-            Self::get_resolver_address(address, &address_hash, mainnet_client).await?;
+        debug!("Getting ENS name for {} via Universal Resolver", address);
 
-        if resolver_address != Address::ZERO {
-            let alloy_contract = ENSNameInstance::new(resolver_address, mainnet_client.provider());
-            let name = alloy_contract
-                .name(FixedBytes::from_slice(address_hash.as_slice()))
-                .call()
-                .await?;
-            debug!("ResolvedENS name: {:?}", name);
-            Ok(Some(name))
-        } else {
-            Ok(None)
-        }
-    }
+        // ABI-encode the address as a 20-byte `bytes` argument
+        let lookup_address = Bytes::from(address.abi_encode_packed());
+        let coin_type = U256::from(COIN_TYPE_ETH);
 
-    /// This function gets the resolver address for an address hash.
-    async fn get_resolver_address(
-        address: Address,
-        address_hash: &[u8],
-        mainnet_client: &ENSRegistryInstance<DynProvider, Ethereum>,
-    ) -> Result<Address, ConsumerError> {
-        let resolver_address = mainnet_client
-            .resolver(FixedBytes::from_slice(address_hash))
+        match universal_resolver
+            .reverse(lookup_address, coin_type)
             .call()
-            .await?;
-
-        if resolver_address == Address::ZERO {
-            debug!("No resolver found for {}", address);
-        } else {
-            debug!("Resolver found for {}: {}", address, resolver_address);
+            .await
+        {
+            Ok(result) => {
+                let name = result.primary;
+                if name.is_empty() {
+                    debug!("No ENS primary name set for {}", address);
+                    Ok(None)
+                } else {
+                    debug!("Resolved ENS name for {}: {}", address, name);
+                    Ok(Some(name))
+                }
+            }
+            Err(e) => {
+                // Don't propagate contract call errors — the consumer must keep
+                // processing messages. Log the error for observability.
+                warn!(
+                    "ENS reverse lookup failed for {} (non-fatal, returning None): {}",
+                    address, e
+                );
+                Ok(None)
+            }
         }
-
-        Ok(resolver_address)
-    }
-
-    /// This function prepares the name for the ENS resolver.
-    fn prepare_name(address: Address) -> String {
-        let addr_str = address.to_string().to_lowercase();
-        format!("{}.addr.reverse", addr_str.trim_start_matches("0x"))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_namehash() {
-        // Test empty string
-        assert_eq!(Ens::namehash(""), vec![0u8; 32]);
-
-        // Test "eth"
-        let eth_hash = "93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae";
-        assert_eq!(hex::encode(Ens::namehash("eth")), eth_hash);
-
-        // Test "foo.eth"
-        let foo_eth_hash = "de9b09fd7c5f901e23a3f19fecc54828e9c848539801e86591bd9801b019f84f";
-        assert_eq!(hex::encode(Ens::namehash("foo.eth")), foo_eth_hash);
-
-        // Test "alice.eth"
-        let alice_eth_hash = "787192fc5378cc32aa956ddfdedbf26b24e8d78e40109add0eea2c1a012c3dec";
-        assert_eq!(hex::encode(Ens::namehash("alice.eth")), alice_eth_hash);
     }
 }

--- a/apps/consumer/src/mode/resolver/mod.rs
+++ b/apps/consumer/src/mode/resolver/mod.rs
@@ -1,4 +1,5 @@
 pub mod atom_resolver;
 pub mod caip22_resolver;
 pub mod ens_resolver;
+pub mod tns_resolver;
 pub mod types;

--- a/apps/consumer/src/mode/resolver/tns_resolver.rs
+++ b/apps/consumer/src/mode/resolver/tns_resolver.rs
@@ -22,7 +22,7 @@ sol! {
     }
 }
 
-pub const TNS_REGISTRY_ADDRESS: &str = "0x34D7648aecc10fd86A53Cdd2436125342f3d7412";
+pub const TNS_REGISTRY_ADDRESS: &str = "0x3220B4EDbA3a1661F02f1D8D241DBF55EDcDa09e";
 pub const INTUITION_RPC_URL: &str = "https://intuition.calderachain.xyz";
 
 #[derive(Clone, Debug)]
@@ -351,7 +351,7 @@ mod tests {
             dyn_provider,
         );
 
-        let name = "testing.trust";
+        let name = "sammy.trust";
         println!("Querying avatar text record for: {name}");
 
         // Check what resolver we get for this name

--- a/apps/consumer/src/mode/resolver/tns_resolver.rs
+++ b/apps/consumer/src/mode/resolver/tns_resolver.rs
@@ -1,0 +1,400 @@
+use alloy::{
+    primitives::{Address, FixedBytes, keccak256},
+    providers::DynProvider,
+    sol,
+};
+use alloy_network::Ethereum;
+use tracing::{debug, warn};
+
+sol! {
+    #[sol(rpc)]
+    interface TNSRegistry {
+        function resolver(bytes32 node) external view returns (address);
+        function owner(bytes32 node) external view returns (address);
+    }
+
+    #[sol(rpc)]
+    interface TNSResolver {
+        function addr(bytes32 node) external view returns (address);
+        function name(bytes32 node) external view returns (string);
+        function text(bytes32 node, string key) external view returns (string);
+        function contenthash(bytes32 node) external view returns (bytes);
+    }
+}
+
+pub const TNS_REGISTRY_ADDRESS: &str = "0x34D7648aecc10fd86A53Cdd2436125342f3d7412";
+pub const INTUITION_RPC_URL: &str = "https://intuition.calderachain.xyz";
+
+#[derive(Clone, Debug)]
+pub struct Tns {
+    pub name: Option<String>,
+    pub address: Option<Address>,
+    pub avatar: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TnsError {
+    #[error("Contract call failed: {0}")]
+    ContractError(String),
+    #[error("HTTP request failed: {0}")]
+    HttpError(#[from] reqwest::Error),
+}
+
+impl From<TnsError> for crate::error::ConsumerError {
+    fn from(e: TnsError) -> Self {
+        crate::error::ConsumerError::TnsError(e.to_string())
+    }
+}
+
+impl Tns {
+    fn namehash(name: &str) -> Vec<u8> {
+        if name.is_empty() {
+            return vec![0u8; 32];
+        }
+        let mut hash = vec![0u8; 32];
+        for label in name.rsplit('.') {
+            hash.append(&mut keccak256(label.as_bytes()).to_vec());
+            hash = keccak256(hash.as_slice()).to_vec();
+        }
+        hash
+    }
+
+    /// Ensures the name ends with `.trust`
+    fn ensure_trust_suffix(name: &str) -> String {
+        if name.ends_with(".trust") {
+            name.to_string()
+        } else {
+            format!("{}.trust", name)
+        }
+    }
+
+    /// Looks up the resolver contract for a given node hash.
+    /// Returns `None` if no resolver is set (address is zero).
+    async fn get_resolver(
+        node_bytes: FixedBytes<32>,
+        registry: &TNSRegistry::TNSRegistryInstance<DynProvider, Ethereum>,
+    ) -> Result<Option<TNSResolver::TNSResolverInstance<DynProvider, Ethereum>>, TnsError> {
+        let resolver_address = registry
+            .resolver(node_bytes)
+            .call()
+            .await
+            .map_err(|e| TnsError::ContractError(e.to_string()))?;
+
+        if resolver_address == Address::ZERO {
+            return Ok(None);
+        }
+
+        Ok(Some(TNSResolver::TNSResolverInstance::new(
+            resolver_address,
+            registry.provider().clone(),
+        )))
+    }
+
+    /// Computes the node hash for a name
+    fn node_for_name(name: &str) -> FixedBytes<32> {
+        let full_name = Self::ensure_trust_suffix(name);
+        let node = Self::namehash(&full_name);
+        FixedBytes::from_slice(node.as_slice())
+    }
+
+    /// Forward resolves a TNS name to an address and avatar
+    pub async fn resolve_name(
+        name: &str,
+        registry: &TNSRegistry::TNSRegistryInstance<DynProvider, Ethereum>,
+    ) -> Result<Tns, TnsError> {
+        let full_name = Self::ensure_trust_suffix(name);
+        let node_bytes = Self::node_for_name(&full_name);
+
+        let resolver = match Self::get_resolver(node_bytes, registry).await? {
+            Some(r) => r,
+            None => {
+                debug!("No resolver found for {full_name}");
+                return Ok(Tns {
+                    name: None,
+                    address: None,
+                    avatar: None,
+                });
+            }
+        };
+
+        let addr = resolver
+            .addr(node_bytes)
+            .call()
+            .await
+            .map_err(|e| TnsError::ContractError(e.to_string()))?;
+
+        let avatar = resolver
+            .text(node_bytes, "avatar".to_string())
+            .call()
+            .await
+            .ok()
+            .filter(|s| !s.is_empty());
+
+        debug!("Resolved {full_name}: addr={addr}, avatar={avatar:?}");
+
+        Ok(Tns {
+            name: Some(full_name),
+            address: if addr != Address::ZERO {
+                Some(addr)
+            } else {
+                None
+            },
+            avatar,
+        })
+    }
+
+    /// Reverse resolves an address to a TNS name and avatar
+    pub async fn reverse_resolve(
+        address: Address,
+        registry: &TNSRegistry::TNSRegistryInstance<DynProvider, Ethereum>,
+    ) -> Result<Tns, TnsError> {
+        debug!("Reverse resolving TNS name for {address}");
+
+        let reverse_name = Self::prepare_reverse_name(address);
+        let node = Self::namehash(&reverse_name);
+        let node_bytes = FixedBytes::from_slice(node.as_slice());
+
+        let resolver = match Self::get_resolver(node_bytes, registry).await? {
+            Some(r) => r,
+            None => {
+                debug!("No reverse resolver found for {address}");
+                return Ok(Tns {
+                    name: None,
+                    address: Some(address),
+                    avatar: None,
+                });
+            }
+        };
+
+        let name = resolver
+            .name(node_bytes)
+            .call()
+            .await
+            .map_err(|e| TnsError::ContractError(e.to_string()))?;
+
+        if name.is_empty() {
+            return Ok(Tns {
+                name: None,
+                address: Some(address),
+                avatar: None,
+            });
+        }
+
+        // Try fetching avatar from multiple locations:
+        // 1. Reverse resolver with reverse node
+        // 2. Reverse resolver with forward name's node (where TNS commonly stores it)
+        // 3. Forward name's own resolver
+        let avatar = match resolver
+            .text(node_bytes, "avatar".to_string())
+            .call()
+            .await
+            .ok()
+            .filter(|s| !s.is_empty())
+        {
+            Some(avatar) => Some(avatar),
+            None => {
+                // Try forward name's node on the reverse resolver
+                let fwd_node = Self::node_for_name(&name);
+                match resolver
+                    .text(fwd_node, "avatar".to_string())
+                    .call()
+                    .await
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                {
+                    Some(avatar) => Some(avatar),
+                    None => {
+                        // Fall back to forward name's own resolver
+                        match Self::get_text_record(&name, "avatar", registry).await {
+                            Ok(avatar) => avatar,
+                            Err(e) => {
+                                warn!("Failed to fetch avatar for {name}: {e}");
+                                None
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        debug!("Reverse resolved {address}: name={name}, avatar={avatar:?}");
+
+        Ok(Tns {
+            name: Some(name),
+            address: Some(address),
+            avatar,
+        })
+    }
+
+    /// Fetches a text record for a given name
+    pub async fn get_text_record(
+        name: &str,
+        key: &str,
+        registry: &TNSRegistry::TNSRegistryInstance<DynProvider, Ethereum>,
+    ) -> Result<Option<String>, TnsError> {
+        let node_bytes = Self::node_for_name(name);
+
+        let resolver = match Self::get_resolver(node_bytes, registry).await? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        let value = resolver
+            .text(node_bytes, key.to_string())
+            .call()
+            .await
+            .ok()
+            .filter(|s| !s.is_empty());
+
+        Ok(value)
+    }
+
+    fn prepare_reverse_name(address: Address) -> String {
+        let addr_str = address.to_string().to_lowercase();
+        format!("{}.addr.reverse", addr_str.trim_start_matches("0x"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_namehash_empty() {
+        assert_eq!(Tns::namehash(""), vec![0u8; 32]);
+    }
+
+    #[test]
+    fn test_namehash_trust() {
+        let hash = Tns::namehash("trust");
+        assert_eq!(hash.len(), 32);
+        assert_ne!(hash, vec![0u8; 32]);
+    }
+
+    #[test]
+    fn test_namehash_alice_trust() {
+        let hash = Tns::namehash("alice.trust");
+        assert_eq!(hash.len(), 32);
+        assert_ne!(hash, vec![0u8; 32]);
+        assert_ne!(hash, Tns::namehash("trust"));
+    }
+
+    #[test]
+    fn test_namehash_consistency() {
+        let hash1 = Tns::namehash("alice.trust");
+        let hash2 = Tns::namehash("alice.trust");
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_namehash_different_names() {
+        let hash_alice = Tns::namehash("alice.trust");
+        let hash_bob = Tns::namehash("bob.trust");
+        assert_ne!(hash_alice, hash_bob);
+    }
+
+    #[test]
+    fn test_prepare_reverse_name() {
+        let address: Address = "0xf1016a7fe89eb9d244c3bfb270071b24619e36c6"
+            .parse()
+            .unwrap();
+        let reverse = Tns::prepare_reverse_name(address);
+        assert_eq!(
+            reverse,
+            "f1016a7fe89eb9d244c3bfb270071b24619e36c6.addr.reverse"
+        );
+    }
+
+    #[test]
+    fn test_ensure_trust_suffix() {
+        assert_eq!(Tns::ensure_trust_suffix("alice"), "alice.trust");
+        assert_eq!(Tns::ensure_trust_suffix("alice.trust"), "alice.trust");
+        assert_eq!(Tns::ensure_trust_suffix("bob.sub"), "bob.sub.trust");
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires live Intuition RPC - run with --ignored"]
+    async fn test_reverse_resolve_live() {
+        use alloy::providers::ProviderBuilder;
+
+        let provider = ProviderBuilder::new()
+            .connect_http(INTUITION_RPC_URL.parse().unwrap());
+        let dyn_provider = DynProvider::new(provider);
+        let registry = TNSRegistry::TNSRegistryInstance::new(
+            TNS_REGISTRY_ADDRESS.parse::<Address>().unwrap(),
+            dyn_provider,
+        );
+
+        // Test with the address you're trying to resolve
+        let address: Address = "0xf1016a7Fe89EB9D244c3bfB270071b24619e36C6"
+            .parse()
+            .unwrap();
+        let result = Tns::reverse_resolve(address, &registry).await;
+        println!("Reverse resolve result for {address}: {result:?}");
+
+        assert!(result.is_ok(), "RPC call should not fail");
+        let tns = result.unwrap();
+        println!("  name: {:?}", tns.name);
+        println!("  avatar: {:?}", tns.avatar);
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires live Intuition RPC - run with --ignored"]
+    async fn test_avatar_text_record() {
+        use alloy::providers::ProviderBuilder;
+
+        let provider = ProviderBuilder::new()
+            .connect_http(INTUITION_RPC_URL.parse().unwrap());
+        let dyn_provider = DynProvider::new(provider);
+        let registry = TNSRegistry::TNSRegistryInstance::new(
+            TNS_REGISTRY_ADDRESS.parse::<Address>().unwrap(),
+            dyn_provider,
+        );
+
+        let name = "testing.trust";
+        println!("Querying avatar text record for: {name}");
+
+        // Check what resolver we get for this name
+        let node_bytes = Tns::node_for_name(name);
+        println!("  node_bytes: 0x{}", hex::encode(node_bytes));
+
+        let resolver = Tns::get_resolver(node_bytes, &registry).await;
+        println!("  resolver result: {resolver:?}");
+
+        // Try fetching avatar
+        let avatar = Tns::get_text_record(name, "avatar", &registry).await;
+        println!("  avatar result: {avatar:?}");
+
+        // Also try other common keys
+        let url = Tns::get_text_record(name, "url", &registry).await;
+        println!("  url result: {url:?}");
+
+        // Try fetching avatar from the reverse resolver directly
+        let address: Address = "0xf1016a7Fe89EB9D244c3bfB270071b24619e36C6"
+            .parse()
+            .unwrap();
+        let reverse_name = Tns::prepare_reverse_name(address);
+        let reverse_node = Tns::namehash(&reverse_name);
+        let reverse_node_bytes = FixedBytes::from_slice(reverse_node.as_slice());
+        println!("  reverse node: 0x{}", hex::encode(reverse_node_bytes));
+
+        let reverse_resolver = Tns::get_resolver(reverse_node_bytes, &registry).await;
+        println!("  reverse resolver: {reverse_resolver:?}");
+
+        if let Ok(Some(rev_resolver)) = reverse_resolver {
+            let avatar_from_reverse = rev_resolver
+                .text(reverse_node_bytes, "avatar".to_string())
+                .call()
+                .await;
+            println!("  avatar from reverse resolver (reverse node): {avatar_from_reverse:?}");
+
+            // Try with forward name node on reverse resolver
+            let fwd_node = Tns::node_for_name(name);
+            let avatar_fwd_node = rev_resolver
+                .text(fwd_node, "avatar".to_string())
+                .call()
+                .await;
+            println!("  avatar from reverse resolver (forward node): {avatar_fwd_node:?}");
+        }
+    }
+}

--- a/apps/consumer/src/mode/resolver/types.rs
+++ b/apps/consumer/src/mode/resolver/types.rs
@@ -8,6 +8,7 @@ use crate::{
                 handle_binary_data, try_to_parse_json_or_text, try_to_resolve_ipfs_uri,
             },
             ens_resolver::Ens,
+            tns_resolver::Tns,
         },
         types::ResolverConsumerContext,
     },
@@ -23,7 +24,7 @@ use models::{
 use serde::{Deserialize, Serialize};
 use sqlx::{Postgres, Transaction};
 use std::str::FromStr;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// This struct represents a message that is sent to the resolver
 /// consumer to be processed.
@@ -184,36 +185,70 @@ impl ResolverMessageType {
         .ok_or(ConsumerError::AccountNotFound)
     }
 
-    /// This function processes an account message type
+    /// This function processes an account message type.
+    /// TNS resolution is attempted first. If no TNS name is found,
+    /// falls back to ENS resolution.
     async fn process_account(
         &self,
         resolver_consumer_context: &ResolverConsumerContext,
         account: &mut Account,
     ) -> Result<(), ConsumerError> {
-        let ens = Ens::get_ens(Address::from_str(&account.id)?, resolver_consumer_context).await?;
-        if let Some(_name) = ens.name.clone() {
-            debug!("ENS for account: {:?}", ens);
-            // We need to update the account metadata
+        let address = Address::from_str(&account.id)?;
+
+        // Try TNS first (priority)
+        let resolved = match Tns::reverse_resolve(address, &resolver_consumer_context.tns_client)
+            .await
+        {
+            Ok(tns) if tns.name.is_some() => {
+                debug!("TNS resolved for account: {:?}", tns);
+                // Send avatar to IPFS upload consumer for image processing
+                if let Some(ref avatar_url) = tns.avatar {
+                    debug!("Sending TNS avatar to IPFS upload consumer: {}", avatar_url);
+                    if let Err(e) = resolver_consumer_context
+                        .client
+                        .send_message(
+                            serde_json::to_string(&IpfsUploadMessage {
+                                image: avatar_url.clone(),
+                            })?,
+                            None,
+                        )
+                        .await
+                    {
+                        warn!("Failed to send TNS avatar to IPFS upload consumer: {e}");
+                    }
+                }
+                Ens {
+                    name: tns.name,
+                    image: tns.avatar,
+                }
+            }
+            Ok(_) => {
+                debug!("No TNS name found, falling back to ENS");
+                Ens::get_ens(address, resolver_consumer_context).await?
+            }
+            Err(e) => {
+                debug!("TNS resolution failed: {e}, falling back to ENS");
+                Ens::get_ens(address, resolver_consumer_context).await?
+            }
+        };
+
+        if let Some(_name) = resolved.name.clone() {
             debug!("Updating account metadata for account: {:?}", account);
             self.update_account_metadata(
                 resolver_consumer_context,
                 account.id.clone(),
-                ens.clone(),
+                resolved.clone(),
             )
             .await?;
-            // We also need to update the atom
             if let Some(atom_id) = account.atom_id.clone() {
                 debug!("Updating atom metadata for account: {:?}", account);
-                self.update_atom_metadata(resolver_consumer_context, &atom_id, ens)
+                self.update_atom_metadata(resolver_consumer_context, &atom_id, resolved)
                     .await?;
             } else {
-                // We deal with the case where the account atom_id was not set
-                // when the account was created. In this case, we need to query the DB
-                // to find the atom_id, as this update happens in another consumer
                 debug!("No atom found for account: {:?}", account)
             }
         } else {
-            debug!("No ENS found for account: {:?}", account);
+            debug!("No name resolved (TNS or ENS) for account: {:?}", account);
         }
         Ok(())
     }

--- a/apps/consumer/src/mode/resolver/types.rs
+++ b/apps/consumer/src/mode/resolver/types.rs
@@ -22,7 +22,6 @@ use models::{
     types::FixedBytesWrapper,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::{Postgres, Transaction};
 use std::str::FromStr;
 use tracing::{debug, warn};
 
@@ -253,23 +252,26 @@ impl ResolverMessageType {
         Ok(())
     }
 
-    /// This function processes an atom message type
+    /// This function processes an atom message type.
+    ///
+    /// Network I/O (IPFS fetches, etc.) is performed before any DB writes
+    /// to avoid holding database connections during slow external requests.
     async fn process_atom(
         &self,
         resolver_consumer_context: &ResolverConsumerContext,
         atom_id: &str,
     ) -> Result<(), ConsumerError> {
-        let mut tx = resolver_consumer_context.pg_pool.begin().await?;
-
+        // Phase 1: Fetch atom and resolve data (includes network I/O like IPFS)
+        // No transaction needed — this avoids holding a DB connection during slow fetches
         let metadata = self
-            .resolve_and_parse_atom_data(resolver_consumer_context, atom_id, &mut tx)
+            .resolve_and_parse_atom_data(resolver_consumer_context, atom_id)
             .await?;
         debug!("Metadata: {:?}", metadata);
 
-        // If the atom type is not unknown, we handle the new atom type that was resolved
+        // Phase 2: DB writes only (fast path)
         if AtomType::from_str(&metadata.atom_type)? != AtomType::Unknown {
             debug!("Handling known atom type: {:?}", metadata);
-            self.handle_known_atom_type(resolver_consumer_context, atom_id, metadata, &mut tx)
+            self.handle_known_atom_type(resolver_consumer_context, atom_id, metadata)
                 .await?;
         } else {
             self.mark_atom_as_failed(
@@ -277,21 +279,22 @@ impl ResolverMessageType {
                     .server_initialize
                     .env
                     .backend_schema,
-                &mut tx,
+                &resolver_consumer_context.pg_pool,
                 &FixedBytesWrapper::from_str(atom_id)?,
             )
             .await?;
         }
-        tx.commit().await?;
         Ok(())
     }
 
-    /// This function resolves and parses the atom data
+    /// This function resolves and parses the atom data.
+    ///
+    /// Uses the connection pool for the initial read and performs all network I/O
+    /// (IPFS fetches) without holding a transaction open.
     async fn resolve_and_parse_atom_data(
         &self,
         resolver_consumer_context: &ResolverConsumerContext,
         atom_id: &str,
-        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<AtomMetadata, ConsumerError> {
         let atom = Atom::find_by_id(
             FixedBytesWrapper::from_str(atom_id)?,
@@ -299,7 +302,7 @@ impl ResolverMessageType {
                 .server_initialize
                 .env
                 .backend_schema,
-            tx.as_mut(),
+            &resolver_consumer_context.pg_pool,
         )
         .await?
         .ok_or(ConsumerError::AtomDataNotFound)?;
@@ -356,10 +359,9 @@ impl ResolverMessageType {
         resolver_consumer_context: &ResolverConsumerContext,
         atom_id: &str,
         metadata: AtomMetadata,
-        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<(), ConsumerError> {
         let atom = self
-            .find_and_update_atom(resolver_consumer_context, atom_id, metadata, tx)
+            .find_and_update_atom(resolver_consumer_context, atom_id, metadata)
             .await?;
 
         if let Some(image) = atom.image.clone() {
@@ -372,7 +374,7 @@ impl ResolverMessageType {
                 .server_initialize
                 .env
                 .backend_schema,
-            tx.as_mut(),
+            &resolver_consumer_context.pg_pool,
         )
         .await?;
 
@@ -386,20 +388,17 @@ impl ResolverMessageType {
         resolver_consumer_context: &ResolverConsumerContext,
         atom_id: &str,
         metadata: AtomMetadata,
-        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<Atom, ConsumerError> {
-        let atom = Atom::find_by_id(
+        let mut atom = Atom::find_by_id(
             FixedBytesWrapper::from_str(atom_id)?,
             &resolver_consumer_context
                 .server_initialize
                 .env
                 .backend_schema,
-            tx.as_mut(),
+            &resolver_consumer_context.pg_pool,
         )
         .await?
         .ok_or(ConsumerError::AtomNotFound)?;
-
-        let mut atom = atom;
         metadata
             .update_atom_metadata(
                 &mut atom,
@@ -431,13 +430,13 @@ impl ResolverMessageType {
     async fn mark_atom_as_failed(
         &self,
         backend_schema: &str,
-        tx: &mut Transaction<'_, Postgres>,
+        pg_pool: &sqlx::PgPool,
         atom_id: &FixedBytesWrapper,
     ) -> Result<(), ConsumerError> {
-        let atom = Atom::find_by_id(atom_id.clone(), backend_schema, tx.as_mut())
+        let atom = Atom::find_by_id(atom_id.clone(), backend_schema, pg_pool)
             .await?
             .ok_or(ConsumerError::AtomNotFound)?;
-        atom.mark_as_failed(backend_schema, tx.as_mut())
+        atom.mark_as_failed(backend_schema, pg_pool)
             .await
             .map_err(ConsumerError::from)
     }

--- a/apps/consumer/src/mode/types.rs
+++ b/apps/consumer/src/mode/types.rs
@@ -225,18 +225,6 @@ impl ConsumerMode {
         }
     }
 
-    /// Builds the alloy client for the ENS Universal Resolver (ENSIP-23).
-    fn build_universal_resolver_client(
-        rpc_url: &str,
-        contract_address: &str,
-    ) -> Result<UniversalResolverInstance<DynProvider, Ethereum>, ConsumerError> {
-        let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
-        let dyn_provider = DynProvider::new(provider);
-        let address = Address::from_str(contract_address)
-            .map_err(|e| ConsumerError::AddressParse(e.to_string()))?;
-        Ok(crate::UniversalResolver::new(address, dyn_provider))
-    }
-
     /// Builds the alloy client for the TNS contract
     fn build_tns_client(
         rpc_url: &str,
@@ -431,15 +419,21 @@ impl ConsumerMode {
         // Build Universal Resolver client (ENSIP-23) for modern ENS reverse lookups.
         // Handles L1, L2 (Base/Optimism/Linea), and offchain primary names in one call.
         // Default address is the canonical ENSIP-23 Universal Resolver on Ethereum mainnet.
-        let ur_address = data
+        let ur_address_str = data
             .env
             .universal_resolver_address
             .clone()
-            .unwrap_or_else(|| "0xce01f8eee7E479C928F8919abD53E553a36CeF67".to_string());
-        let universal_resolver = Arc::new(Self::build_universal_resolver_client(
-            &rpc_url,
-            &ur_address,
-        )?);
+            .unwrap_or_else(|| {
+                "0xeeeeeeee14d718c2b47d9923deab1335e144eeee".to_string()
+            });
+        let ur_provider = DynProvider::new(
+            ProviderBuilder::new().connect_http(rpc_url.parse()?),
+        );
+        let ur_address = Address::from_str(&ur_address_str)
+            .map_err(|e| ConsumerError::AddressParse(e.to_string()))?;
+        let universal_resolver = Arc::new(
+            crate::UniversalResolver::new(ur_address, ur_provider),
+        );
 
         let client = Self::build_client(
             data.clone(),

--- a/apps/consumer/src/mode/types.rs
+++ b/apps/consumer/src/mode/types.rs
@@ -8,6 +8,7 @@ use crate::{
     config::{ConsumerType, ContractInstance, ContractVersion, IndexerSource},
     consumer_type::{redis_hybrid::RedisHybrid, redis_streams::RedisStreams},
     error::ConsumerError,
+    mode::resolver::tns_resolver::{TNSRegistry, INTUITION_RPC_URL, TNS_REGISTRY_ADDRESS},
     schemas::types::DecodedMessage,
     traits::{AtomUpdater, BasicConsumer},
 };
@@ -194,6 +195,7 @@ pub struct ResolverConsumerContext {
     pub client: Arc<dyn BasicConsumer>,
     pub ipfs_resolver: IPFSResolver,
     pub mainnet_client: Arc<ENSRegistryInstance<DynProvider, Ethereum>>,
+    pub tns_client: Arc<TNSRegistry::TNSRegistryInstance<DynProvider, Ethereum>>,
     pub pg_pool: PgPool,
     pub server_initialize: ServerInitialize,
 }
@@ -241,6 +243,19 @@ impl ConsumerMode {
         let ens_contract = ENSRegistry::new(address, dyn_provider);
 
         Ok(ens_contract)
+    }
+
+    /// Builds the alloy client for the TNS contract
+    fn build_tns_client(
+        rpc_url: &str,
+        contract_address: &str,
+    ) -> Result<TNSRegistry::TNSRegistryInstance<DynProvider, Ethereum>, ConsumerError> {
+        let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
+        let dyn_provider = DynProvider::new(provider);
+        let address = Address::from_str(contract_address)
+            .map_err(|e| ConsumerError::AddressParse(e.to_string()))?;
+        let tns_contract = TNSRegistry::TNSRegistryInstance::new(address, dyn_provider);
+        Ok(tns_contract)
     }
 
     /// This function gets the contract version from the database, if no version is found
@@ -441,12 +456,18 @@ impl ConsumerMode {
         )
         .await?;
 
+        let tns_client = Arc::new(Self::build_tns_client(
+            INTUITION_RPC_URL,
+            TNS_REGISTRY_ADDRESS,
+        )?);
+
         let ipfs_resolver = Self::create_ipfs_resolver(data.clone()).await?;
 
         Ok(ConsumerMode::Resolver(Box::new(ResolverConsumerContext {
             client,
             ipfs_resolver,
             mainnet_client,
+            tns_client,
             pg_pool,
             server_initialize: data,
         })))

--- a/apps/consumer/src/mode/types.rs
+++ b/apps/consumer/src/mode/types.rs
@@ -3,7 +3,7 @@ use super::{
     resolver::types::ResolverConsumerMessage,
 };
 use crate::{
-    ENSRegistry::{self, ENSRegistryInstance},
+    UniversalResolver::UniversalResolverInstance,
     app_context::ServerInitialize,
     config::{ConsumerType, ContractInstance, ContractVersion, IndexerSource},
     consumer_type::{redis_hybrid::RedisHybrid, redis_streams::RedisStreams},
@@ -194,7 +194,7 @@ pub struct RawConsumerContext {
 pub struct ResolverConsumerContext {
     pub client: Arc<dyn BasicConsumer>,
     pub ipfs_resolver: IPFSResolver,
-    pub mainnet_client: Arc<ENSRegistryInstance<DynProvider, Ethereum>>,
+    pub universal_resolver: Arc<UniversalResolverInstance<DynProvider, Ethereum>>,
     pub tns_client: Arc<TNSRegistry::TNSRegistryInstance<DynProvider, Ethereum>>,
     pub pg_pool: PgPool,
     pub server_initialize: ServerInitialize,
@@ -225,24 +225,16 @@ impl ConsumerMode {
         }
     }
 
-    /// Builds the alloy client for the ENS contract
-    fn build_ens_client(
+    /// Builds the alloy client for the ENS Universal Resolver (ENSIP-23).
+    fn build_universal_resolver_client(
         rpc_url: &str,
         contract_address: &str,
-    ) -> Result<ENSRegistryInstance<DynProvider, Ethereum>, ConsumerError> {
-        // Initialize the provider using the provided RPC URL
+    ) -> Result<UniversalResolverInstance<DynProvider, Ethereum>, ConsumerError> {
         let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
-        // Wrap the provider in a DynProvider to erase its concrete type
         let dyn_provider = DynProvider::new(provider);
-
-        // Parse the contract address
         let address = Address::from_str(contract_address)
             .map_err(|e| ConsumerError::AddressParse(e.to_string()))?;
-
-        // Instantiate the ENSRegistry contract with the dynamic provider
-        let ens_contract = ENSRegistry::new(address, dyn_provider);
-
-        Ok(ens_contract)
+        Ok(crate::UniversalResolver::new(address, dyn_provider))
     }
 
     /// Builds the alloy client for the TNS contract
@@ -430,17 +422,23 @@ impl ConsumerMode {
         data: ServerInitialize,
         pg_pool: PgPool,
     ) -> Result<ConsumerMode, ConsumerError> {
-        let mainnet_client = Arc::new(Self::build_ens_client(
-            &data
-                .clone()
-                .env
-                .rpc_url_mainnet
-                .unwrap_or_else(|| panic!("RPC URL mainnet is not set")),
-            &data
-                .clone()
-                .env
-                .ens_contract_address
-                .unwrap_or_else(|| panic!("ENS contract address is not set")),
+        let rpc_url = data
+            .env
+            .rpc_url_mainnet
+            .clone()
+            .unwrap_or_else(|| panic!("RPC URL mainnet is not set"));
+
+        // Build Universal Resolver client (ENSIP-23) for modern ENS reverse lookups.
+        // Handles L1, L2 (Base/Optimism/Linea), and offchain primary names in one call.
+        // Default address is the canonical ENSIP-23 Universal Resolver on Ethereum mainnet.
+        let ur_address = data
+            .env
+            .universal_resolver_address
+            .clone()
+            .unwrap_or_else(|| "0xce01f8eee7E479C928F8919abD53E553a36CeF67".to_string());
+        let universal_resolver = Arc::new(Self::build_universal_resolver_client(
+            &rpc_url,
+            &ur_address,
         )?);
 
         let client = Self::build_client(
@@ -466,7 +464,7 @@ impl ConsumerMode {
         Ok(ConsumerMode::Resolver(Box::new(ResolverConsumerContext {
             client,
             ipfs_resolver,
-            mainnet_client,
+            universal_resolver,
             tns_client,
             pg_pool,
             server_initialize: data,

--- a/apps/consumer/src/mode/utils.rs
+++ b/apps/consumer/src/mode/utils.rs
@@ -1,4 +1,7 @@
-use super::{decoded::utils::get_block_timestamp, types::DecodedConsumerContext};
+use super::{
+    decoded::utils::get_block_timestamp, resolver::types::ResolverConsumerMessage,
+    types::DecodedConsumerContext,
+};
 use crate::{
     error::ConsumerError,
     mode::decoded::{
@@ -67,7 +70,10 @@ impl VaultOrigin {
             event.term_id()?
         );
 
-        // If this is a triple vault, also create/update the triple_vault record
+        // If this is a triple vault, also create/update the triple_vault and triple_term records.
+        // CounterTriple events are excluded: ensure_triple_term_exists derives counter_term_id
+        // from event.term_id() via get_counter_id_from_triple_id, which is only valid when
+        // event.term_id() is the canonical triple term_id (not the counter).
         if matches!(event.vault_type()?.into(), TermType::Triple) {
             self.ensure_triple_vault_exists(event, context, decoded_message)
                 .await?;
@@ -101,7 +107,7 @@ impl VaultOrigin {
     }
 
     /// This function ensures that a triple_vault record exists for the given vault
-    async fn ensure_triple_vault_exists(
+    pub async fn ensure_triple_vault_exists(
         &self,
         event: &impl SharePriceChangedEvent,
         context: &DecodedConsumerContext,
@@ -191,7 +197,7 @@ impl VaultOrigin {
         ))
     }
     /// This function gets or creates a triple term
-    async fn ensure_triple_term_exists(
+    pub async fn ensure_triple_term_exists(
         &self,
         event: &impl SharePriceChangedEvent,
         decoded_consumer_context: &DecodedConsumerContext,
@@ -273,38 +279,50 @@ pub fn short_id(address: &str) -> String {
     format!("{}...{}", &address[..6], &address[address.len() - 4..])
 }
 
-/// This function creates a default account
+/// Creates a new default account and enqueues it for ENS resolution.
+///
+/// The account is persisted with a short-id label (e.g. `0x1234...5678`) which
+/// serves as the fallback if no ENS reverse record is found. After persisting,
+/// a message is sent to the resolver stream so the resolver consumer can
+/// attempt an ENS lookup and, if successful, update the label and avatar.
+///
+/// Enqueueing the resolver message from this function was accidentally dropped
+/// during the atom_id refactor in commit 0841ec2 (Dec 2025), which caused
+/// 200K+ accounts created via Deposited/Redeemed/AtomCreated/ProtocolFeeAccrued
+/// event handlers to be stuck with short-id labels. This is the restored path.
 pub async fn create_default_account(
     decoded_consumer_context: &DecodedConsumerContext,
     id: String,
     atom_id: Option<FixedBytesWrapper>,
 ) -> Result<Account, ConsumerError> {
-    let account = if let Some(atom_id) = atom_id {
+    let new_account = if let Some(atom_id) = atom_id {
         Account::builder()
             .id(id.clone())
             .label(short_id(&id))
             .account_type(AccountType::Default)
             .atom_id(atom_id)
             .build()
-            .upsert(
-                &decoded_consumer_context.backend_schema,
-                &decoded_consumer_context.pg_pool.clone(),
-            )
-            .await
-            .map_err(ConsumerError::ModelError)?
     } else {
         Account::builder()
             .id(id.clone())
             .label(short_id(&id))
             .account_type(AccountType::Default)
             .build()
-            .upsert(
-                &decoded_consumer_context.backend_schema,
-                &decoded_consumer_context.pg_pool.clone(),
-            )
-            .await
-            .map_err(ConsumerError::ModelError)?
     };
+
+    let account = new_account
+        .upsert(
+            &decoded_consumer_context.backend_schema,
+            &decoded_consumer_context.pg_pool,
+        )
+        .await
+        .map_err(ConsumerError::ModelError)?;
+
+    let message = ResolverConsumerMessage::new_account(account.clone());
+    decoded_consumer_context
+        .client
+        .send_message(serde_json::to_string(&message)?, None)
+        .await?;
 
     Ok(account)
 }

--- a/apps/shared-utils/src/error.rs
+++ b/apps/shared-utils/src/error.rs
@@ -22,6 +22,8 @@ pub enum LibError {
     PostgresConnectError(String),
     #[error("Resource does not exist")]
     ResourceNotFoundError(String),
+    #[error("SSRF protection: URL points to internal/private network or uses a disallowed scheme: {0}")]
+    SsrfBlocked(String),
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
     #[error(transparent)]

--- a/apps/shared-utils/src/lib.rs
+++ b/apps/shared-utils/src/lib.rs
@@ -2,4 +2,5 @@ pub mod error;
 pub mod image;
 pub mod ipfs;
 pub mod postgres;
+pub mod ssrf;
 pub mod types;

--- a/apps/shared-utils/src/ssrf.rs
+++ b/apps/shared-utils/src/ssrf.rs
@@ -1,0 +1,83 @@
+//! Server-Side Request Forgery (SSRF) protection for outbound URL fetches.
+//!
+//! Any code path that fetches a *user-supplied* URL server-side (image
+//! downloads, NFT `tokenURI` metadata, etc.) must run the URL through
+//! [`validate_url_not_internal`] before handing it to an HTTP client.
+//!
+//! The check enforces two things:
+//!  1. A scheme allowlist — only `http`/`https` are permitted. This blocks
+//!     local-file reads (`file://`), `gopher://`, `ftp://`, and other schemes
+//!     that can be abused for SSRF/LFI.
+//!  2. An internal-destination denylist — localhost, private/loopback/link-local
+//!     IP ranges, cloud metadata endpoints, and common internal hostnames are
+//!     rejected so an attacker cannot pivot to internal services
+//!     (e.g. `http://169.254.169.254/...` for cloud credentials).
+
+use crate::error::LibError;
+use reqwest::Url;
+use std::net::IpAddr;
+
+/// Validates that a URL is safe to fetch server-side (SSRF protection).
+///
+/// Returns `Err(LibError::SsrfBlocked)` if the scheme is not `http`/`https`,
+/// or if the host resolves to an internal/private destination. Returns
+/// `Err(LibError::InvalidInput)` if the string is not a parseable URL.
+pub fn validate_url_not_internal(url_str: &str) -> Result<(), LibError> {
+    let url = Url::parse(url_str).map_err(|_| LibError::InvalidInput(url_str.to_string()))?;
+
+    // 1. Scheme allowlist. Blocks file://, gopher://, ftp://, data://, etc.
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(LibError::SsrfBlocked(url_str.to_string()));
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| LibError::SsrfBlocked(url_str.to_string()))?;
+
+    // 2a. Explicit localhost variants
+    if host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]" {
+        return Err(LibError::SsrfBlocked(url_str.to_string()));
+    }
+
+    // 2b. Literal IP hosts in a private/internal range.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if is_private_ip(&ip) {
+            return Err(LibError::SsrfBlocked(url_str.to_string()));
+        }
+    }
+
+    // 2c. Common internal hostnames and the cloud metadata endpoint.
+    let host_lower = host.to_lowercase();
+    if host_lower.ends_with(".local")
+        || host_lower.ends_with(".internal")
+        || host_lower.ends_with(".localhost")
+        || host_lower == "metadata.google.internal"
+        || host_lower == "169.254.169.254"
+    {
+        return Err(LibError::SsrfBlocked(url_str.to_string()));
+    }
+
+    Ok(())
+}
+
+/// Returns `true` if the IP address belongs to a private, loopback, link-local,
+/// or otherwise non-publicly-routable range that should be blocked for SSRF.
+pub fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ipv4) => {
+            ipv4.is_private()
+                || ipv4.is_loopback()
+                || ipv4.is_link_local()
+                || (ipv4.octets()[0] == 100 && (ipv4.octets()[1] & 0xC0) == 64) // 100.64.0.0/10
+                || ipv4.is_broadcast()
+                || ipv4.is_documentation()
+                || ipv4.is_unspecified()
+        }
+        IpAddr::V6(ipv6) => {
+            ipv6.is_loopback()
+                || ipv6.is_unspecified()
+                || (ipv6.segments()[0] & 0xfe00) == 0xfc00 // fc00::/7 unique local
+                || (ipv6.segments()[0] & 0xffc0) == 0xfe80 // fe80::/10 link-local
+        }
+    }
+}

--- a/docker/docker-compose-apps.yml
+++ b/docker/docker-compose-apps.yml
@@ -2,7 +2,9 @@ services:
 
   
   resolver_consumer:
-    image: ghcr.io/0xintuition/apps:latest
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     command: ./consumer --mode resolver
     environment:
       CONSUMER_TYPE: 'redis_streams'
@@ -35,10 +37,12 @@ services:
     restart: always
     volumes:
       - ./logs:/app/logs
+    networks:
+      - intuition_default
     deploy:
       replicas: 1
 
-  
+
   ipfs_upload_consumer:
     image: ghcr.io/0xintuition/apps:latest
     command: ./consumer --mode ipfs-upload
@@ -79,7 +83,7 @@ services:
       LOCALSTACK_URL: 'http://redis:6379'
       PG_MIN_CONNECTIONS: '20'
       RESOLVER_STREAM: 'resolver_stream'
-      RPC_URL_BASE: "http://prod-rpc-proxy:3008/31337/proxy"
+      RPC_URL_BASE: "http://prod-rpc-proxy:3008/1155/proxy"
       RUST_LOG: 'info'
       BACKEND_SCHEMA: 'public'
       REDIS_URL: 'redis://redis:6379'
@@ -89,6 +93,8 @@ services:
       - ./logs:/app/logs
     ports:
       - 3002:3002
+    networks:
+      - intuition_default
 
     
   api:
@@ -181,8 +187,7 @@ services:
 
 
 networks:
-  intuition-be:
-    driver: bridge
+  intuition_default:
     external: true
     
 volumes:

--- a/docker/docker-compose-apps.yml
+++ b/docker/docker-compose-apps.yml
@@ -37,6 +37,7 @@ services:
     restart: always
     volumes:
       - ./logs:/app/logs
+      - ../target/release/consumer:/app/consumer
     networks:
       - intuition_default
     deploy:

--- a/docs/RESOLVER_CHANGES.md
+++ b/docs/RESOLVER_CHANGES.md
@@ -1,0 +1,143 @@
+# Resolver Consumer: Changes & Updates
+
+## Overview
+
+This document covers two sets of changes:
+
+1. **ENS Resolver** — migrated from the legacy ENSRegistry/ENSName contract pattern to the ENS Universal Resolver (ENSIP-23), mirroring upstream PR #217.
+2. **Integration Tests** — added automatic `.env` loading so scripts can be run directly without manually sourcing environment variables.
+
+The **TNS Resolver** was not changed. It remains fully intact with its existing priority-over-ENS logic.
+
+---
+
+## 1. ENS Resolver Migration (ENSIP-23 Universal Resolver)
+
+### Why
+
+The old implementation did a two-step manual lookup:
+1. Call `ENSRegistry.resolver(node)` to find the resolver contract for the address.
+2. Call `ENSName.name(node)` on that resolver to get the primary name.
+
+This pattern does not support L2 primary names (Base, Optimism, Linea) or offchain resolvers, and requires multiple RPC calls. The ENS Universal Resolver (ENSIP-23) handles all of this in a single call, with CCIP-Read handled transparently by the provider.
+
+### Files Changed
+
+#### `apps/consumer/src/main.rs`
+
+Replaced the two old sol! macro definitions:
+
+```rust
+// REMOVED
+sol! { interface ENSRegistry { function resolver(bytes32 node) ... } }
+sol! { interface ENSName { function name(bytes32 node) ... } }
+```
+
+With the Universal Resolver interface:
+
+```rust
+// ADDED
+sol! {
+    interface UniversalResolver {
+        function reverse(bytes lookupAddress, uint256 coinType)
+            external view returns (string primary, address resolver, address reverseResolver);
+    }
+}
+```
+
+#### `apps/consumer/src/mode/resolver/ens_resolver.rs`
+
+Complete rewrite. Key differences:
+
+| Old | New |
+|-----|-----|
+| Took `mainnet_client: &ENSRegistryInstance` | Takes `universal_resolver: &UniversalResolverInstance` |
+| Two-step lookup (registry → resolver → name) | Single call: `universal_resolver.reverse(addr_bytes, coin_type)` |
+| Only resolved L1 primary names | Resolves L1, L2 (Base/Optimism/Linea via CCIP-Read), and offchain names |
+| Errors propagated to caller | Non-fatal: logs a warning and returns `Ok(None)` |
+
+The new `Ens::get_ens_name` ABI-encodes the address as a 20-byte `bytes` argument and uses coin type `60` (ETH per SLIP-44) as required by the Universal Resolver's `reverse()` function.
+
+#### `apps/consumer/src/mode/types.rs`
+
+- `ResolverConsumerContext.mainnet_client` replaced with `universal_resolver: Arc<UniversalResolverInstance<DynProvider, Ethereum>>`
+- `build_ens_client()` replaced with `build_universal_resolver_client(rpc_url, contract_address)`
+- `create_resolver_consumer()` now builds the Universal Resolver client using `RPC_URL_MAINNET` and an optional `UNIVERSAL_RESOLVER_ADDRESS` env var (defaults to the canonical ENSIP-23 deployment `0xce01f8eee7E479C928F8919abD53E553a36CeF67` if not set)
+- `tns_client` field and `build_tns_client()` kept unchanged
+
+#### `apps/consumer/src/config.rs`
+
+Added:
+
+```rust
+pub universal_resolver_address: Option<String>,
+```
+
+If not set, the code defaults to the canonical Universal Resolver address on Ethereum mainnet.
+
+---
+
+## 2. TNS Resolver (Unchanged)
+
+The TNS resolver (`apps/consumer/src/mode/resolver/tns_resolver.rs`) was not modified. It is entirely local work not present in the upstream.
+
+### Resolution Priority
+
+The `process_account` function in `apps/consumer/src/mode/resolver/types.rs` resolves names in this order:
+
+1. **TNS first** — calls `Tns::reverse_resolve(address, &tns_client)`
+   - If a name is found: use it, send avatar to the IPFS upload consumer, stop.
+2. **ENS fallback** — calls `Ens::get_ens(address, resolver_consumer_context)`
+   - Uses the Universal Resolver via `universal_resolver` field.
+   - If a name is found: fetch avatar from `metadata.ens.domains`, send to IPFS upload consumer.
+3. **No name found** — logs a debug message, no metadata update.
+
+TNS errors are non-fatal and fall through to ENS automatically.
+
+### TNS Constants
+
+| Constant | Value |
+|----------|-------|
+| `TNS_REGISTRY_ADDRESS` | `0x3220B4EDbA3a1661F02f1D8D241DBF55EDcDa09e` |
+| `INTUITION_RPC_URL` | `https://intuition.calderachain.xyz` |
+
+---
+
+## 3. Integration Tests: Automatic `.env` Loading
+
+### Problem
+
+Running scripts directly with `pnpm exec tsx src/*.script.ts` failed with:
+
+```
+Error: VITE_INTUITION_CONTRACT_ADDRESS is not set
+```
+
+`tsx` does not automatically load `.env` files into `process.env`. The root `.env` at the repo root had the required values, but they were never read.
+
+### Fix
+
+**`integration-tests/package.json`** — added `dotenv` as a dependency.
+
+**`integration-tests/src/setup/constants.ts`** — added dotenv config at the top of the file, which is imported by all scripts:
+
+```typescript
+import dotenv from 'dotenv'
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+dotenv.config({ path: resolve(fileURLToPath(import.meta.url), '../../../../.env') })
+```
+
+This resolves to the root `.env` (`intuition-rs/.env`) regardless of which directory the script is run from. Since `constants.ts` is imported by every script via `utils.ts`, all scripts pick this up automatically without any changes to individual script files.
+
+---
+
+## Environment Variables Reference
+
+| Variable | Used By | Default | Notes |
+|----------|---------|---------|-------|
+| `RPC_URL_MAINNET` | Universal Resolver | — | Required. Ethereum mainnet RPC. |
+| `UNIVERSAL_RESOLVER_ADDRESS` | Universal Resolver | `0xce01f8eee7E479C928F8919abD53E553a36CeF67` | Optional. Canonical ENSIP-23 address. |
+| `ENS_CONTRACT_ADDRESS` | — | — | No longer used. Can be removed from docker-compose. |
+| `VITE_INTUITION_CONTRACT_ADDRESS` | Integration tests | — | Loaded from root `.env` via dotenv. |

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -17,6 +17,7 @@
     "@faker-js/faker": "^9.0.3",
     "@graphql-codegen/client-preset": "^4.8.0",
     "@graphql-typed-document-node/core": "^3.2.0",
+    "dotenv": "^17.4.2",
     "tsx": "^4.16.5",
     "viem": "2.33.3"
   },

--- a/integration-tests/pnpm-lock.yaml
+++ b/integration-tests/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.11.0)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       tsx:
         specifier: ^4.16.5
         version: 4.20.4
@@ -1056,6 +1059,10 @@ packages:
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dset@3.1.4:
@@ -3159,6 +3166,8 @@ snapshots:
       tslib: 2.8.1
 
   dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
 
   dset@3.1.4: {}
 

--- a/integration-tests/src/create-user-atom.script.ts
+++ b/integration-tests/src/create-user-atom.script.ts
@@ -1,0 +1,30 @@
+import { getIntuition, wait } from './setup/utils.js'
+
+async function main() {
+  console.log('Starting atom creation script...\n')
+
+  const intuition = await getIntuition(0)
+
+  const userAddress = '0xf1016a7Fe89EB9D244c3bfB270071b24619e36C6'
+
+  console.log(`Creating atom for address ${userAddress}...`)
+  const atom = await intuition.getOrCreateAtom(userAddress)
+  console.log(`Atom vaultId: ${atom.vaultId}`)
+
+  if (atom.hash) {
+    console.log('Waiting for transaction to be indexed...')
+    await wait(atom.hash)
+  }
+
+  console.log('\nAtom creation complete!')
+}
+
+main()
+  .then(() => {
+    console.log('\nScript completed successfully')
+    process.exit(0)
+  })
+  .catch((error) => {
+    console.error('\nError:', error)
+    process.exit(1)
+  })

--- a/integration-tests/src/create-user-atom.script.ts
+++ b/integration-tests/src/create-user-atom.script.ts
@@ -5,7 +5,7 @@ async function main() {
 
   const intuition = await getIntuition(0)
 
-  const userAddress = '0xf1016a7Fe89EB9D244c3bfB270071b24619e36C6'
+  const userAddress = '0x25d5C9DbC1E12163B973261A08739927E4F72BA8'
 
   console.log(`Creating atom for address ${userAddress}...`)
   const atom = await intuition.getOrCreateAtom(userAddress)

--- a/integration-tests/src/create-user-atom.script.ts
+++ b/integration-tests/src/create-user-atom.script.ts
@@ -5,7 +5,7 @@ async function main() {
 
   const intuition = await getIntuition(0)
 
-  const userAddress = '0x25d5C9DbC1E12163B973261A08739927E4F72BA8'
+  const userAddress = '0x1Bc35cAE544DF00BfdfEE6597c4E54850eFDD9af'
 
   console.log(`Creating atom for address ${userAddress}...`)
   const atom = await intuition.getOrCreateAtom(userAddress)

--- a/integration-tests/src/deposit-on-atom.script.ts
+++ b/integration-tests/src/deposit-on-atom.script.ts
@@ -1,0 +1,38 @@
+import { getIntuition, wait } from './setup/utils.js'
+import { parseEther, toHex } from 'viem'
+
+async function main() {
+  console.log('Starting deposit on atom script...\n')
+
+  const intuition = await getIntuition(0)
+
+  const userAddress = '0xf1016a7Fe89EB9D244c3bfB270071b24619e36C6'
+  const depositAmount = parseEther('0.1')
+
+  // Resolve the atom's vaultId from the address
+  const vaultId = await intuition.contract.read.calculateAtomId([toHex(userAddress)])
+  console.log(`Atom vaultId for ${userAddress}: ${vaultId}`)
+
+  // Deposit on the atom
+  console.log(`Depositing ${depositAmount} wei on atom...`)
+  const hash = await intuition.contract.write.deposit(
+    [intuition.account.address, vaultId, 1n, 0n],
+    { value: depositAmount },
+  )
+  console.log(`Transaction hash: ${hash}`)
+
+  console.log('Waiting for transaction to be indexed...')
+  await wait(hash)
+
+  console.log('\nDeposit complete!')
+}
+
+main()
+  .then(() => {
+    console.log('\nScript completed successfully')
+    process.exit(0)
+  })
+  .catch((error) => {
+    console.error('\nError:', error)
+    process.exit(1)
+  })

--- a/integration-tests/src/deposit-on-atom.script.ts
+++ b/integration-tests/src/deposit-on-atom.script.ts
@@ -6,7 +6,7 @@ async function main() {
 
   const intuition = await getIntuition(0)
 
-  const userAddress = '0xf1016a7Fe89EB9D244c3bfB270071b24619e36C6'
+  const userAddress = '0x25d5C9DbC1E12163B973261A08739927E4F72BA8'
   const depositAmount = parseEther('0.1')
 
   // Resolve the atom's vaultId from the address

--- a/integration-tests/src/deposit-on-atom.script.ts
+++ b/integration-tests/src/deposit-on-atom.script.ts
@@ -6,7 +6,7 @@ async function main() {
 
   const intuition = await getIntuition(0)
 
-  const userAddress = '0x25d5C9DbC1E12163B973261A08739927E4F72BA8'
+  const userAddress = '0x1Bc35cAE544DF00BfdfEE6597c4E54850eFDD9af'
   const depositAmount = parseEther('0.1')
 
   // Resolve the atom's vaultId from the address

--- a/integration-tests/src/setup/constants.ts
+++ b/integration-tests/src/setup/constants.ts
@@ -1,3 +1,9 @@
+import dotenv from 'dotenv'
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+dotenv.config({ path: resolve(fileURLToPath(import.meta.url), '../../../../.env') })
+
 import { createNonceManager, privateKeyToAccount } from 'viem/accounts'
 import { jsonRpc } from 'viem/nonce'
 

--- a/scripts/re-resolve-all-accounts.sh
+++ b/scripts/re-resolve-all-accounts.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Re-queues all accounts into the resolver stream so TNS names get refreshed.
+
+DB_CONTAINER="database"
+REDIS_CONTAINER="redis"
+REDIS_STREAM="resolver_stream"
+SCHEMA="public"
+
+echo "Fetching all accounts from database..."
+
+# Fetch accounts as: id|atom_id|label|image|account_type
+accounts=$(docker exec "$DB_CONTAINER" psql -U postgres -d storage -t -A -F'|' \
+  -c "SELECT id, COALESCE(atom_id, ''), label, COALESCE(image, ''), type FROM $SCHEMA.account;")
+
+count=0
+while IFS='|' read -r id atom_id label image account_type; do
+  [[ -z "$id" ]] && continue
+
+  # Build atom_id JSON value
+  if [[ -n "$atom_id" ]]; then
+    atom_id_json="\"$atom_id\""
+  else
+    atom_id_json="null"
+  fi
+
+  # Build image JSON value
+  if [[ -n "$image" ]]; then
+    escaped_image=$(echo "$image" | sed 's/"/\\"/g')
+    image_json="\"$escaped_image\""
+  else
+    image_json="null"
+  fi
+
+  message="{\"message\":{\"Account\":{\"id\":\"$id\",\"atom_id\":$atom_id_json,\"label\":\"$label\",\"image\":$image_json,\"account_type\":\"$account_type\"}}}"
+
+  docker exec "$REDIS_CONTAINER" redis-cli XADD "$REDIS_STREAM" '*' body "$message" > /dev/null
+  echo "  Queued: $id"
+  count=$((count + 1))
+done <<< "$accounts"
+
+echo "Done. Queued $count account(s) for re-resolution."


### PR DESCRIPTION
The TNS/ENS resolver is a consumer service that enriches account and atom data with human-readable names and avatars. When a deposit or atom creation event is processed, the decoded consumer re-queues the account for resolution via a Redis stream. The resolver consumer picks it up and attempts resolution in two steps:

TNS (Trust Name Service) is tried first. It performs a reverse lookup on the Intuition chain (https://intuition.calderachain.xyz) using the registry at 0x3220B4EDbA3a1661F02f1D8D241DBF55EDcDa09e. It hashes the address into an <addr>.addr.reverse node, finds the resolver contract, and calls name() to get the .trust domain. For the avatar, it queries the text record avatar on the resolver, first via the reverse node, then the forward node, then the forward resolver as a fallback.

ENS (Ethereum Name Service) is the fallback if TNS returns nothing. It performs the same reverse lookup but on Ethereum mainnet via the ENS registry at 0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e. Avatars are fetched from https://metadata.ens.domains/mainnet/avatar/{name}.

Once a name or avatar is resolved, the account label and image are updated in the database. If an avatar URL is found, it's also forwarded to the IPFS upload consumer to be pinned to IPFS/Pinata for permanent storage.

