### PR TITLE
[ENG-12518] fix: make Pinata remote-pin non-blocking to stop image-guard upload hangs

### DIFF
--- a/apps/shared-utils/src/ipfs.rs
+++ b/apps/shared-utils/src/ipfs.rs
@@ -71,6 +71,7 @@ impl IPFSResolver {
     ) -> Result<Response, reqwest::Error> {
         self.http_client
             .post(self.format_add_remote_pin_to_pinata(cid, name))
+            .timeout(self.pin_timeout.unwrap_or(PIN_TIMEOUT))
             .send()
             .await
     }
@@ -163,7 +164,7 @@ impl IPFSResolver {
     /// Formats the URL to add a remote pin to Pinata
     fn format_add_remote_pin_to_pinata(&self, cid: &str, name: &str) -> String {
         format!(
-            "{}/api/v0/pin/remote/add?arg={}&service=Pinata&name={}",
+            "{}/api/v0/pin/remote/add?arg={}&service=Pinata&name={}&background=true",
             self.ipfs_upload_url, cid, name
         )
     }
@@ -510,6 +511,7 @@ impl IPFSResolver {
     async fn pin_with_cid(&self, cid: &str) -> Result<Response, reqwest::Error> {
         self.http_client
             .post(self.format_pin_with_cid(cid))
+            .timeout(self.pin_timeout.unwrap_or(PIN_TIMEOUT))
             .send()
             .await
     }


### PR DESCRIPTION
## Problem

`image-guard` image uploads hang intermittently and never return.

**Root cause** (confirmed via a live Kubo goroutine dump on the GKE cluster + a code trace through `shared-utils`):

`IPFSResolver::add_remote_pin_to_pinata` (`apps/shared-utils/src/ipfs.rs`) calls Kubo's `/api/v0/pin/remote/add` **in the foreground** — the URL has no `background=true`. Kubo therefore holds the HTTP response open while it polls Pinata's PSA `/pins/{id}` status endpoint (~every 30s) until the pin reaches `pinned`. The Rust call is a bare `.send().await` with **no timeout**, so the Tokio handler task blocks indefinitely and the upload request never completes. Under concurrent load these stack up — the goroutine dump showed 6 uploads parked at exactly this point, on stale pooled HTTP/2 connections to Pinata.

This affects all three upload entry points (`/upload`, `/upload_image_from_url`, `/upload_json_to_ipfs`), which all await the pin chain.

## Fix

- **`&background=true`** on the remote-pin URL → Kubo enqueues the pin and returns `202` immediately; status polling stays internal to the daemon. This is the actual hang fix.
- **`.timeout(pin_timeout.unwrap_or(PIN_TIMEOUT))`** (10s) added to the two pin `.send()` calls (`add_remote_pin_to_pinata`, `pin_with_cid`) as defense-in-depth, matching the existing fetch/legacy-pin timeout pattern already in this file.

3-line change, `apps/shared-utils/src/ipfs.rs`.

## Testing

- `cargo build -p shared-utils` ✅
- `cargo clippy -p shared-utils` ✅ (no new warnings)
- Behavioral verification on-cluster recommended after deploy: watch `kubectl logs -l app=ipfs -n default` — the ~30s repeating pin-status poll should stop, and image-guard uploads should return promptly.

## Related / not in this PR (tracked in ENG-12518)

- ⚠️ **Pinata JWT is expired (`exp 2025-11-21`) and committed in plaintext** in 5 deployment files. Pins won't actually succeed on Pinata until it's rotated. This fix stops the *hang* regardless, but the token rotation + move to External Secrets is a separate task.
- The HTTP client is built `Client::new()` per request in `image-guard` (no shared pool / timeout). Recommended follow-up; intentionally left out to keep this diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)