### PR TITLE
fix: validate EIP-55 checksum before resolving ENS in resolver

### DIFF
--- a/apps/consumer/src/mode/resolver/types.rs
+++ b/apps/consumer/src/mode/resolver/types.rs
@@ -190,6 +190,21 @@ impl ResolverMessageType {
         resolver_consumer_context: &ResolverConsumerContext,
         account: &mut Account,
     ) -> Result<(), ConsumerError> {
+        // Validate EIP-55 checksum before resolving ENS
+        // Addresses with invalid checksums should be skipped to prevent false positives
+        match Address::parse_checksummed(&account.id, None) {
+            Ok(_) => {
+                debug!("Address {} has valid EIP-55 checksum, proceeding with ENS resolution", account.id);
+            }
+            Err(e) => {
+                debug!(
+                    "Address {} has invalid EIP-55 checksum, skipping ENS resolution: {}",
+                    account.id, e
+                );
+                return Ok(());
+            }
+        }
+
         let ens = Ens::get_ens(Address::from_str(&account.id)?, resolver_consumer_context).await?;
         if let Some(_name) = ens.name.clone() {
             debug!("ENS for account: {:?}", ens);


### PR DESCRIPTION
## Summary

Addresses GitHub issue #151: Check for EIP-55 when resolving account atoms.

## Changes

This change adds EIP-55 checksum validation in the resolver's `process_account` function. When an account with an invalid EIP-55 checksum is encountered, the ENS resolution is skipped instead of attempting to resolve it.

## Why

Previously, the resolver would attempt to resolve ENS for any valid Ethereum address format without validating the EIP-55 checksum. This could lead to:
- False positives in ENS resolution
- Potential issues with addresses that have incorrect checksum formatting

The validation uses `Address::parse_checksummed` from the alloy library, which is the same approach used in `metadata.rs` for atom creation validation.

## Testing

The change adds debug logging to indicate whether an address has valid or invalid EIP-55 checksum during the resolution process.