### PR TITLE
feat(hasura): add partner role to IPFS pin/upload actions (ENG-12789)

### DIFF
--- a/infrastructure/hasura/metadata/actions.yaml
+++ b/infrastructure/hasura/metadata/actions.yaml
@@ -235,6 +235,7 @@ actions:
         version: 2
     permissions:
       - role: frontend
+      - role: partner
     comment: Uploads and pins Organization to IPFS
   - name: pinPerson
     definition:
@@ -277,6 +278,7 @@ actions:
         version: 2
     permissions:
       - role: frontend
+      - role: partner
     comment: Uploads and pins Person to IPFS
   - name: pinThing
     definition:
@@ -317,6 +319,7 @@ actions:
         version: 2
     permissions:
       - role: frontend
+      - role: partner
     comment: Uploads and pins Thing to IPFS
   - name: uploadImage
     definition:
@@ -342,6 +345,7 @@ actions:
         version: 2
     permissions:
       - role: frontend
+      - role: partner
     comment: 'Uploads and classifies an image file using image-guard. Accepts base64-encoded image data. Note: The original /upload endpoint requires multipart/form-data which Hasura actions cannot construct directly. This mutation uses upload_image_from_url with a data URL workaround. For direct file uploads, use the image-guard API directly or create a wrapper endpoint.'
   - name: uploadImageFromUrl
     definition:
@@ -370,6 +374,7 @@ actions:
         version: 2
     permissions:
       - role: frontend
+      - role: partner
     comment: Uploads and classifies an image from a URL using image-guard
   - name: uploadJsonToIpfs
     definition:
@@ -397,6 +402,7 @@ actions:
         version: 2
     permissions:
       - role: frontend
+      - role: partner
     comment: Uploads JSON to IPFS using image-guard
 custom_types:
   enums: []


### PR DESCRIPTION
## What

Adds a new `partner` Hasura role to the **six** IPFS pin/upload Actions, alongside the existing `frontend` role (PR #218):

| Action | Backend |
|---|---|
| `pinThing` / `pinPerson` / `pinOrganization` | Pinata (`pinJSONToIPFS`) |
| `uploadImage` / `uploadImageFromUrl` / `uploadJsonToIpfs` | image-guard (`:3000`) |

No other action is touched; `custom_types` is unchanged. Diff is +6 lines.

## Why

Part of **ENG-12789** — securely exposing IPFS pinning to external partners. The `partner` role is authenticated at the **Kong edge** (`key-auth` API key) and asserted to Hasura via an **injected partner-scoped JWT** (companion PR in `gcp-deployment`). It deliberately exposes **only** these six mutations — no other root field, no admin, no `frontend` privileges.

## ⚠️ Deploy ordering

This metadata only takes effect once it ships in the `ghcr.io/0xintuition/hasura-migrations` image **and** that image tag is bumped in `gcp-deployment`'s graphql ApplicationSet (`intuition-mainnet-next`). Until then the partner endpoint is non-functional. Sequence: merge this → CI builds hasura-migrations image → bump tag in gcp-deployment → Argo runs the migrations job → `partner` role live → Kong manifests synced → issue first partner key.

Linear: https://linear.app/0xintuition/issue/ENG-12789

🤖 Generated with [Claude Code](https://claude.com/claude-code)