### PR TITLE
feat: notify docs repo on schema changes

### DIFF
--- a/.github/workflows/notify-docs-schema-change.yml
+++ b/.github/workflows/notify-docs-schema-change.yml
@@ -1,0 +1,23 @@
+name: Notify docs of schema changes
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'hasura/migrations/**'
+      - 'hasura/metadata/**'
+      - 'hasura/config.yaml'
+
+jobs:
+  notify-docs:
+    name: Notify intuition-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch schema-changed event
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/0xIntuition/intuition-docs/dispatches \
+            --method POST \
+            --field event_type=schema-changed \
+            -f client_payload[ref]="${{ github.sha }}"


### PR DESCRIPTION
## Summary

Adds a workflow that dispatches a `schema-changed` event to `intuition-docs`
when Hasura migrations or metadata are merged to main. This lets the docs repo
automatically detect GraphQL schema drift and flag any documented queries that
may have broken.

## Changes

- `.github/workflows/notify-docs-schema-change.yml` — triggers on pushes to
  main that touch `hasura/migrations/**`, `hasura/metadata/**`, or
  `hasura/config.yaml`

## Receiving side

`intuition-docs` already has a `repository_dispatch` handler in
`.github/workflows/validate-graphql.yml` that fetches fresh schemas,
validates all documented queries, and opens a draft PR if drift is detected.