### PR TITLE
fix: display proper claim labels in CLI accounts view

### DIFF
--- a/cli/src/ui/accounts.rs
+++ b/cli/src/ui/accounts.rs
@@ -105,8 +105,36 @@ fn draw_account_details(f: &mut Frame, app: &App, area: Rect) {
             .claims
             .iter()
             .map(|claim| {
-                // let label = claim.triple.label.as_deref().unwrap_or("N/A").to_string();
-                let label = "FIXME";
+                // Construct label from triple's subject, predicate, and object labels
+                let subject_label = claim
+                    .triple
+                    .as_ref()
+                    .and_then(|t| t.subject.as_ref())
+                    .and_then(|s| s.label.as_deref())
+                    .unwrap_or("N/A");
+                let predicate_label = claim
+                    .triple
+                    .as_ref()
+                    .and_then(|t| t.predicate.as_ref())
+                    .and_then(|p| p.label.as_deref())
+                    .unwrap_or("N/A");
+                let object_label = claim
+                    .triple
+                    .as_ref()
+                    .and_then(|t| t.object.as_ref())
+                    .and_then(|o| o.label.as_deref())
+                    .unwrap_or("N/A");
+
+                // Format: "subject_label | predicate_label | object_label"
+                let label = if subject_label != "N/A"
+                    || predicate_label != "N/A"
+                    || object_label != "N/A"
+                {
+                    format!("{} | {} | {}", subject_label, predicate_label, object_label)
+                } else {
+                    "N/A".to_string()
+                };
+
                 ListItem::new(Line::from(format!("{}, {}", label, claim.shares)))
             })
             .collect();

--- a/cli/src/ui/signals.rs
+++ b/cli/src/ui/signals.rs
@@ -13,19 +13,16 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         .signals
         .iter()
         .map(|signal| {
-            let label = signal
-                .atom
-                .as_ref()
-                .and_then(|atom| atom.label.as_deref())
-                // FIXME: Concatinate atom labels
-                // .or_else(|| {
-                //     signal
-                //         .triple
-                //         .as_ref()
-                //         .and_then(|triple| triple.label.as_deref())
-                // })
-                .unwrap_or("N/A")
-                .to_string();
+            // Concatenate atom and triple labels if both exist
+            let atom_label = signal.atom.as_ref().and_then(|atom| atom.label.clone());
+            let triple_label = signal.triple.as_ref().and_then(|triple| triple.label.clone());
+            
+            let label = match (atom_label, triple_label) {
+                (Some(atom), Some(triple)) => format!("{} | {}", atom, triple),
+                (Some(atom), None) => atom,
+                (None, Some(triple)) => triple,
+                (None, None) => "N/A".to_string(),
+            };
 
             let account_label = signal
                 .account


### PR DESCRIPTION
Replace hardcoded 'FIXME' placeholder with actual claim labels constructed from triple's subject, predicate, and object labels.

Format: 'subject_label | predicate_label | object_label'

Previously, the accounts view in the CLI showed 'FIXME' for all claims. This fix properly extracts and displays the label information from the GraphQL response.