### PR TITLE
ENG-7947 feat: add market cap support to bonding curve chart (backend)

### DIFF
--- a/apps/chart-api/src/error.rs
+++ b/apps/chart-api/src/error.rs
@@ -6,11 +6,17 @@ use axum::{
 use serde::Serialize;
 use thiserror::Error;
 
-/// Error response body for JSON responses
+/// Extensions object for Hasura-compatible error responses
+#[derive(Serialize)]
+pub struct ErrorExtensions {
+    pub code: String,
+}
+
+/// Error response body for JSON responses (Hasura Action webhook format)
 #[derive(Serialize)]
 pub struct ErrorResponse {
-    pub error: String,
-    pub code: String,
+    pub message: String,
+    pub extensions: ErrorExtensions,
 }
 
 /// Error types for the Chart API
@@ -40,7 +46,7 @@ pub enum ApiError {
     InvalidCurveId(String),
     #[error("Invalid account_id: {0}. Must be a 0x-prefixed 40-character hex address")]
     InvalidAccountId(String),
-    #[error("Invalid graph type: {0}. Valid values are: sharePriceChange, totalMarketCap")]
+    #[error("Invalid graph type: {0}. Valid values are: sharePriceChange, totalMarketCap, marketCapPerCurve")]
     InvalidGraphType(String),
     #[error("Missing curve_id: this graph type requires a curve_id parameter")]
     MissingCurveId,
@@ -114,8 +120,10 @@ impl IntoResponse for ApiError {
         };
 
         let body = ErrorResponse {
-            error: self.to_string(),
-            code: self.code().to_string(),
+            message: self.to_string(),
+            extensions: ErrorExtensions {
+                code: self.code().to_string(),
+            },
         };
 
         (status, Json(body)).into_response()

--- a/apps/chart-api/src/types.rs
+++ b/apps/chart-api/src/types.rs
@@ -30,6 +30,9 @@ pub enum GraphType {
     /// Total market cap over time (term-level, no curve_id required)
     #[serde(rename = "totalMarketCap")]
     TotalMarketCap,
+    /// Per-curve market cap over time (requires curve_id)
+    #[serde(rename = "marketCapPerCurve")]
+    MarketCapPerCurve,
 }
 
 impl GraphType {
@@ -38,6 +41,7 @@ impl GraphType {
         match s.to_lowercase().replace('_', "").as_str() {
             "sharepricechange" => Some(GraphType::SharePriceChange),
             "totalmarketcap" => Some(GraphType::TotalMarketCap),
+            "marketcappercurve" | "marketcapercurve" => Some(GraphType::MarketCapPerCurve),
             _ => None,
         }
     }
@@ -47,6 +51,7 @@ impl GraphType {
         match self {
             GraphType::SharePriceChange => true,
             GraphType::TotalMarketCap => false,
+            GraphType::MarketCapPerCurve => true,
         }
     }
 
@@ -55,6 +60,7 @@ impl GraphType {
         match self {
             GraphType::SharePriceChange => "share_price_change_stats",
             GraphType::TotalMarketCap => "term_total_state_change_stats",
+            GraphType::MarketCapPerCurve => "share_price_mcap_stats",
         }
     }
 
@@ -68,6 +74,7 @@ impl GraphType {
         match self {
             GraphType::SharePriceChange => "last_share_price",
             GraphType::TotalMarketCap => "last_total_market_cap",
+            GraphType::MarketCapPerCurve => "last_market_cap",
         }
     }
 }
@@ -77,6 +84,7 @@ impl fmt::Display for GraphType {
         match self {
             GraphType::SharePriceChange => write!(f, "sharePriceChange"),
             GraphType::TotalMarketCap => write!(f, "totalMarketCap"),
+            GraphType::MarketCapPerCurve => write!(f, "marketCapPerCurve"),
         }
     }
 }
@@ -181,7 +189,7 @@ pub struct ChartQueryParams {
     pub start: String,
     /// Range end timestamp (unix seconds, unix milliseconds, or RFC3339)
     pub end: String,
-    /// Graph type: sharePriceChange (default), totalMarketCap
+    /// Graph type: sharePriceChange (default), totalMarketCap, marketCapPerCurve
     pub graph_type: Option<String>,
     /// Optional: SVG width in pixels (default: 800)
     pub width: Option<u32>,

--- a/infrastructure/hasura/migrations/intuition/1740700000000_add_per_curve_mcap_aggregates/down.sql
+++ b/infrastructure/hasura/migrations/intuition/1740700000000_add_per_curve_mcap_aggregates/down.sql
@@ -1,0 +1,7 @@
+-- Down migration: drop per-curve market cap continuous aggregates
+-- Drop in reverse dependency order (monthly/weekly/daily before hourly)
+
+DROP MATERIALIZED VIEW IF EXISTS share_price_mcap_stats_monthly;
+DROP MATERIALIZED VIEW IF EXISTS share_price_mcap_stats_weekly;
+DROP MATERIALIZED VIEW IF EXISTS share_price_mcap_stats_daily;
+DROP MATERIALIZED VIEW IF EXISTS share_price_mcap_stats_hourly;

--- a/infrastructure/hasura/migrations/intuition/1740700000000_add_per_curve_mcap_aggregates/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1740700000000_add_per_curve_mcap_aggregates/up.sql
@@ -1,0 +1,89 @@
+-- ========================================
+-- PER-CURVE MARKET CAP CONTINUOUS AGGREGATES
+-- ========================================
+-- Computes market cap (share_price * total_shares / 10^18) per term_id and curve_id
+-- sourced directly from share_price_change which already has both share_price,
+-- total_shares, and curve_id per event.
+--
+-- This enables per-curve mcap charts (e.g. curve_id=1 vs curve_id=2 show different data).
+-- Unlike term_total_state_change_stats which aggregates across all curves.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS share_price_mcap_stats_hourly
+WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 h'::interval, updated_at) as bucket,
+    term_id,
+    curve_id,
+    LAST(share_price * total_shares / 1000000000000000000::numeric, updated_at) as last_market_cap,
+    FIRST(share_price * total_shares / 1000000000000000000::numeric, updated_at) as first_market_cap,
+    LAST(share_price * total_shares / 1000000000000000000::numeric, updated_at) - FIRST(share_price * total_shares / 1000000000000000000::numeric, updated_at) as difference,
+    count(*) as change_count
+FROM share_price_change
+GROUP BY 1, 2, 3;
+
+ALTER MATERIALIZED VIEW share_price_mcap_stats_hourly set (timescaledb.materialized_only = false);
+
+SELECT add_continuous_aggregate_policy('share_price_mcap_stats_hourly',
+  start_offset => INTERVAL '3 hours',
+  end_offset => INTERVAL '1 h',
+  schedule_interval => INTERVAL '1 h');
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS share_price_mcap_stats_daily
+WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 day'::interval, bucket) as bucket,
+    term_id,
+    curve_id,
+    LAST(last_market_cap, bucket) as last_market_cap,
+    FIRST(first_market_cap, bucket) as first_market_cap,
+    LAST(last_market_cap, bucket) - FIRST(first_market_cap, bucket) as difference,
+    sum(change_count) as change_count
+FROM share_price_mcap_stats_hourly
+GROUP BY 1, 2, 3;
+
+ALTER MATERIALIZED VIEW share_price_mcap_stats_daily set (timescaledb.materialized_only = false);
+
+SELECT add_continuous_aggregate_policy('share_price_mcap_stats_daily',
+  start_offset => INTERVAL '3 days',
+  end_offset => INTERVAL '1 day',
+  schedule_interval => INTERVAL '1 day');
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS share_price_mcap_stats_weekly
+WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 week'::interval, bucket) as bucket,
+    term_id,
+    curve_id,
+    LAST(last_market_cap, bucket) as last_market_cap,
+    FIRST(first_market_cap, bucket) as first_market_cap,
+    LAST(last_market_cap, bucket) - FIRST(first_market_cap, bucket) as difference,
+    sum(change_count) as change_count
+FROM share_price_mcap_stats_daily
+GROUP BY 1, 2, 3;
+
+ALTER MATERIALIZED VIEW share_price_mcap_stats_weekly set (timescaledb.materialized_only = false);
+
+SELECT add_continuous_aggregate_policy('share_price_mcap_stats_weekly',
+  start_offset => INTERVAL '3 weeks',
+  end_offset => INTERVAL '1 week',
+  schedule_interval => INTERVAL '1 week');
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS share_price_mcap_stats_monthly
+WITH (timescaledb.continuous)
+AS SELECT
+    time_bucket('1 month'::interval, bucket) as bucket,
+    term_id,
+    curve_id,
+    LAST(last_market_cap, bucket) as last_market_cap,
+    FIRST(first_market_cap, bucket) as first_market_cap,
+    LAST(last_market_cap, bucket) - FIRST(first_market_cap, bucket) as difference,
+    sum(change_count) as change_count
+FROM share_price_mcap_stats_daily
+GROUP BY 1, 2, 3;
+
+ALTER MATERIALIZED VIEW share_price_mcap_stats_monthly set (timescaledb.materialized_only = false);
+
+SELECT add_continuous_aggregate_policy('share_price_mcap_stats_monthly',
+  start_offset => INTERVAL '3 months',
+  end_offset => INTERVAL '1 month',
+  schedule_interval => INTERVAL '1 week');


### PR DESCRIPTION
## Summary
- Fix chart-api error response format for Hasura webhook compatibility
- Add per-curve market cap continuous aggregates from existing `share_price_change` data
- Add `MarketCapPerCurve` graph type to chart-api

## Key Changes

### ENG-9136: Error Response Format
- Error responses now use `{"message": "...", "extensions": {"code": "..."}}` (Hasura ActionWebhookErrorResponse format)
- Previously used `{"error": "...", "code": "..."}` which caused Hasura to fail with `key "message" not found`

### ENG-9138: Per-Curve Market Cap Aggregates
- **Migration**: 4 new continuous aggregates (`share_price_mcap_stats_{hourly,daily,weekly,monthly}`) computing `share_price * total_shares / 10^18` per `term_id` and `curve_id`
- **Chart-api**: New `MarketCapPerCurve` graph type — `requires_curve_id: true`, queries `share_price_mcap_stats_*` views, reads `last_market_cap` column
- Cascading rollup pattern (hourly → daily → weekly/monthly) matches existing `share_price_change_stats_*` views

## Test Plan
- [ ] Requesting `graphType=marketCapPerCurve` with `curve_id=1` and `curve_id=2` returns different data
- [ ] All timeframes (1h, 1d, 1w, 1m) return correct per-curve mcap data
- [ ] Error responses from chart-api now parse correctly in Hasura
- [ ] Existing `sharePriceChange` and `totalMarketCap` graph types unaffected
- [ ] Requesting `marketCapPerCurve` without `curve_id` returns proper error

🤖 Generated with [Claude Code](https://claude.com/claude-code)