### PR TITLE
Fixing transaction atomocity for resolver consumers

### DIFF
--- a/apps/consumer/src/mode/resolver/atom_resolver.rs
+++ b/apps/consumer/src/mode/resolver/atom_resolver.rs
@@ -35,7 +35,7 @@ pub async fn try_to_resolve_ipfs_uri(
     resolver_consumer_context: &ResolverConsumerContext,
 ) -> Result<Option<Response>, ConsumerError> {
     // Handle IPFS URIs
-    warn!("Trying to resolve IPFS URI: {}", atom_data);
+    debug!("Trying to resolve IPFS URI: {}", atom_data);
     if let Some(ipfs_hash) = atom_data.strip_prefix("ipfs://") {
         if let Ok(ipfs_data) = resolver_consumer_context
             .ipfs_resolver
@@ -50,7 +50,7 @@ pub async fn try_to_resolve_ipfs_uri(
             Ok(None)
         }
     } else {
-        warn!("Atom data is not an IPFS URI: {}", atom_data);
+        debug!("Atom data is not an IPFS URI: {}", atom_data);
         Ok(None)
     }
 }

--- a/apps/consumer/src/mode/resolver/types.rs
+++ b/apps/consumer/src/mode/resolver/types.rs
@@ -21,7 +21,6 @@ use models::{
     types::FixedBytesWrapper,
 };
 use serde::{Deserialize, Serialize};
-use sqlx::{Postgres, Transaction};
 use std::str::FromStr;
 use tracing::debug;
 
@@ -218,23 +217,26 @@ impl ResolverMessageType {
         Ok(())
     }
 
-    /// This function processes an atom message type
+    /// This function processes an atom message type.
+    ///
+    /// Network I/O (IPFS fetches, etc.) is performed before any DB writes
+    /// to avoid holding database connections during slow external requests.
     async fn process_atom(
         &self,
         resolver_consumer_context: &ResolverConsumerContext,
         atom_id: &str,
     ) -> Result<(), ConsumerError> {
-        let mut tx = resolver_consumer_context.pg_pool.begin().await?;
-
+        // Phase 1: Fetch atom and resolve data (includes network I/O like IPFS)
+        // No transaction needed — this avoids holding a DB connection during slow fetches
         let metadata = self
-            .resolve_and_parse_atom_data(resolver_consumer_context, atom_id, &mut tx)
+            .resolve_and_parse_atom_data(resolver_consumer_context, atom_id)
             .await?;
         debug!("Metadata: {:?}", metadata);
 
-        // If the atom type is not unknown, we handle the new atom type that was resolved
+        // Phase 2: DB writes only (fast path)
         if AtomType::from_str(&metadata.atom_type)? != AtomType::Unknown {
             debug!("Handling known atom type: {:?}", metadata);
-            self.handle_known_atom_type(resolver_consumer_context, atom_id, metadata, &mut tx)
+            self.handle_known_atom_type(resolver_consumer_context, atom_id, metadata)
                 .await?;
         } else {
             self.mark_atom_as_failed(
@@ -242,21 +244,22 @@ impl ResolverMessageType {
                     .server_initialize
                     .env
                     .backend_schema,
-                &mut tx,
+                &resolver_consumer_context.pg_pool,
                 &FixedBytesWrapper::from_str(atom_id)?,
             )
             .await?;
         }
-        tx.commit().await?;
         Ok(())
     }
 
-    /// This function resolves and parses the atom data
+    /// This function resolves and parses the atom data.
+    ///
+    /// Uses the connection pool for the initial read and performs all network I/O
+    /// (IPFS fetches) without holding a transaction open.
     async fn resolve_and_parse_atom_data(
         &self,
         resolver_consumer_context: &ResolverConsumerContext,
         atom_id: &str,
-        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<AtomMetadata, ConsumerError> {
         let atom = Atom::find_by_id(
             FixedBytesWrapper::from_str(atom_id)?,
@@ -264,7 +267,7 @@ impl ResolverMessageType {
                 .server_initialize
                 .env
                 .backend_schema,
-            tx.as_mut(),
+            &resolver_consumer_context.pg_pool,
         )
         .await?
         .ok_or(ConsumerError::AtomDataNotFound)?;
@@ -321,10 +324,9 @@ impl ResolverMessageType {
         resolver_consumer_context: &ResolverConsumerContext,
         atom_id: &str,
         metadata: AtomMetadata,
-        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<(), ConsumerError> {
         let atom = self
-            .find_and_update_atom(resolver_consumer_context, atom_id, metadata, tx)
+            .find_and_update_atom(resolver_consumer_context, atom_id, metadata)
             .await?;
 
         if let Some(image) = atom.image.clone() {
@@ -337,7 +339,7 @@ impl ResolverMessageType {
                 .server_initialize
                 .env
                 .backend_schema,
-            tx.as_mut(),
+            &resolver_consumer_context.pg_pool,
         )
         .await?;
 
@@ -351,20 +353,18 @@ impl ResolverMessageType {
         resolver_consumer_context: &ResolverConsumerContext,
         atom_id: &str,
         metadata: AtomMetadata,
-        tx: &mut Transaction<'_, Postgres>,
     ) -> Result<Atom, ConsumerError> {
-        let atom = Atom::find_by_id(
+        let mut atom = Atom::find_by_id(
             FixedBytesWrapper::from_str(atom_id)?,
             &resolver_consumer_context
                 .server_initialize
                 .env
                 .backend_schema,
-            tx.as_mut(),
+            &resolver_consumer_context.pg_pool,
         )
         .await?
         .ok_or(ConsumerError::AtomNotFound)?;
 
-        let mut atom = atom;
         metadata
             .update_atom_metadata(
                 &mut atom,
@@ -396,13 +396,13 @@ impl ResolverMessageType {
     async fn mark_atom_as_failed(
         &self,
         backend_schema: &str,
-        tx: &mut Transaction<'_, Postgres>,
+        pg_pool: &sqlx::PgPool,
         atom_id: &FixedBytesWrapper,
     ) -> Result<(), ConsumerError> {
-        let atom = Atom::find_by_id(atom_id.clone(), backend_schema, tx.as_mut())
+        let atom = Atom::find_by_id(atom_id.clone(), backend_schema, pg_pool)
             .await?
             .ok_or(ConsumerError::AtomNotFound)?;
-        atom.mark_as_failed(backend_schema, tx.as_mut())
+        atom.mark_as_failed(backend_schema, pg_pool)
             .await
             .map_err(ConsumerError::from)
     }

--- a/release_notes/consumer-3.0.61.md
+++ b/release_notes/consumer-3.0.61.md
@@ -1,0 +1,35 @@
+# consumer:3.0.61
+
+**Date:** 2026-02-27
+
+## Fix: Resolver consumer database connection pool starvation
+
+### Problem
+
+The resolver consumer was experiencing database connection pool exhaustion, causing batch processing to stall (batches taking 60+ seconds instead of ~2.5s) and messages to accumulate in the Redis PEL (Pending Entry List).
+
+**Root cause:** The `process_atom()` function opened a database transaction (`BEGIN`) to fetch an atom, then performed slow network I/O (IPFS fetches, HTTP requests) while the transaction remained open. This left connections in an `idle in transaction` state for the entire duration of external requests (potentially 30-60+ seconds per message). With 10 concurrent workers and a pool of 10 connections, all connections would become parked during slow IPFS fetches, starving new requests.
+
+Additionally, the transaction provided no actual atomicity — sub-operations (upserts for TextObject, JsonObject, AtomValue, etc.) were already using the connection pool directly instead of the transaction handle, making the transaction purely a source of connection waste.
+
+### Fix
+
+Removed the unnecessary transaction from the resolver consumer's atom processing path. All network I/O (IPFS fetches, RPC calls) now runs without holding a database connection. DB connections are only acquired for individual, short-lived queries and upserts.
+
+### Changes
+
+- `apps/consumer/src/mode/resolver/types.rs`
+  - `process_atom()` — removed transaction; network I/O and DB writes use the pool directly
+  - `resolve_and_parse_atom_data()` — removed `tx` parameter, uses pool for initial atom read
+  - `handle_known_atom_type()` — removed `tx` parameter
+  - `find_and_update_atom()` — removed `tx` parameter, uses pool consistently
+  - `mark_atom_as_failed()` — changed from transaction to pool
+
+- `apps/consumer/src/mode/resolver/atom_resolver.rs`
+  - Reduced log verbosity for non-IPFS atom data checks from `warn!` to `debug!` (these fire for every non-IPFS atom and were flooding logs, making real issues hard to spot)
+
+### Impact
+
+- **Scope:** Resolver consumer only. Decoded, raw, and IPFS upload consumers are unaffected.
+- **Safety:** All DB writes in the resolver path are idempotent upserts, so transactional atomicity was not required.
+- **Expected result:** Eliminates `idle in transaction` connection starvation, restoring normal batch processing throughput (~2.5s per batch of 100 messages).


### PR DESCRIPTION
## Fix: Resolver consumer database connection pool starvation

### Problem

The resolver consumer was experiencing database connection pool exhaustion, causing batch processing to stall (batches taking 60+ seconds instead of ~2.5s) and messages to accumulate in the Redis PEL (Pending Entry List).

**Root cause:** The `process_atom()` function opened a database transaction (`BEGIN`) to fetch an atom, then performed slow network I/O (IPFS fetches, HTTP requests) while the transaction remained open. This left connections in an `idle in transaction` state for the entire duration of external requests (potentially 30-60+ seconds per message). With 10 concurrent workers and a pool of 10 connections, all connections would become parked during slow IPFS fetches, starving new requests.

Additionally, the transaction provided no actual atomicity — sub-operations (upserts for TextObject, JsonObject, AtomValue, etc.) were already using the connection pool directly instead of the transaction handle, making the transaction purely a source of connection waste.

### Fix

Removed the unnecessary transaction from the resolver consumer's atom processing path. All network I/O (IPFS fetches, RPC calls) now runs without holding a database connection. DB connections are only acquired for individual, short-lived queries and upserts.

### Changes

- `apps/consumer/src/mode/resolver/types.rs`
  - `process_atom()` — removed transaction; network I/O and DB writes use the pool directly
  - `resolve_and_parse_atom_data()` — removed `tx` parameter, uses pool for initial atom read
  - `handle_known_atom_type()` — removed `tx` parameter
  - `find_and_update_atom()` — removed `tx` parameter, uses pool consistently
  - `mark_atom_as_failed()` — changed from transaction to pool

- `apps/consumer/src/mode/resolver/atom_resolver.rs`
  - Reduced log verbosity for non-IPFS atom data checks from `warn!` to `debug!` (these fire for every non-IPFS atom and were flooding logs, making real issues hard to spot)

### Impact

- **Scope:** Resolver consumer only. Decoded, raw, and IPFS upload consumers are unaffected.
- **Safety:** All DB writes in the resolver path are idempotent upserts, so transactional atomicity was not required.
- **Expected result:** Eliminates `idle in transaction` connection starvation, restoring normal batch processing throughput (~2.5s per batch of 100 messages).
