### PR TITLE
fix: concatenate atom and triple labels in CLI signals display

### DIFF
--- a/cli/src/ui/signals.rs
+++ b/cli/src/ui/signals.rs
@@ -13,19 +13,16 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         .signals
         .iter()
         .map(|signal| {
-            let label = signal
-                .atom
-                .as_ref()
-                .and_then(|atom| atom.label.as_deref())
-                // FIXME: Concatinate atom labels
-                // .or_else(|| {
-                //     signal
-                //         .triple
-                //         .as_ref()
-                //         .and_then(|triple| triple.label.as_deref())
-                // })
-                .unwrap_or("N/A")
-                .to_string();
+            // Concatenate atom and triple labels if both exist
+            let atom_label = signal.atom.as_ref().and_then(|atom| atom.label.clone());
+            let triple_label = signal.triple.as_ref().and_then(|triple| triple.label.clone());
+            
+            let label = match (atom_label, triple_label) {
+                (Some(atom), Some(triple)) => format!("{} | {}", atom, triple),
+                (Some(atom), None) => atom,
+                (None, Some(triple)) => triple,
+                (None, None) => "N/A".to_string(),
+            };
 
             let account_label = signal
                 .account


### PR DESCRIPTION
Fixed the FIXME comment about concatenating atom labels in the CLI signals display.

## Changes
- Removed FIXME comment about concatenation
- Added logic to show both atom and triple labels when they exist
- Format: 'atom_label | triple_label' when both present
- Falls back to single label if only one exists
- Shows 'N/A' if neither exists

## Why
The signals UI was only showing atom labels but not triple labels. This fix ensures both are displayed when available, giving users more context about what the signal relates to.