### PR TITLE
feat: add TNS resolver with priority over ENS resolution

### DIFF
--- a/apps/consumer/src/mode/resolver/mod.rs
+++ b/apps/consumer/src/mode/resolver/mod.rs
@@ -1,4 +1,5 @@
 pub mod atom_resolver;
 pub mod caip22_resolver;
 pub mod ens_resolver;
+pub mod tns_resolver;
 pub mod types;

--- a/apps/consumer/src/mode/resolver/tns_resolver.rs
+++ b/apps/consumer/src/mode/resolver/tns_resolver.rs
@@ -1,0 +1,166 @@
+use crate::{
+    error::ConsumerError,
+    mode::{
+        ipfs_upload::types::IpfsUploadMessage, resolver::ens_resolver::Ens,
+        types::ResolverConsumerContext,
+    },
+};
+use alloy::{
+    primitives::{Address, FixedBytes, keccak256},
+    providers::{DynProvider, ProviderBuilder},
+    sol,
+};
+use alloy_network::Ethereum;
+use tracing::{debug, warn};
+
+sol! {
+    #[sol(rpc)]
+    interface TNSRegistry {
+        function resolver(bytes32 node) external view returns (address);
+    }
+
+    #[sol(rpc)]
+    interface TNSResolver {
+        function name(bytes32 node) external view returns (string);
+        function text(bytes32 node, string key) external view returns (string);
+    }
+}
+
+/// TNS registry contract on the Intuition (Caldera) chain.
+const TNS_REGISTRY_ADDRESS: &str = "0x3220B4EDbA3a1661F02f1D8D241DBF55EDcDa09e";
+/// RPC endpoint for the Intuition (Caldera) chain where TNS lives.
+const INTUITION_RPC_URL: &str = "https://intuition.calderachain.xyz";
+
+type TnsRegistry = TNSRegistry::TNSRegistryInstance<DynProvider, Ethereum>;
+type TnsResolver = TNSResolver::TNSResolverInstance<DynProvider, Ethereum>;
+
+/// Trust Name Service (TNS) resolution.
+///
+/// Mirrors [`Ens`]: reverse-resolves an address to its primary `.trust` name and
+/// avatar, uploads the avatar to IPFS as a side effect, and returns an [`Ens`] so
+/// the pipeline treats TNS and ENS results uniformly.
+pub struct Tns;
+
+impl Tns {
+    /// Resolves the TNS primary name and avatar for an address.
+    ///
+    /// TNS is attempted before ENS in `process_account`.
+    pub async fn get_tns(
+        address: Address,
+        consumer_context: &ResolverConsumerContext,
+    ) -> Result<Ens, ConsumerError> {
+        let registry = Self::registry()?;
+        let name = Self::get_tns_name(address, &registry).await;
+        let mut image = None;
+        if let Some(name) = &name {
+            image = Self::get_tns_avatar(name, &registry, consumer_context).await?;
+        }
+        Ok(Ens { name, image })
+    }
+
+    /// Gets the avatar text record for a name and forwards it to the IPFS upload
+    /// consumer. Mirrors [`Ens::get_ens_avatar`].
+    async fn get_tns_avatar(
+        name: &str,
+        registry: &TnsRegistry,
+        consumer_context: &ResolverConsumerContext,
+    ) -> Result<Option<String>, ConsumerError> {
+        let node = Self::namehash(&Self::ensure_trust_suffix(name));
+        let avatar = match Self::get_resolver(node, registry).await {
+            Some(resolver) => resolver
+                .text(node, "avatar".to_string())
+                .call()
+                .await
+                .ok()
+                .filter(|s| !s.is_empty()),
+            None => None,
+        };
+
+        if let Some(url) = &avatar {
+            debug!("Sending image to IPFS upload consumer: {}", url);
+            consumer_context
+                .client
+                .send_message(
+                    serde_json::to_string(&IpfsUploadMessage { image: url.clone() })?,
+                    None,
+                )
+                .await?;
+        }
+        Ok(avatar)
+    }
+
+    /// Reverse-resolves an address to its primary TNS name.
+    ///
+    /// Returns `None` if no name is set or the lookup fails for any reason. Never
+    /// blocks message processing — mirrors [`Ens::get_ens_name`], which swallows
+    /// lookup errors so resolution falls back to ENS.
+    pub async fn get_tns_name(address: Address, registry: &TnsRegistry) -> Option<String> {
+        let reverse_name = format!(
+            "{}.addr.reverse",
+            address.to_string().to_lowercase().trim_start_matches("0x")
+        );
+        let node = Self::namehash(&reverse_name);
+        let resolver = Self::get_resolver(node, registry).await?;
+        match resolver.name(node).call().await {
+            Ok(name) if !name.is_empty() => {
+                debug!("Resolved TNS name for {}: {}", address, name);
+                Some(name)
+            }
+            Ok(_) => None,
+            Err(e) => {
+                warn!("TNS reverse lookup failed for {} (non-fatal): {}", address, e);
+                None
+            }
+        }
+    }
+
+    /// Builds the alloy client for the TNS registry on the Intuition (Caldera) chain.
+    fn registry() -> Result<TnsRegistry, ConsumerError> {
+        let provider =
+            DynProvider::new(ProviderBuilder::new().connect_http(INTUITION_RPC_URL.parse()?));
+        let address = TNS_REGISTRY_ADDRESS
+            .parse::<Address>()
+            .map_err(|e| ConsumerError::AddressParse(e.to_string()))?;
+        Ok(TNSRegistry::TNSRegistryInstance::new(address, provider))
+    }
+
+    /// Looks up the resolver contract for a node hash. Returns `None` if unset or
+    /// if the lookup fails (non-fatal — resolution falls back to ENS).
+    async fn get_resolver(node: FixedBytes<32>, registry: &TnsRegistry) -> Option<TnsResolver> {
+        match registry.resolver(node).call().await {
+            Ok(address) if address != Address::ZERO => {
+                Some(TNSResolver::TNSResolverInstance::new(
+                    address,
+                    registry.provider().clone(),
+                ))
+            }
+            Ok(_) => None,
+            Err(e) => {
+                warn!("TNS resolver lookup failed (non-fatal): {}", e);
+                None
+            }
+        }
+    }
+
+    /// Ensures a name carries the `.trust` TLD before hashing.
+    fn ensure_trust_suffix(name: &str) -> String {
+        if name.ends_with(".trust") {
+            name.to_string()
+        } else {
+            format!("{name}.trust")
+        }
+    }
+
+    /// Namehash of a name (EIP-137).
+    fn namehash(name: &str) -> FixedBytes<32> {
+        if name.is_empty() {
+            return FixedBytes::ZERO;
+        }
+        let mut hash = vec![0u8; 32];
+        for label in name.rsplit('.') {
+            hash.append(&mut keccak256(label.as_bytes()).to_vec());
+            hash = keccak256(hash.as_slice()).to_vec();
+        }
+        FixedBytes::from_slice(hash.as_slice())
+    }
+}

--- a/apps/consumer/src/mode/resolver/types.rs
+++ b/apps/consumer/src/mode/resolver/types.rs
@@ -8,6 +8,7 @@ use crate::{
                 handle_binary_data, try_to_parse_json_or_text, try_to_resolve_ipfs_uri,
             },
             ens_resolver::Ens,
+            tns_resolver::Tns,
         },
         types::ResolverConsumerContext,
     },
@@ -183,27 +184,35 @@ impl ResolverMessageType {
         .ok_or(ConsumerError::AccountNotFound)
     }
 
-    /// This function processes an account message type
+    /// This function processes an account message type.
+    /// TNS resolution is attempted first. If no TNS name is found,
+    /// falls back to ENS resolution.
     async fn process_account(
         &self,
         resolver_consumer_context: &ResolverConsumerContext,
         account: &mut Account,
     ) -> Result<(), ConsumerError> {
-        let ens = Ens::get_ens(Address::from_str(&account.id)?, resolver_consumer_context).await?;
-        if let Some(_name) = ens.name.clone() {
-            debug!("ENS for account: {:?}", ens);
+        let address = Address::from_str(&account.id)?;
+
+        // TNS takes priority; fall back to ENS when no TNS name is set.
+        let mut resolved = Tns::get_tns(address, resolver_consumer_context).await?;
+        if resolved.name.is_none() {
+            resolved = Ens::get_ens(address, resolver_consumer_context).await?;
+        }
+
+        if let Some(_name) = resolved.name.clone() {
             // We need to update the account metadata
             debug!("Updating account metadata for account: {:?}", account);
             self.update_account_metadata(
                 resolver_consumer_context,
                 account.id.clone(),
-                ens.clone(),
+                resolved.clone(),
             )
             .await?;
             // We also need to update the atom
             if let Some(atom_id) = account.atom_id.clone() {
                 debug!("Updating atom metadata for account: {:?}", account);
-                self.update_atom_metadata(resolver_consumer_context, &atom_id, ens)
+                self.update_atom_metadata(resolver_consumer_context, &atom_id, resolved)
                     .await?;
             } else {
                 // We deal with the case where the account atom_id was not set
@@ -212,7 +221,7 @@ impl ResolverMessageType {
                 debug!("No atom found for account: {:?}", account)
             }
         } else {
-            debug!("No ENS found for account: {:?}", account);
+            debug!("No name resolved (TNS or ENS) for account: {:?}", account);
         }
         Ok(())
     }

--- a/integration-tests/src/create-user-atom.script.ts
+++ b/integration-tests/src/create-user-atom.script.ts
@@ -1,0 +1,30 @@
+import { getIntuition, wait } from './setup/utils.js'
+
+async function main() {
+  console.log('Starting atom creation script...\n')
+
+  const intuition = await getIntuition(0)
+
+  const userAddress = '0x1Bc35cAE544DF00BfdfEE6597c4E54850eFDD9af'
+
+  console.log(`Creating atom for address ${userAddress}...`)
+  const atom = await intuition.getOrCreateAtom(userAddress)
+  console.log(`Atom vaultId: ${atom.vaultId}`)
+
+  if (atom.hash) {
+    console.log('Waiting for transaction to be indexed...')
+    await wait(atom.hash)
+  }
+
+  console.log('\nAtom creation complete!')
+}
+
+main()
+  .then(() => {
+    console.log('\nScript completed successfully')
+    process.exit(0)
+  })
+  .catch((error) => {
+    console.error('\nError:', error)
+    process.exit(1)
+  })

--- a/integration-tests/src/deposit-on-atom.script.ts
+++ b/integration-tests/src/deposit-on-atom.script.ts
@@ -1,0 +1,38 @@
+import { getIntuition, wait } from './setup/utils.js'
+import { parseEther, toHex } from 'viem'
+
+async function main() {
+  console.log('Starting deposit on atom script...\n')
+
+  const intuition = await getIntuition(0)
+
+  const userAddress = '0x1Bc35cAE544DF00BfdfEE6597c4E54850eFDD9af'
+  const depositAmount = parseEther('0.1')
+
+  // Resolve the atom's vaultId from the address
+  const vaultId = await intuition.contract.read.calculateAtomId([toHex(userAddress)])
+  console.log(`Atom vaultId for ${userAddress}: ${vaultId}`)
+
+  // Deposit on the atom
+  console.log(`Depositing ${depositAmount} wei on atom...`)
+  const hash = await intuition.contract.write.deposit(
+    [intuition.account.address, vaultId, 1n, 0n],
+    { value: depositAmount },
+  )
+  console.log(`Transaction hash: ${hash}`)
+
+  console.log('Waiting for transaction to be indexed...')
+  await wait(hash)
+
+  console.log('\nDeposit complete!')
+}
+
+main()
+  .then(() => {
+    console.log('\nScript completed successfully')
+    process.exit(0)
+  })
+  .catch((error) => {
+    console.error('\nError:', error)
+    process.exit(1)
+  })


### PR DESCRIPTION
## Summary

Adds a **Trust Name Service (TNS)** resolver to the consumer pipeline, built to mirror the existing ENS resolver. When an account atom is processed, TNS reverse resolution is attempted first; only if TNS returns no name does the system fall back to the existing ENS resolution.

`Tns::get_tns` mirrors `Ens::get_ens`: same `&ResolverConsumerContext` signature, it uploads the resolved avatar to the IPFS upload consumer internally, and — like `get_ens_name` — it **swallows lookup failures to `None`** so a TNS RPC issue gracefully falls back to ENS and never blocks message processing. It returns an `Ens { name, image }` so the pipeline treats TNS and ENS results uniformly. The only structural difference is the resolution mechanism itself (TNS registry + namehash vs. the ENS Universal Resolver), which is inherent to the two name services.

The resolver is fully self-contained: it builds its own registry client from the two constants at the top of the module, so it touches no shared files beyond registering the module and the one-line wiring in `process_account`.

This is a clean, minimal re-do of #197, which unintentionally carried ~23 files of unrelated changes (a re-implementation of the ENS→universal_resolver refactor that `v2_0` already contains, a `redis_streams.rs` deletion, and local-dev docker-compose tweaks). This branch is based on current `v2_0`.

## Changes (5 files)

**Resolver:**
- `apps/consumer/src/mode/resolver/tns_resolver.rs` — new TNS resolver, mirrors `ens_resolver.rs`
- `apps/consumer/src/mode/resolver/mod.rs` — register `tns_resolver`
- `apps/consumer/src/mode/resolver/types.rs` — `process_account`: TNS-first, ENS fallback

**Scripts to try the integration:**
- `integration-tests/src/create-user-atom.script.ts`
- `integration-tests/src/deposit-on-atom.script.ts`

## Note for reviewers

- `tns_resolver.rs` hardcodes `TNS_REGISTRY_ADDRESS` and `INTUITION_RPC_URL` (the TNS registry on the Intuition Caldera chain). Happy to move these to config/env if preferred.
- The registry client is built per resolution rather than once at startup (ENS caches `universal_resolver` on the context). Account resolution is low-frequency so the cost is negligible, and it keeps the feature self-contained — easy to switch to a cached client if reviewers prefer parity with ENS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)