### PR TITLE
feat(image-guard): add /classify endpoint for classification-only moderation

### DIFF
--- a/apps/image-guard/src/app.rs
+++ b/apps/image-guard/src/app.rs
@@ -1,7 +1,7 @@
 use crate::{
     endpoints::{
-        upload_image::upload_image, upload_image_from_url::upload_image_from_url,
-        upload_json_to_ipfs::upload_json_to_jpfs,
+        classify::classify, upload_image::upload_image,
+        upload_image_from_url::upload_image_from_url, upload_json_to_ipfs::upload_json_to_jpfs,
     },
     error::ApiError,
     openapi::ApiDoc,
@@ -98,6 +98,7 @@ impl App {
     fn router(&self) -> Router {
         let (prometheus_layer, metric_handle) = PrometheusMetricLayer::pair();
         Router::new()
+            .route("/classify", post(classify))
             .route("/upload", post(upload_image))
             .route("/upload_image_from_url", post(upload_image_from_url))
             .route("/upload_json_to_ipfs", post(upload_json_to_jpfs))

--- a/apps/image-guard/src/endpoints/classify.rs
+++ b/apps/image-guard/src/endpoints/classify.rs
@@ -1,0 +1,124 @@
+use crate::{
+    endpoints::{handle_image, validate_image_bytes},
+    error::ApiError,
+    state::{AppState, Flag},
+    types::{ClassificationResponse, MultipartRequest},
+};
+use axum::{Json, body::Bytes, extract::State};
+use axum_macros::debug_handler;
+use log::info;
+use shared_utils::{
+    image::Image,
+    types::{ClassificationModel, MultiPartHandler},
+};
+
+/// Classify an image without uploading it to IPFS or writing to the database.
+///
+/// Returns the moderation verdict immediately. Use this endpoint to surface
+/// content rejections to the user before committing to the full upload path.
+/// When no classifier is configured (`classified: false`), the verdict fields
+/// are omitted entirely — callers must treat the response as "no verdict",
+/// not as safe or unsafe.
+#[utoipa::path(
+    post,
+    path = "/classify",
+    request_body = inline(MultipartRequest),
+    responses(
+        (status = 200, description = "Image classified successfully", body = ClassificationResponse,
+            example = json!({
+                "safe": true,
+                "score": "{\"normal\":0.82167643,\"nsfw\":0.1601617}",
+                "model": "Falconsai",
+                "classified": true
+            })
+        ),
+        (status = 400, description = "Invalid input - not an image or wrong format", body = String),
+        (status = 500, description = "Internal server error", body = String)
+    ),
+    tag = "images"
+)]
+#[debug_handler]
+pub async fn classify(
+    State(state): State<AppState>,
+    Json(image): Json<Image>,
+) -> Result<Json<ClassificationResponse>, ApiError> {
+    info!("Classifying image");
+
+    let data_url_info = if image.is_data_url() {
+        Some(image.parse_data_url_info()?)
+    } else {
+        None
+    };
+
+    let (image_bytes, image_name, content_type) = match data_url_info {
+        Some(info) => {
+            let name = info.name;
+            let parsed = info.parsed;
+            let content_type = parsed.mime_type;
+            (parsed.data, name, content_type)
+        }
+        None => {
+            let image_bytes = match image.download().await? {
+                Some(bytes) => bytes,
+                None => {
+                    return Err(ApiError::InvalidInput(
+                        "Failed to download image from URL".into(),
+                    ));
+                }
+            };
+
+            let image_output = image
+                .extract_name_and_extension()
+                .ok_or(ApiError::ExtractNameAndExtension)?;
+            let image_name = image_output.name;
+            let content_type = format!("image/{}", image_output.extension.to_lowercase());
+            (image_bytes, image_name, content_type)
+        }
+    };
+
+    // Validate the image bytes
+    validate_image_bytes(&image_bytes)?;
+
+    let multi_part_handler = MultiPartHandler {
+        name: image_name,
+        content_type,
+        data: Bytes::from(image_bytes),
+    };
+
+    // Only call handle_image when a classifier is actually configured. The
+    // match is additive (rather than excluding Flag::LocalWithDbOnly) so any
+    // future Flag variant defaults to "no verdict" — mirroring handle_image's
+    // own else-branch, which returns (ClassificationScoreParsed::unknown(),
+    // false) for unhandled variants.
+    let classified = matches!(
+        state.flag,
+        Flag::HfClassification | Flag::LocalWithClassification
+    );
+
+    if !classified {
+        info!(
+            "No classifier configured; returning no verdict for `{}`",
+            multi_part_handler.name
+        );
+        return Ok(Json(ClassificationResponse {
+            safe: None,
+            score: None,
+            model: None,
+            classified: false,
+        }));
+    }
+
+    let (scores, safe) = handle_image(&state, &multi_part_handler).await?;
+
+    info!(
+        "Classification result for `{}`: safe={}",
+        multi_part_handler.name, safe
+    );
+
+    Ok(Json(ClassificationResponse {
+        safe: Some(safe),
+        score: Some(serde_json::to_string(&scores)?),
+        model: Some(ClassificationModel::FalconsaiNsfwImageDetection.to_string()),
+        classified: true,
+    }))
+}

--- a/apps/image-guard/src/endpoints/mod.rs
+++ b/apps/image-guard/src/endpoints/mod.rs
@@ -1,3 +1,4 @@
+pub mod classify;
 pub mod upload_image;
 pub mod upload_image_from_url;
 pub mod upload_json_to_ipfs;

--- a/apps/image-guard/src/openapi.rs
+++ b/apps/image-guard/src/openapi.rs
@@ -1,6 +1,6 @@
 use crate::{
     endpoints,
-    types::{ClassificationScoreParsed, LocalClassificationScore},
+    types::{ClassificationResponse, ClassificationScoreParsed, LocalClassificationScore},
 };
 use models::cached_image::CachedImage;
 use shared_utils::{image::Image, types::ClassificationModel};
@@ -9,6 +9,7 @@ use utoipa::OpenApi;
 #[derive(OpenApi)]
 #[openapi(
     paths(
+        endpoints::classify::classify,
         endpoints::upload_image::upload_image,
         endpoints::upload_image_from_url::upload_image_from_url,
         endpoints::upload_json_to_ipfs::upload_json_to_jpfs,
@@ -18,6 +19,7 @@ use utoipa::OpenApi;
             Image,
             CachedImage,
             ClassificationModel,
+            ClassificationResponse,
             ClassificationScoreParsed,
             LocalClassificationScore,
         )

--- a/apps/image-guard/src/types.rs
+++ b/apps/image-guard/src/types.rs
@@ -1,6 +1,31 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+/// Response returned by the `/classify` endpoint.
+///
+/// `classified` is `false` when no content classifier is configured
+/// (i.e., the service is running in db-only mode). In that case `safe`,
+/// `score`, and `model` are omitted entirely — no verdict was produced, and
+/// callers must not interpret the response as either safe or unsafe.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ClassificationResponse {
+    /// Whether the image passed the safety threshold. Omitted when no
+    /// classifier produced a verdict.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub safe: Option<bool>,
+    /// JSON-serialised classification scores (e.g. `{"normal":0.82,"nsfw":0.18}`).
+    /// Omitted when no classifier produced a verdict.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<String>,
+    /// Name of the classification model used. Omitted when no classifier
+    /// produced a verdict.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// `true` when a classifier was active and produced a real verdict;
+    /// `false` when the service is running without a classifier configured.
+    pub classified: bool,
+}
+
 #[derive(Deserialize)]
 pub struct Env {
     pub classification_api_port: u16,

--- a/infrastructure/hasura/metadata/actions.graphql
+++ b/infrastructure/hasura/metadata/actions.graphql
@@ -59,6 +59,12 @@ type Query {
 }
 
 type Mutation {
+  classifyImage(
+    image: ClassifyImageInput!
+  ): ClassifyImageOutput
+}
+
+type Mutation {
   pinOrganization(
     organization: PinOrganizationInput!
   ): PinOutput
@@ -122,6 +128,10 @@ input PinJsonInput {
   json: jsonb
 }
 
+input ClassifyImageInput {
+  url: String!
+}
+
 input UploadImageFromUrlInput {
   url: String!
 }
@@ -182,6 +192,13 @@ input GetAccountPnlRealizedInput {
 
 type PinOutput {
   uri: String
+}
+
+type ClassifyImageOutput {
+  safe: Boolean
+  score: String
+  model: String
+  classified: Boolean!
 }
 
 type UploadImageFromUrlOutput {

--- a/infrastructure/hasura/metadata/actions.yaml
+++ b/infrastructure/hasura/metadata/actions.yaml
@@ -1,4 +1,23 @@
 actions:
+  - name: classifyImage
+    definition:
+      kind: synchronous
+      handler: http://image-guard:3000/classify
+      headers:
+        - name: Content-Type
+          value: application/json
+      request_transform:
+        body:
+          action: transform
+          template: |-
+            {
+              "url": "{{$body.input.image.url}}"
+            }
+        template_engine: Kriti
+        version: 2
+    permissions:
+      - role: frontend
+    comment: Classifies an image for content moderation using image-guard without uploading it to IPFS
   - name: getAccountPnlChart
     definition:
       kind: ""


### PR DESCRIPTION
## Summary

Adds `POST /classify` to image-guard: same request body as `/upload_image_from_url` (base64 data URL or remote URL), but returns the moderation verdict immediately — **no IPFS pin, no database write**. The classifier itself answers in ~100ms–2s; today its verdict is only delivered after the full IPFS upload completes because both are bundled into one response.

Linear: ENG-12604 (parent ENG-12603 / ENG-12479). Motivation: the Portal's optimistic image upload (intuition-portal-new#592) shows the user's image immediately and uploads in the background — this endpoint lets it surface content rejections in ~1–2s instead of after the pin, closing most of the window where a rejected image could reach atom metadata.

## Response contract

```json
// classifier active (Flag::HfClassification | Flag::LocalWithClassification)
{ "safe": true, "score": "{\"normal\":0.82,\"nsfw\":0.18}", "model": "Falconsai/nsfw_image_detection", "classified": true }

// no classifier configured (db-only mode)
{ "classified": false }
```

When no classifier is configured, the verdict fields are **omitted entirely** rather than defaulted — "no verdict" can't be mistaken for safe (fail-open) or unsafe (would reject every image on a misconfigured deployment). The flag check is additive (`matches!` on the classification-enabled variants), so any future `Flag` variant defaults to no-verdict — mirroring `handle_image`'s own else-branch.

## Implementation notes

- `endpoints/classify.rs` mirrors `upload_image_from_url.rs` exactly (same data-URL parse, remote download, `validate_image_bytes` before classification) and stops after `handle_image()` — no `upload_image_to_ipfs`, no `CachedImage` upsert.
- Wiring: route in `app.rs`, module in `endpoints/mod.rs`, path + `ClassificationResponse` schema in `openapi.rs`. No changes to existing endpoints, shared-utils, or models.
- **Hasura exposure** (per review feedback): `classifyImage` action mirroring `uploadImageFromUrl` — synchronous, internal handler `http://image-guard:3000/classify`, Kriti request transform, `frontend` role only (per #218). Output type `ClassifyImageOutput { safe: Boolean, score: String, model: String, classified: Boolean! }`; omitted verdict fields surface as GraphQL nulls.
- Exposure parity with existing routes (no auth at the service layer, same `DefaultBodyLimit`); the recent #218 frontend-role restriction is Hasura-action-level and unaffected. The remote-URL path reuses the existing download codepath — no new SSRF surface beyond what `/upload_image_from_url` already allows.

## Testing

- `cargo build -p image-guard`, `cargo clippy -p image-guard --all-targets` (0 warnings), `cargo fmt` — all clean; no unit test suite exists in this crate.
- Suggested manual check: `curl -X POST <host>/classify -H 'Content-Type: application/json' -d '{"url":"data:image/png;base64,..."}'` → verdict without a Pinata pin appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
