### PR TITLE
Adding migration to fix vaults with negative positions

### DIFF
--- a/infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/down.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS vault_recalculate_position_count_on_insert ON vault;
+DROP FUNCTION IF EXISTS recalculate_vault_position_count_on_insert();

--- a/infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/up.sql
@@ -1,0 +1,43 @@
+-- Fix: When a vault is created, calculate position_count from existing positions
+-- instead of using the default value (0). This handles the race condition where
+-- Deposited events create positions before the SharePriceChanged event creates
+-- the vault, causing the position INSERT trigger's increment to be lost.
+--
+-- The BEFORE INSERT trigger fires before the row is written, so we can override
+-- the position_count with the correct value. For ON CONFLICT DO UPDATE cases
+-- (vault already exists), this trigger fires but its changes are discarded since
+-- the UPDATE path is taken instead — which is the correct behavior since the
+-- vault already has a valid position_count maintained by the position triggers.
+
+CREATE OR REPLACE FUNCTION recalculate_vault_position_count_on_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.position_count := COALESCE(
+        (SELECT COUNT(*)::int
+         FROM position
+         WHERE term_id = NEW.term_id
+           AND curve_id = NEW.curve_id
+           AND shares > 0),
+        0
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER vault_recalculate_position_count_on_insert
+    BEFORE INSERT ON vault
+    FOR EACH ROW
+EXECUTE FUNCTION recalculate_vault_position_count_on_insert();
+
+-- Fix existing data: recalculate vault.position_count for all negative values.
+-- The AFTER UPDATE trigger on vault (update_triple_vault_from_vault) will
+-- automatically cascade to triple_term, predicate_object, and subject_predicate.
+UPDATE vault v
+SET position_count = COALESCE(
+    (SELECT COUNT(*)::int
+     FROM position p
+     WHERE p.term_id = v.term_id
+       AND p.curve_id = v.curve_id
+       AND p.shares > 0),
+    0)
+WHERE v.position_count < 0;

--- a/infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/up.sql
@@ -29,9 +29,10 @@ CREATE TRIGGER vault_recalculate_position_count_on_insert
     FOR EACH ROW
 EXECUTE FUNCTION recalculate_vault_position_count_on_insert();
 
--- Fix existing data: recalculate vault.position_count for all negative values.
+-- Fix existing data: recalculate vault.position_count for negative values.
 -- The AFTER UPDATE trigger on vault (update_triple_vault_from_vault) will
 -- automatically cascade to triple_term, predicate_object, and subject_predicate.
+-- NOTE: Non-negative undercounts are fixed in migration 1771526407000.
 UPDATE vault v
 SET position_count = COALESCE(
     (SELECT COUNT(*)::int

--- a/infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/down.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/down.sql
@@ -1,0 +1,1 @@
+-- No-op: data-only migration, cannot be reversed.

--- a/infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/up.sql
@@ -2,13 +2,16 @@
 -- The same race condition also causes undercounts that stay at 0 or above (the position
 -- was never redeemed, so position_count never went negative — it just stayed wrong).
 --
--- Strategy: temporarily increase statement_timeout for this transaction only (SET LOCAL),
--- then run a batched DO block. SET LOCAL scopes the timeout to the current transaction
--- so it cannot affect other sessions or persist after the migration completes.
+-- Strategy: wrap the batched loop in a named function with a SET clause.
+-- PostgreSQL function-level SET overrides the session statement_timeout and
+-- reschedules the timer when entering the function, so this works even when
+-- Hasura applies migrations with --no-transaction (each statement goes through
+-- a separate connection from the pool, making session-level SET unreliable).
 
-SET LOCAL statement_timeout = '30min';
-
-DO $$
+CREATE OR REPLACE FUNCTION _fix_vault_position_count_undercount()
+RETURNS void
+SET statement_timeout = '30min'
+LANGUAGE plpgsql AS $$
 DECLARE
     batch_size INT := 100;
     total_fixed INT := 0;
@@ -45,3 +48,7 @@ BEGIN
     RAISE NOTICE 'Done. Total vaults fixed: %', total_fixed;
 END;
 $$;
+
+SELECT _fix_vault_position_count_undercount();
+
+DROP FUNCTION _fix_vault_position_count_undercount();

--- a/infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/up.sql
@@ -1,0 +1,45 @@
+-- Fix: The previous migration (1771526406000) only fixed vaults with position_count < 0.
+-- The same race condition also causes undercounts that stay at 0 or above (the position
+-- was never redeemed, so position_count never went negative — it just stayed wrong).
+-- Total additionally affected: ~2028 vaults undercounted by 1.
+--
+-- Done in batches of 200 to avoid statement timeouts from the cascade triggers
+-- (update_triple_vault_from_vault -> triple_term -> predicate_object -> subject_predicate).
+
+DO $$
+DECLARE
+    batch_size INT := 200;
+    total_fixed INT := 0;
+    batch_fixed INT;
+BEGIN
+    LOOP
+        WITH mismatched AS (
+            SELECT v.term_id, v.curve_id,
+                   (SELECT COUNT(*)::int FROM position p
+                    WHERE p.term_id = v.term_id
+                      AND p.curve_id = v.curve_id
+                      AND p.shares > 0) AS correct_count
+            FROM vault v
+            WHERE v.position_count <> (
+                SELECT COUNT(*)::int FROM position p
+                WHERE p.term_id = v.term_id
+                  AND p.curve_id = v.curve_id
+                  AND p.shares > 0)
+            LIMIT batch_size
+        )
+        UPDATE vault v
+        SET position_count = m.correct_count
+        FROM mismatched m
+        WHERE v.term_id = m.term_id AND v.curve_id = m.curve_id;
+
+        GET DIAGNOSTICS batch_fixed = ROW_COUNT;
+        total_fixed := total_fixed + batch_fixed;
+
+        EXIT WHEN batch_fixed = 0;
+
+        RAISE NOTICE 'Fixed % vaults so far (% this batch)', total_fixed, batch_fixed;
+    END LOOP;
+
+    RAISE NOTICE 'Done. Total vaults fixed: %', total_fixed;
+END;
+$$;

--- a/infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/up.sql
@@ -1,29 +1,31 @@
 -- Fix: The previous migration (1771526406000) only fixed vaults with position_count < 0.
 -- The same race condition also causes undercounts that stay at 0 or above (the position
 -- was never redeemed, so position_count never went negative — it just stayed wrong).
--- Total additionally affected: ~2028 vaults undercounted by 1.
 --
--- Done in batches of 200 to avoid statement timeouts from the cascade triggers
--- (update_triple_vault_from_vault -> triple_term -> predicate_object -> subject_predicate).
+-- Strategy: temporarily increase statement_timeout for this transaction only (SET LOCAL),
+-- then run a batched DO block. SET LOCAL scopes the timeout to the current transaction
+-- so it cannot affect other sessions or persist after the migration completes.
+
+SET LOCAL statement_timeout = '30min';
 
 DO $$
 DECLARE
-    batch_size INT := 200;
+    batch_size INT := 100;
     total_fixed INT := 0;
     batch_fixed INT;
 BEGIN
     LOOP
         WITH mismatched AS (
-            SELECT v.term_id, v.curve_id,
+            SELECT v2.term_id, v2.curve_id,
                    (SELECT COUNT(*)::int FROM position p
-                    WHERE p.term_id = v.term_id
-                      AND p.curve_id = v.curve_id
+                    WHERE p.term_id = v2.term_id
+                      AND p.curve_id = v2.curve_id
                       AND p.shares > 0) AS correct_count
-            FROM vault v
-            WHERE v.position_count <> (
+            FROM vault v2
+            WHERE v2.position_count <> (
                 SELECT COUNT(*)::int FROM position p
-                WHERE p.term_id = v.term_id
-                  AND p.curve_id = v.curve_id
+                WHERE p.term_id = v2.term_id
+                  AND p.curve_id = v2.curve_id
                   AND p.shares > 0)
             LIMIT batch_size
         )

--- a/release_notes/hasura-migrations-3.1.2.md
+++ b/release_notes/hasura-migrations-3.1.2.md
@@ -10,7 +10,7 @@ Portal displays negative supporter counts (-1, and -2 in aggregate views) when s
 
 **Affected tables:** `vault.position_count`, `triple_term.supporter_count`, `predicate_object.supporter_count`, `subject_predicate.supporter_count`
 
-**Scale:** 78 vaults with `position_count = -1`, cascading to negative `supporter_count` in `triple_term`, `predicate_object` (min: -1), and `subject_predicate` (min: -2, from two affected triples summing).
+**Scale:** 2106 vaults affected total — 78 with `position_count = -1` (where the position was subsequently redeemed, pushing the count negative) and 2028 undercounted by 1 (where the position was never redeemed, so the count stayed at 0 instead of the correct 1). The negative values cascaded to `supporter_count` in `triple_term`, `predicate_object` (min: -1), and `subject_predicate` (min: -2, from two affected triples summing).
 
 **Root cause:** Event ordering race condition between `Deposited` and `SharePriceChanged` events in the decoded consumer.
 
@@ -37,26 +37,25 @@ New function `recalculate_vault_position_count_on_insert()` fires before a vault
 
 This compensates for any lost increments from positions that were created before their vault. For `ON CONFLICT DO UPDATE` cases (vault already exists), the trigger fires but its changes are discarded since the UPDATE path is taken — which is correct since the vault already has a valid `position_count`.
 
-#### 2. Data backfill (fixes existing negative values)
+#### 2. Data backfill (fixes all existing mismatched values)
 
-Updates all 78 vaults with `position_count < 0` to the correct value calculated from actual positions. The existing `AFTER UPDATE` trigger on `vault` (`update_triple_vault_from_vault`) automatically cascades the fix to `triple_term`, `predicate_object`, and `subject_predicate`.
+Recalculates `position_count` for all 2106 vaults where the stored count doesn't match the actual number of positions with `shares > 0`. Runs in batches of 200 to avoid statement timeouts from cascade triggers. The existing `AFTER UPDATE` trigger on `vault` (`update_triple_vault_from_vault`) automatically cascades the fix to `triple_term`, `predicate_object`, and `subject_predicate`.
 
-### Migration
+### Migrations
 
-`1771526406000_fix_vault_position_count_on_insert`
+#### `1771526406000_fix_vault_position_count_on_insert`
 
-### Changes
+- `recalculate_vault_position_count_on_insert()` — BEFORE INSERT trigger function on `vault` that calculates `position_count` from existing positions
+- `vault_recalculate_position_count_on_insert` — trigger binding
+- Data fix for the 78 vaults with `position_count < 0`
 
-- `infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/up.sql`
-  - `recalculate_vault_position_count_on_insert()` — BEFORE INSERT trigger function on `vault` that calculates `position_count` from existing positions
-  - `vault_recalculate_position_count_on_insert` — trigger binding
-  - Data fix UPDATE for all vaults with `position_count < 0`
+#### `1771526407000_fix_vault_position_count_undercount`
 
-- `infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/down.sql`
-  - Drops the trigger and function
+- Batched data fix (200 rows per batch) for all remaining ~2028 vaults where `position_count` is undercounted but not negative
+- Runs in a `DO` block loop to stay within statement timeout limits, since each vault UPDATE cascades through `update_triple_vault_from_vault` triggers
 
 ### Impact
 
 - **Scope:** `vault`, `triple_term`, `predicate_object`, `subject_predicate` tables. No Rust code changes.
-- **Safety:** The BEFORE INSERT trigger only runs on vault creation (not updates). The COUNT query is scoped to a specific `(term_id, curve_id)` pair, so performance impact is negligible. The data fix UPDATE targets only the 78 affected rows and cascades via existing triggers.
-- **Expected result:** All negative `supporter_count` / `opposer_count` / `position_count` values corrected to 0. Future vault creations will initialize with the correct count even when positions are created before the vault.
+- **Safety:** The BEFORE INSERT trigger only runs on vault creation (not updates). The COUNT query is scoped to a specific `(term_id, curve_id)` pair, so performance impact is negligible. The data backfill runs in batches of 200 to stay within statement timeout limits.
+- **Expected result:** All 2106 mismatched `position_count` values corrected, with cascading fixes to `supporter_count` / `opposer_count` in `triple_term`, `predicate_object`, and `subject_predicate`. Future vault creations will initialize with the correct count even when positions are created before the vault.

--- a/release_notes/hasura-migrations-3.1.2.md
+++ b/release_notes/hasura-migrations-3.1.2.md
@@ -1,0 +1,62 @@
+# hasura-migrations:3.1.2
+
+**Date:** 2026-02-27
+
+## Fix: Negative supporter/opposer counts on triples
+
+### Problem
+
+Portal displays negative supporter counts (-1, and -2 in aggregate views) when sorting claims by fewest supporters on `/explore/triples`. The negative values appear in both list views and triple detail pages.
+
+**Affected tables:** `vault.position_count`, `triple_term.supporter_count`, `predicate_object.supporter_count`, `subject_predicate.supporter_count`
+
+**Scale:** 78 vaults with `position_count = -1`, cascading to negative `supporter_count` in `triple_term`, `predicate_object` (min: -1), and `subject_predicate` (min: -2, from two affected triples summing).
+
+**Root cause:** Event ordering race condition between `Deposited` and `SharePriceChanged` events in the decoded consumer.
+
+For a deposit, the blockchain emits events in this order within the same block:
+
+1. `Deposited` (log_index N)
+2. `SharePriceChanged` (log_index N+1)
+
+The consumer processes them sequentially:
+
+1. **Deposited handler** creates a position with `shares > 0`. The `AFTER INSERT` trigger on `position` fires and tries to increment `vault.position_count`, but the vault row doesn't exist yet (it's created by the next event). The trigger retries 5 times, fails, logs a WARNING, and the **increment is lost**.
+
+2. **SharePriceChanged handler** creates the vault with `position_count = 0` (doesn't know about the lost increment).
+
+3. Later, when the position is **redeemed** (shares -> 0), the `AFTER UPDATE` trigger fires and successfully decrements `vault.position_count` from 0 to -1.
+
+The negative `vault.position_count` then propagates through existing triggers: `vault` -> `triple_term.supporter_count` / `opposer_count` -> `predicate_object` / `subject_predicate` aggregates.
+
+### Fix
+
+#### 1. BEFORE INSERT trigger on vault (prevents future occurrences)
+
+New function `recalculate_vault_position_count_on_insert()` fires before a vault row is written. It overrides the incoming `position_count` with the actual count of existing positions that have `shares > 0` for that `(term_id, curve_id)` pair.
+
+This compensates for any lost increments from positions that were created before their vault. For `ON CONFLICT DO UPDATE` cases (vault already exists), the trigger fires but its changes are discarded since the UPDATE path is taken — which is correct since the vault already has a valid `position_count`.
+
+#### 2. Data backfill (fixes existing negative values)
+
+Updates all 78 vaults with `position_count < 0` to the correct value calculated from actual positions. The existing `AFTER UPDATE` trigger on `vault` (`update_triple_vault_from_vault`) automatically cascades the fix to `triple_term`, `predicate_object`, and `subject_predicate`.
+
+### Migration
+
+`1771526406000_fix_vault_position_count_on_insert`
+
+### Changes
+
+- `infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/up.sql`
+  - `recalculate_vault_position_count_on_insert()` — BEFORE INSERT trigger function on `vault` that calculates `position_count` from existing positions
+  - `vault_recalculate_position_count_on_insert` — trigger binding
+  - Data fix UPDATE for all vaults with `position_count < 0`
+
+- `infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/down.sql`
+  - Drops the trigger and function
+
+### Impact
+
+- **Scope:** `vault`, `triple_term`, `predicate_object`, `subject_predicate` tables. No Rust code changes.
+- **Safety:** The BEFORE INSERT trigger only runs on vault creation (not updates). The COUNT query is scoped to a specific `(term_id, curve_id)` pair, so performance impact is negligible. The data fix UPDATE targets only the 78 affected rows and cascades via existing triggers.
+- **Expected result:** All negative `supporter_count` / `opposer_count` / `position_count` values corrected to 0. Future vault creations will initialize with the correct count even when positions are created before the vault.

--- a/release_notes/hasura-migrations-3.1.3.md
+++ b/release_notes/hasura-migrations-3.1.3.md
@@ -1,0 +1,34 @@
+# hasura-migrations:3.1.3
+
+**Date:** 2026-02-27
+
+## Fix: Undercounted vault position_count (follow-up to 3.1.2)
+
+### Problem
+
+The 3.1.2 migration fixed 78 vaults with negative `position_count`, but the same race condition also caused ~2028 additional vaults to be undercounted by 1 without going negative. These are cases where the position was created before the vault (lost increment) but was never redeemed, so `position_count` stayed at 0 instead of the correct 1.
+
+This means Portal was showing 0 supporters for triples that actually had 1 active supporter.
+
+See `hasura-migrations-3.1.2.md` for the full root cause analysis.
+
+### Fix
+
+Batched data backfill that recalculates `vault.position_count` from actual positions for all remaining mismatched vaults. Runs in batches of 200 to stay within statement timeout limits, since each vault UPDATE cascades through `update_triple_vault_from_vault` triggers to `triple_term`, `predicate_object`, and `subject_predicate`.
+
+### Migration
+
+`1771526407000_fix_vault_position_count_undercount`
+
+### Changes
+
+- `infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/up.sql`
+  - `DO` block that loops in batches of 200, finding vaults where `position_count` differs from the actual count of positions with `shares > 0`, and corrects them
+- `infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/down.sql`
+  - No-op (data-only migration)
+
+### Impact
+
+- **Scope:** Same tables as 3.1.2 — `vault`, `triple_term`, `predicate_object`, `subject_predicate`. No Rust code changes.
+- **Safety:** Data-only migration. Each batch of 200 updates commits independently. Cascade triggers update aggregate tables automatically.
+- **Expected result:** ~2028 additional vaults corrected from `position_count = 0` to `position_count = 1`, with cascading fixes to `supporter_count` in aggregate tables.

--- a/release_notes/hasura-migrations-3.1.4.md
+++ b/release_notes/hasura-migrations-3.1.4.md
@@ -1,4 +1,4 @@
-# hasura-migrations:3.1.3
+# hasura-migrations:3.1.4
 
 **Date:** 2026-02-27
 

--- a/release_notes/hasura-migrations-3.1.4.md
+++ b/release_notes/hasura-migrations-3.1.4.md
@@ -12,9 +12,13 @@ This means Portal was showing 0 supporters for triples that actually had 1 activ
 
 See `hasura-migrations-3.1.2.md` for the full root cause analysis.
 
-### Fix
+### Fix (3.1.4 — replaces 3.1.3 approach)
 
-Batched recalculation of `vault.position_count` from actual positions for all remaining mismatched vaults. Uses `SET LOCAL statement_timeout = '30min'` (scoped to the migration transaction only) to accommodate the cascade trigger overhead across environments with varying dataset sizes. Cascade triggers remain enabled throughout, so live position changes are never missed.
+The 3.1.3 attempt used `SET LOCAL statement_timeout = '30min'` as a separate SQL statement before the `DO` block. This failed on mainnet-next because the Hasura Dockerfile applies migrations with `--no-transaction`, which sends each SQL statement as a separate `run_sql` API call through the connection pool. The `SET LOCAL` ran on one connection, the `DO` block on another — the timeout override was lost.
+
+**3.1.4 fix:** Wraps the batched loop in a temporary PL/pgSQL function with a function-level `SET statement_timeout = '30min'` clause. PostgreSQL applies function-level GUC overrides when entering the function and reschedules the timeout timer, so this works regardless of `--no-transaction` and connection pooling. The function is created, called, and dropped within the same migration.
+
+Cascade triggers remain enabled throughout, so live position changes are never missed.
 
 ### Migration
 
@@ -23,13 +27,15 @@ Batched recalculation of `vault.position_count` from actual positions for all re
 ### Changes
 
 - `infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/up.sql`
-  - `SET LOCAL statement_timeout = '30min'` — transaction-scoped timeout increase, cannot affect other sessions
-  - `DO` block that loops in batches of 100, finding vaults where `position_count` differs from the actual count of positions with `shares > 0`, and corrects them. Cascade triggers (`update_triple_vault_from_vault` -> `triple_term` -> `predicate_object` / `subject_predicate`) fire normally for each batch.
+  - `CREATE OR REPLACE FUNCTION _fix_vault_position_count_undercount()` with `SET statement_timeout = '30min'` — function-level GUC override that reschedules the timeout timer on entry, unaffected by `--no-transaction` or connection pooling
+  - Function body loops in batches of 100, finding vaults where `position_count` differs from the actual count of positions with `shares > 0`, and corrects them. Cascade triggers (`update_triple_vault_from_vault` -> `triple_term` -> `predicate_object` / `subject_predicate`) fire normally for each batch.
+  - `SELECT _fix_vault_position_count_undercount()` — executes the fix
+  - `DROP FUNCTION _fix_vault_position_count_undercount()` — cleanup
 - `infrastructure/hasura/migrations/intuition/1771526407000_fix_vault_position_count_undercount/down.sql`
   - No-op (data-only migration)
 
 ### Impact
 
 - **Scope:** Same tables as 3.1.2 — `vault`, `triple_term`, `predicate_object`, `subject_predicate`. No Rust code changes.
-- **Safety:** Data-only migration. Cascade triggers stay enabled — live position changes are processed normally. The timeout increase is `SET LOCAL` (transaction-scoped, not session or global).
-- **Expected result:** All remaining undercounted vaults corrected, with cascade triggers propagating the fix to all aggregate tables. Works across environments regardless of the number of affected rows.
+- **Safety:** Data-only migration. Cascade triggers stay enabled — live position changes are processed normally. The 30-minute timeout is scoped to the function call only and reverts when the function returns. The function is dropped after use.
+- **Expected result:** All remaining undercounted vaults corrected, with cascade triggers propagating the fix to all aggregate tables. Works across environments regardless of the number of affected rows or `statement_timeout` configuration.


### PR DESCRIPTION
## Fix: Negative supporter/opposer counts on triples

### Problem

Portal displays negative supporter counts (-1, and -2 in aggregate views) when sorting claims by fewest supporters on `/explore/triples`. The negative values appear in both list views and triple detail pages.

**Affected tables:** `vault.position_count`, `triple_term.supporter_count`, `predicate_object.supporter_count`, `subject_predicate.supporter_count`

**Scale:** 78 vaults with `position_count = -1`, cascading to negative `supporter_count` in `triple_term`, `predicate_object` (min: -1), and `subject_predicate` (min: -2, from two affected triples summing).

**Root cause:** Event ordering race condition between `Deposited` and `SharePriceChanged` events in the decoded consumer.

For a deposit, the blockchain emits events in this order within the same block:

1. `Deposited` (log_index N)
2. `SharePriceChanged` (log_index N+1)

The consumer processes them sequentially:

1. **Deposited handler** creates a position with `shares > 0`. The `AFTER INSERT` trigger on `position` fires and tries to increment `vault.position_count`, but the vault row doesn't exist yet (it's created by the next event). The trigger retries 5 times, fails, logs a WARNING, and the **increment is lost**.

2. **SharePriceChanged handler** creates the vault with `position_count = 0` (doesn't know about the lost increment).

3. Later, when the position is **redeemed** (shares -> 0), the `AFTER UPDATE` trigger fires and successfully decrements `vault.position_count` from 0 to -1.

The negative `vault.position_count` then propagates through existing triggers: `vault` -> `triple_term.supporter_count` / `opposer_count` -> `predicate_object` / `subject_predicate` aggregates.

### Fix

#### 1. BEFORE INSERT trigger on vault (prevents future occurrences)

New function `recalculate_vault_position_count_on_insert()` fires before a vault row is written. It overrides the incoming `position_count` with the actual count of existing positions that have `shares > 0` for that `(term_id, curve_id)` pair.

This compensates for any lost increments from positions that were created before their vault. For `ON CONFLICT DO UPDATE` cases (vault already exists), the trigger fires but its changes are discarded since the UPDATE path is taken — which is correct since the vault already has a valid `position_count`.

#### 2. Data backfill (fixes existing negative values)

Updates all 78 vaults with `position_count < 0` to the correct value calculated from actual positions. The existing `AFTER UPDATE` trigger on `vault` (`update_triple_vault_from_vault`) automatically cascades the fix to `triple_term`, `predicate_object`, and `subject_predicate`.

### Migration

`1771526406000_fix_vault_position_count_on_insert`

### Changes

- `infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/up.sql`
  - `recalculate_vault_position_count_on_insert()` — BEFORE INSERT trigger function on `vault` that calculates `position_count` from existing positions
  - `vault_recalculate_position_count_on_insert` — trigger binding
  - Data fix UPDATE for all vaults with `position_count < 0`

- `infrastructure/hasura/migrations/intuition/1771526406000_fix_vault_position_count_on_insert/down.sql`
  - Drops the trigger and function

### Impact

- **Scope:** `vault`, `triple_term`, `predicate_object`, `subject_predicate` tables. No Rust code changes.
- **Safety:** The BEFORE INSERT trigger only runs on vault creation (not updates). The COUNT query is scoped to a specific `(term_id, curve_id)` pair, so performance impact is negligible. The data fix UPDATE targets only the 78 affected rows and cascades via existing triggers.
- **Expected result:** All negative `supporter_count` / `opposer_count` / `position_count` values corrected to 0. Future vault creations will initialize with the correct count even when positions are created before the vault.
