### PR TITLE
GWTH-4354 feat(hasura): freeze leaderboard IQ at Season 2 Epoch 20

### DIFF
--- a/docs/leaderboard-wind-down-assessment-2026-08-12.md
+++ b/docs/leaderboard-wind-down-assessment-2026-08-12.md
@@ -1,0 +1,100 @@
+# Leaderboard Wind-Down — Backend Effort Assessment
+
+**Date:** 2026-08-12
+**Context:** Product plans to wind down the portal leaderboard (`portal.intuition.systems/leaderboard`) — future epochs will no longer award IQ points for trading / holding a leaderboard position. Question asked: how big is the backend lift to stop it?
+
+**Answer: small.** The minimal version is zero code (stop running one script). The clean version is roughly half a day of work plus a review cycle.
+
+---
+
+## How the system actually works (two separable pieces)
+
+### 1. The leaderboard *display* (what the portal page shows)
+
+- Portal queries Hasura-tracked SQL functions: `get_pnl_leaderboard`, `get_pnl_leaderboard_stats`, `get_account_pnl_rank`, `get_vault_leaderboard` (see `infrastructure/hasura/metadata/databases/intuition/functions/functions.yaml`).
+- Rankings are computed **at query time** from timescale data. There is **no background accrual process** feeding the display.
+- If the frontend removes the page, the queries simply stop. Backend needs zero changes for that; optionally the functions can be untracked from Hasura metadata to remove them from the GraphQL schema.
+
+### 2. The IQ points *awarding* (Season 2 settlement)
+
+Defined in migration `1771526400000_add_season2_iq_points_mvp`:
+
+- `season2_epoch` — pre-seeded calendar, epochs **8..30**, 14 days each, 2026-02-24 → 2027-01-12.
+- `scripts/season2_capture_trust_price.sh` — snapshots TRUST/USD from CoinGecko into `season2_trust_price_snapshot` every 12h (00:00 / 12:00 UTC).
+- `scripts/season2_settle_epoch.sh --epoch N [--finalize]` — run **after** an epoch ends (+12h grace). Calls `settle_season2_epoch(N)`, which writes `season2_iq_ledger` entries of three types:
+  - `fee` — every account's protocol fees for the epoch converted to IQ (`protocol_fee_accrued` × avg TRUST/USD × 2000).
+  - `leaderboard_pnl` — top-25 payout curve on the nominal PnL board (`season2_leaderboard_payout` ranks 1–25).
+  - `leaderboard_roi` — top-25 payout curve on the ROI (`pnl_pct`) board.
+  Then optionally `finalize_season2_epoch(N)` freezes it.
+- **IQ points only ever come into existence when settlement runs.** There is no continuous accrual. Hasura has no cron triggers (`cron_triggers.yaml` is `[]`) and this repo has no k8s CronJob manifests — the two scripts are run manually or scheduled outside this repo (likely gcp-deployment; see open items).
+- `chart-api` serves `GET /api/v1/accounts/{id}/season2/iq` by reading the ledger — pure historical read; keeps working unchanged after wind-down.
+
+## What "stopping" requires
+
+### Minimal (zero code)
+
+Stop running `season2_settle_epoch.sh` for epochs after the last rewarded one. No IQ is ever created for those epochs. Historical ledger, epoch prices, and the chart-api endpoint are untouched.
+
+### Clean (recommended, ~half a day + review)
+
+1. **Guard the settlement function** — one small Hasura migration adding a cutoff check to `settle_season2_epoch` (refuse epochs > last rewarded epoch), and/or delete the unneeded future rows from `season2_epoch`. Prevents an accidental manual settlement months later.
+2. **Stop the 12h TRUST price capture** wherever it is scheduled. Harmless if left running (tiny table, one CoinGecko call), but pointless.
+3. **Optionally untrack the leaderboard read functions** from Hasura metadata once the frontend removes the page — the period-leaderboard queries are the expensive part of this feature, and untracking guarantees nobody keeps hitting them. If the frontend keeps a read-only historical page instead, leave them tracked.
+
+### Not involved at all
+
+- No indexer/consumer changes, no contract changes, no data migrations, no backfills.
+- `protocol_fee_accrued` keeps accruing from chain events regardless — harmless; it just never gets converted to IQ once settlement stops.
+
+## Decision points for planning
+
+1. **Does fee IQ stop too?** Settlement awards three entry types in one function. "No IQ for leaderboard positions" kills `leaderboard_pnl`/`leaderboard_roi`; if `fee` IQ should *continue*, that's a small migration to `settle_season2_epoch` (skip the two leaderboard inserts) rather than simply not running the script — still small, but different work.
+2. **Does the display stay?** Keeping a read-only leaderboard page (no rewards) costs the backend nothing. Removing it is a frontend change; backend just untracks functions afterwards.
+3. **Cutoff epoch** — need the last epoch that still pays out, to write the guard.
+
+## Scheduling — verified in cluster (2026-08-12)
+
+Checked `gke_be-cluster_us-west2_debug-cluster`:
+
+- **Price capture IS scheduled** as k8s CronJobs (every 12h, `0,12` UTC with per-env minute offsets), active in three namespaces:
+  - `intuition-mainnet-next` — `intuition-mainnet-next-season2-price-capture` (7 0,12 * * *)
+  - `intuition-mainnet-nested-triples` — `mainnet-nested-season2-price-capture` (9 0,12 * * *)
+  - `intuition-testnet-next` — `intuition-testnet-next-season2-price-capture` (5 0,12 * * *)
+  - (`intuition-testnet-a` has one too, already suspended)
+  Each runs a `postgres:17-alpine` pod executing a ConfigMap-mounted `capture.sh` with `DATABASE_URL` from the `season2-db-credentials` secret. The manifests live in the gcp-deployment repo — wind-down step is to suspend/delete them there.
+- **Settlement is NOT scheduled anywhere** — no CronJob, Job, or Deployment for `settle_season2_epoch` exists in the cluster. Epoch settlement is a manual run of `scripts/season2_settle_epoch.sh`. This confirms the minimal wind-down is genuinely zero code: just stop running that script.
+
+---
+
+## Update 2026-09-10
+
+GWTH-4354 implemented the "clean" wind-down (decision point 1 above resolved
+as: **fee IQ continues, leaderboard IQ freezes at Epoch 20**). Two of this
+assessment's "Clean" recommendations turned out to be wrong once we checked
+live data and the actual read path, and were corrected before implementation:
+
+- **"Stop the 12h TRUST price capture" (item 2) — wrong, not done.** Fee IQ's
+  formula divides by the epoch's average TRUST/USD price, computed from
+  `season2_trust_price_snapshot`. Snapshots are point-in-time and cannot be
+  backfilled — an epoch with zero snapshots makes `settle_season2_epoch`
+  raise and makes fee IQ for that epoch permanently unsettleable. Since this
+  wind-down explicitly keeps fee IQ running past Epoch 20, the CronJobs stay
+  running in all three namespaces.
+- **"Optionally untrack the leaderboard read functions" (item 3) — wrong,
+  not done.** The frontend is keeping a read-only archive of Epochs 1-20,
+  and that archive queries `get_pnl_leaderboard_period` live via the
+  `get_pnl_leaderboard_period_min_threshold` Hasura Action / chart-api route
+  on every page load — untracking anything in that chain breaks the archive
+  outright, not just future epochs.
+
+The cutoff epoch from decision point 3 is **Epoch 20**.
+
+Full rationale, live-DB evidence, and the corrected read-path chain (portal
+→ Hasura Action → chart-api → Postgres function, not a directly-tracked
+Postgres function as implied above) are in
+`docs/leaderboard-wind-down-epoch-20.md`. That doc also covers the four
+all-time leaderboard functions (`get_pnl_leaderboard`,
+`get_pnl_leaderboard_stats`, `get_account_pnl_rank`,
+`get_vault_leaderboard`) referenced in "How the system actually works" above
+— confirmed still unused by the portal, and deliberately left tracked rather
+than untracked, pending their own ticket if they're ever removed.

--- a/docs/leaderboard-wind-down-epoch-20.md
+++ b/docs/leaderboard-wind-down-epoch-20.md
@@ -333,3 +333,64 @@ After the down migration, `settle_season2_epoch(21)` raises
 outcome. `down.sql` restores the pre-migration function *verbatim*, including
 the two pre-existing bugs, because a rollback that quietly kept the fixes
 would not be a true revert. The bugs are the pre-migration state.
+
+## The temp-table defect: fixed in the callee, in its own migration
+
+Review finding M1 was that the `42P07` temp-table collision was worked around
+in the caller (`settle_season2_epoch`) while the defect actually lives in
+`get_pnl_leaderboard_period`, which carried an undocumented "call me at most
+once per transaction" contract.
+
+That is now fixed properly, in
+`1771526445000_fix_pnl_leaderboard_period_temp_tables` — a **separate**
+migration, deliberately not folded into the wind-down.
+
+### Why a separate migration
+
+Postgres cannot prepend to a function body; `CREATE OR REPLACE` requires
+restating the whole thing. `get_pnl_leaderboard_period` is **637 lines**, and
+has been redefined **28 times** across the migration history — it is a hot,
+actively-maintained function owned by whoever works on PnL.
+
+Folding it in would have taken the wind-down migration from 768 lines to
+roughly 2,040, and pinned a verbatim snapshot of somebody else's evolving code
+path inside a leaderboard wind-down. Keeping it separate means it can be
+reviewed, approved and reverted on its own terms.
+
+### Why 1771526444000 keeps its caller-side DROPs
+
+They become redundant once this migration is applied, but they are idempotent
+no-ops, and keeping them means **this migration can be reverted without
+breaking settlement**. That independence is the whole point of splitting it
+out.
+
+### Fidelity
+
+`down.sql`'s function body is byte-identical to the source definition in
+`1771526443000_fix_unrealized_pnl_pre_epoch_redemptions` (verified by `diff`).
+`up.sql` differs from it by exactly **20 added lines and 0 removed lines** —
+the `DROP TABLE IF EXISTS` block and its explanatory comment. The
+`COMMENT ON FUNCTION` is byte-verbatim in both directions.
+
+### Verification
+
+`scripts/season2_verify_leaderboard_period_temp_tables.sql`, run inside
+`BEGIN;`/`ROLLBACK;` against both portal databases:
+
+| Database | three calls in one transaction | same-argument calls agree |
+| --- | --- | --- |
+| `intuition-testnet-next` | 0, 0, 0 rows | yes |
+| `intuition-mainnet-nested-triples` | 25, 25, 25 rows | yes |
+
+Three calls rather than two: the second proves the fix, the third proves it is
+not a one-shot. The assertion compares the two same-argument calls against each
+other rather than pinning an absolute row count, since counts reflect live PnL
+activity — but "no error raised" alone would be satisfied by a function that
+returned nothing, so the agreement check is what makes it a real test.
+
+Before the fix, the second call raised
+`42P07 relation "_tmp_active_accounts" already exists` — reproduced against the
+deployed function.
+
+`scripts/season2_check_verify_script_sync.sh` covers this migration's embedded
+copy too, and was negative-tested: injected drift correctly exits non-zero.

--- a/docs/leaderboard-wind-down-epoch-20.md
+++ b/docs/leaderboard-wind-down-epoch-20.md
@@ -176,19 +176,41 @@ been successfully run anywhere (see the evidence table above). Between them,
 the original, unpatched function could never successfully settle any epoch at
 all, for any reason, ever — not just epoch 21+.
 
-1. **`ON CONFLICT (epoch, ...)` is ambiguous.** `settle_season2_epoch`'s
-   `RETURNS TABLE` declares its first OUT column as `epoch`, which PL/pgSQL
-   treats as an implicit variable in scope for the whole function body. Every
-   `ON CONFLICT (epoch, ...)` clause in the function (there are four: one in
-   the `season2_epoch_price` upsert, three in the `season2_iq_ledger`
-   inserts) then has a genuine ambiguity — Postgres can't tell whether
-   `epoch` means the OUT variable or the table column — and raises `column
-   reference "epoch" is ambiguous`. Fix: `#variable_conflict use_column` at
-   the top of the function body, which tells PL/pgSQL to prefer the column
-   interpretation everywhere in the function. Safe here because the function
-   never intentionally references its OUT columns by their bare names (it
+1. **A bare `epoch` reference is ambiguous — at FIVE sites, not four.**
+   `settle_season2_epoch`'s `RETURNS TABLE` declares its first OUT column as
+   `epoch`, which PL/pgSQL treats as an implicit variable in scope for the
+   whole function body. Every bare `epoch` reference in a DML statement
+   below then has a genuine ambiguity — Postgres can't tell whether `epoch`
+   means the OUT variable or the table column — and raises `column
+   reference "epoch" is ambiguous`. There are five such sites: the
+   `ON CONFLICT (epoch)` clause in the `season2_epoch_price` upsert, the
+   three `ON CONFLICT (epoch, entry_type, source_id)` clauses in the
+   `season2_iq_ledger` inserts (fee, pnl, roi) — and a fifth that is easy to
+   miss because it isn't an `ON CONFLICT` clause at all:
+   `DELETE FROM season2_iq_ledger WHERE epoch = p_epoch` inside the
+   `IF p_force THEN` branch. That fifth site is exactly as ambiguous as the
+   other four, but it never surfaced during development (an earlier draft of
+   this writeup also undercounted it as four) because `p_force` has never
+   been exercised — every verification and live call so far used
+   `p_force = FALSE`. Fix: `#variable_conflict use_column` at the top of the
+   function body, which tells PL/pgSQL to prefer the column interpretation
+   everywhere in the function. Safe here because the function never
+   intentionally references its OUT columns by their bare names (it
    consistently uses `v_`-prefixed locals and `p_`-prefixed parameters
    instead).
+
+   **Caution for future edits:** `#variable_conflict use_column` disables
+   Postgres's `42702` ambiguity detection for every bare identifier in the
+   *entire* function, not just these five sites — it's a function-wide
+   pragma, not a per-statement one. If a future edit adds a bare reference
+   that collides with a column name but actually intends the *variable*, it
+   will silently resolve to the column instead of raising an error, with no
+   warning at `CREATE FUNCTION` time or at call time. If this function is
+   revisited, prefer `ON CONFLICT ON CONSTRAINT <constraint_name>` (e.g.
+   `season2_iq_ledger_epoch_entry_source_unique`, `season2_epoch_price_pkey`)
+   over broadening reliance on this pragma — it resolves each site's
+   ambiguity individually, by naming the constraint instead of the column
+   list, without touching the function's global identifier resolution rule.
 2. **`get_pnl_leaderboard_period`'s temp tables collide on a second call
    in the same transaction.** That function creates seven `ON COMMIT DROP`
    temp tables (`_tmp_active_accounts`, `_tmp_position_data`,
@@ -290,7 +312,11 @@ fixes (changes 4 and 5) work: before them, `settle_season2_epoch` raised
 against the deployed function before the fix.
 
 Total runtime for the epoch-20 case, including both leaderboard
-computations: ~27s.
+computations: ~27s. For comparison, `settle_season2_epoch(21)` — past the
+cutoff, so both `get_pnl_leaderboard_period` calls are skipped — took a
+measured **479 ms** on the same environment
+(`intuition-mainnet-nested-triples`): roughly a **56x** reduction, entirely
+attributable to skipping the two leaderboard computations.
 
 ### Reversibility
 

--- a/docs/leaderboard-wind-down-epoch-20.md
+++ b/docs/leaderboard-wind-down-epoch-20.md
@@ -217,28 +217,41 @@ back, since a true revert to the pre-migration `settle_season2_epoch` has to
 restore its pre-migration body verbatim, bugs included (see `down.sql`'s own
 comments).
 
-A third thing surfaced while building the verification script itself, not
-the migration: `protocol_fee_accrued.epoch` turns out **not** to follow
-`season2_epoch`'s 8-30 calendar. It's a separate, far more finely grained,
-densely populated counter — real `intuition-testnet-next` data has rows for
-nearly every integer from 1 to 322+ as of 2026-09-10. This is why the
-verification script's synthetic fixture epochs are `-7` and `90000041`
-rather than small positive numbers like `7` and `41` (an earlier version
-used those and the byte-identical-fee assertion failed, correctly, because
-real `protocol_fee_accrued` rows at epoch 7 and 41 leaked into the totals).
-This is worth knowing about independently of this ticket: it means
-`settle_season2_epoch`'s fee INSERT (`WHERE pfa.epoch = p_epoch::NUMERIC`)
-has always been matching `protocol_fee_accrued` rows against a number that
-isn't actually a Season 2 epoch number in the sense `season2_epoch` defines
-it. Whether that's the intended design (`protocol_fee_accrued.epoch` means
-something else that was always meant to be compared directly, e.g. a raw
-on-chain epoch counter that happens to be fed the same integers) or a
-latent correctness bug in the fee IQ formula is a separate, substantive
-question this ticket did not investigate further and does not change —
-fixing or even fully diagnosing it would mean understanding what emits
-`protocol_fee_accrued` and what "epoch" is supposed to mean there, which is
-out of scope for a migration that only touches the leaderboard cutoff. Flagging
-it here so it isn't lost.
+A third thing surfaced while building the verification script, and it is
+worth stating precisely because the first reading of it was wrong.
+
+On `intuition-testnet-next`, `protocol_fee_accrued.epoch` spans 1 to 322
+(269 distinct values) and clearly does *not* line up with `season2_epoch`'s
+8-30 calendar. That initially looked like a latent correctness bug in the
+fee IQ formula.
+
+It is not. Checked against the environments that actually matter
+(2026-09-10):
+
+| Database | `protocol_fee_accrued.epoch` range | distinct | rows |
+| --- | --- | --- | --- |
+| `intuition-mainnet-nested-triples` | 0 - 22 | 23 | 363,172 |
+| `intuition-mainnet-next` | 0 - 22 | 23 | 363,180 |
+| `intuition-testnet-next` | 1 - 322 | 269 | 69,442 |
+
+On mainnet the counter runs 0-22, which matches the on-chain
+`TrustBonding.currentEpoch()` value of 22 read the same day. `season2_epoch`
+covers epochs 8-30 of that same on-chain sequence, so the fee INSERT's
+`WHERE pfa.epoch = p_epoch::NUMERIC` matches exactly the rows it should.
+**Fee IQ settlement is correct in production.**
+
+The 1-322 spread is a testnet-only artifact: the testnet chain cycles
+epochs far faster, so its on-chain epoch counter has run far past the
+Season 2 calendar that was designed around mainnet's 14-day cadence. The
+only consequence is for testing: synthetic fixture epochs on testnet must
+avoid colliding with real `protocol_fee_accrued` rows, which is why
+`scripts/season2_verify_leaderboard_cutoff.sql` uses `-7` and `90000041`
+rather than small positive integers like `7` and `41` (an earlier version
+used those, and the byte-identical-fee assertion failed correctly because
+real rows at those epochs leaked into the totals).
+
+No follow-up needed. Recorded here so the testnet spread isn't mistaken for
+a production bug the next time someone looks.
 
 ## Validation
 
@@ -248,3 +261,49 @@ selective (blocks leaderboard IQ, not fee IQ) rather than the function being
 broken. See the script header for the fixture design and
 `docs/leaderboard-wind-down-epoch-20.md`'s sibling migration for what it
 verifies against `intuition-testnet-next`.
+
+## End-to-end verification on real mainnet data
+
+The fixture-based script above proves the guard in isolation. This is the
+production-shaped proof: `up.sql` applied inside a transaction against
+`intuition-mainnet-nested-triples`, both epochs settled with **real** data,
+then rolled back (nothing persisted).
+
+| Epoch | fee entries | fee IQ | leaderboard entries | pnl IQ | roi IQ |
+| --- | --- | --- | --- | --- | --- |
+| **20** (<= cutoff) | 3,977 | 828,289 | **25 pnl + 25 roi** | 3,000,000 | 3,000,000 |
+| **21** (> cutoff) | 16,297 | 2,996,047 | **0** | 0 | 0 |
+
+Read together these are the two halves of the requirement:
+
+- Epoch 21 awards **fee IQ and only fee IQ** — requirement 2 holds past the
+  cutoff, and requirement 1 holds at the same time.
+- Epoch 20 still awards **the full 25-rank payout on both boards** — the
+  guard is selective, not a blanket off-switch. An implementation that
+  simply broke settlement would fail this row.
+
+Both epochs settling at all is also the proof that the two pre-existing bug
+fixes (changes 4 and 5) work: before them, `settle_season2_epoch` raised
+`42702 column reference "epoch" is ambiguous` on any epoch, and
+`42P07 relation "_tmp_active_accounts" already exists` on the second
+`get_pnl_leaderboard_period` call within one settlement. Both were confirmed
+against the deployed function before the fix.
+
+Total runtime for the epoch-20 case, including both leaderboard
+computations: ~27s.
+
+### Reversibility
+
+`up.sql` then `down.sql`, applied in one transaction against
+`intuition-testnet-next` and rolled back:
+
+| Stage | `season2_last_leaderboard_epoch` | `settle_season2_epoch` |
+| --- | --- | --- |
+| after `up.sql` | 1 (created) | 1 |
+| after `down.sql` | 0 (dropped) | 1 (restored) |
+
+After the down migration, `settle_season2_epoch(21)` raises
+`42702 column reference "epoch" is ambiguous` again — which is the intended
+outcome. `down.sql` restores the pre-migration function *verbatim*, including
+the two pre-existing bugs, because a rollback that quietly kept the fixes
+would not be a true revert. The bugs are the pre-migration state.

--- a/docs/leaderboard-wind-down-epoch-20.md
+++ b/docs/leaderboard-wind-down-epoch-20.md
@@ -1,0 +1,250 @@
+# Leaderboard Wind-Down — Epoch 20 Freeze (GWTH-4354)
+
+**Date:** 2026-09-10
+**Ticket:** GWTH-4354
+**Migration:** `infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20`
+
+## Decision
+
+The Season 2 leaderboard (`portal.intuition.systems/leaderboard`) is winding down.
+**Epoch 20 (2026-08-11 → 2026-08-25) is the final epoch that pays out leaderboard
+IQ.** From Epoch 21 onward, `settle_season2_epoch` no longer inserts
+`leaderboard_pnl` or `leaderboard_roi` entries into `season2_iq_ledger`.
+
+**Fee IQ (`entry_type = 'fee'`, protocol fees converted to IQ) continues
+unchanged for every epoch, including 21+.** These are separate entry types
+awarded by the same settlement function; only the two leaderboard entry types
+are frozen.
+
+This corrects and supersedes the recommendations in
+`docs/leaderboard-wind-down-assessment-2026-08-12.md` — see the "Update
+2026-09-10" section appended to that doc.
+
+## Live-DB evidence (verified 2026-09-10)
+
+Checked across `intuition-mainnet-next`, `intuition-mainnet-nested-triples`
+and `intuition-testnet-next`:
+
+| Fact | Value |
+|---|---|
+| `season2_iq_ledger` row count | 0 in every environment |
+| `season2_epoch.settled_at` | NULL for every epoch — settlement has never run |
+| `season2_trust_price_snapshot` | healthy, still capturing (last snapshot 2026-09-10 12:00 UTC, ~400 rows) |
+| `protocol_fee_accrued` | accruing normally (epoch 22 has 149,135 rows) |
+| `season2_epoch` calendar | epoch 20 = 2026-08-11 → 2026-08-25; epoch 21 = 2026-08-25 → 2026-09-08; epoch 22 = 2026-09-08 → 2026-09-22 |
+
+Because `season2_iq_ledger` is empty everywhere, this migration's cleanup
+`DELETE` (reversing any leaderboard IQ already settled past the cutoff) has
+**zero rows to act on today** — see "No-op in practice" below.
+
+## Why the price-capture CronJobs were deliberately NOT suspended
+
+The original 2026-08-12 assessment recommended stopping the 12h TRUST/USD
+price-capture CronJobs as part of a clean wind-down (its step 3, item 2).
+**That recommendation was wrong and has been overridden.**
+
+Fee IQ is computed as:
+
+```
+fee_iq = (amount_trust × average_trust_usd_for_epoch) × 2000
+```
+
+`average_trust_usd_for_epoch` comes from `AVG(price_usd)` over
+`season2_trust_price_snapshot` rows inside the epoch's `[start_at, end_at)`
+window. If that window has **zero snapshots**, `settle_season2_epoch` raises:
+
+```
+No TRUST/USD snapshots found for Season 2 epoch %
+```
+
+Snapshots are point-in-time captures — there is no way to backfill a missed
+12h window after the fact. If the CronJobs had been suspended, every epoch
+from the suspension date onward would have a permanent snapshot gap, and
+**fee IQ for those epochs could never be settled**, not even manually,
+because there is no average price to compute it from. Since fee IQ must
+keep working for epoch 21+ (see Decision above), suspending price capture
+would have silently broken the one thing this wind-down explicitly needs to
+keep working.
+
+The correction: **the price-capture CronJobs stay running** in all three
+namespaces (`intuition-mainnet-next`, `intuition-mainnet-nested-triples`,
+`intuition-testnet-next`). This was approved by the ticket owner. The cost
+of leaving them running is negligible — one small table, one CoinGecko call
+every 12h, no relation to the leaderboard read path being wound down.
+
+## Why the Hasura leaderboard functions were NOT untracked
+
+The original assessment also suggested untracking the leaderboard read
+functions from Hasura metadata (step 3, item 3) once the frontend removes
+the live leaderboard page. **That is not being done, for two separate
+reasons — one about what the Epoch 1-20 archive needs, and one about the
+all-time functions nobody uses.**
+
+### 1. The Epochs 1-20 archive needs `get_pnl_leaderboard_period_min_threshold` at runtime
+
+The frontend is keeping a read-only historical archive of Epochs 1-20 (the
+epochs that actually paid out). That archive is not a static snapshot — it
+queries live at render time. The call chain is:
+
+```
+portal GraphQL query
+  -> Hasura Action `get_pnl_leaderboard_period_min_threshold`
+     (infrastructure/hasura/metadata/actions.yaml:73,
+      handler: '{{chartApiUrl}}', timeout: 300)
+  -> chart-api REST: GET /api/v1/leaderboard/pnl/period/min-threshold
+     (apps/chart-api/src/app.rs, apps/chart-api/src/endpoints/leaderboard.rs)
+  -> Postgres function `get_pnl_leaderboard_period`
+```
+
+`get_pnl_leaderboard_period_min_threshold` is a **Hasura Action**, not a
+tracked Postgres function — it does not appear in `pg_proc` in either portal
+database. It is a GraphQL field whose resolver is an HTTP request-transform
+to chart-api, which in turn calls the Postgres function. Untracking anything
+in this chain (the Action, or the chart-api route) breaks every Epoch 1-20
+archive page load, for every epoch, indefinitely — not just for future
+epochs. Nothing in this chain is touched by this migration or by this
+wind-down.
+
+### 2. The four all-time leaderboard functions are unused by the portal — left tracked anyway
+
+Separately, `infrastructure/hasura/metadata/databases/intuition/functions/functions.yaml`
+tracks four all-time (not period-scoped) leaderboard functions:
+`get_pnl_leaderboard`, `get_pnl_leaderboard_stats`, `get_account_pnl_rank`,
+`get_vault_leaderboard`. These are **not used by the current portal** — the
+only local references are the portal's introspected `schema.graphql` and a
+dead codegen file (`app/lib/graphql/queries/leaderboard.graphql`) that no
+route imports.
+
+Decision: **leave them tracked.** They are fields on the public GraphQL
+schema; external consumers of the API cannot be ruled out; untracking them
+is a breaking API change that buys nothing for this ticket (the IQ cutoff is
+enforced in `settle_season2_epoch`, not in any read path); and there is no
+evidence-gathering done yet on who might be calling them. If they are ever
+removed, that should be its own ticket with a deprecation notice and at
+least a day of Hasura query-log sampling first, not a side effect of this
+migration.
+
+## What the migration does
+
+`infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20`:
+
+1. Adds `season2_last_leaderboard_epoch() RETURNS INTEGER` — a single,
+   greppable, commented cutoff constant (`SELECT 20`) instead of a bare `20`
+   buried inside `settle_season2_epoch`'s body.
+2. `CREATE OR REPLACE FUNCTION settle_season2_epoch(...)` with the identical
+   signature and `RETURNS TABLE` column list as the original definition in
+   `1771526400000_add_season2_iq_points_mvp` (Postgres rejects a
+   `CREATE OR REPLACE` that changes a function's return type). The body is
+   copied verbatim with exactly one behavioural change: the
+   `leaderboard_pnl` and `leaderboard_roi` INSERT blocks are wrapped in
+   `IF p_epoch <= season2_last_leaderboard_epoch() THEN ... END IF;`. Epoch
+   validation, snapshot averaging, the `fee` INSERT block, the
+   `settled_at` update, and the final recompute-and-return are byte-for-byte
+   unchanged — settling epoch 21+ still succeeds and still awards fee IQ.
+3. An idempotent `DELETE FROM season2_iq_ledger WHERE epoch >
+   season2_last_leaderboard_epoch() AND entry_type IN ('leaderboard_pnl',
+   'leaderboard_roi')` to reverse any leaderboard IQ already settled past
+   the cutoff.
+4. Does **not** touch `season2_epoch` — epochs 21-30 stay in the table so
+   fee IQ can still be settled for them.
+
+## "Reverse leaderboard IQ already settled for Epoch 21+" was a no-op in practice
+
+The ticket requires that any leaderboard IQ already settled for Epoch 21+ be
+reversed. Per the live-DB evidence above, `season2_iq_ledger` is **empty in
+every environment** — settlement has never been run, so there is nothing to
+reverse today. In practice, step 3 of the migration deletes 0 rows right
+now.
+
+It is still implemented as a real, idempotent `DELETE` (not skipped or left
+as a TODO) so the guarantee holds if this migration lands after someone
+manually runs `settle_season2_epoch` for epoch 21+ before it does, and so
+re-applying the migration is always safe.
+
+## Two pre-existing bugs found while validating this migration
+
+Building `scripts/season2_verify_leaderboard_cutoff.sql` meant calling
+`settle_season2_epoch` for real for the first time ever, against
+`intuition-testnet-next`. It failed — twice, in two different ways, neither
+related to the leaderboard cutoff. Both are fixed in this migration's `up.sql`
+(changes 4 and 5 in its header) because an unfixed `settle_season2_epoch`
+cannot award fee IQ for epoch 21+ either, which is the one thing this
+wind-down explicitly needs to keep working. Both predate this migration —
+they are present verbatim in `1771526400000_add_season2_iq_points_mvp` — and
+were never caught in any environment because `settle_season2_epoch` has never
+been successfully run anywhere (see the evidence table above). Between them,
+the original, unpatched function could never successfully settle any epoch at
+all, for any reason, ever — not just epoch 21+.
+
+1. **`ON CONFLICT (epoch, ...)` is ambiguous.** `settle_season2_epoch`'s
+   `RETURNS TABLE` declares its first OUT column as `epoch`, which PL/pgSQL
+   treats as an implicit variable in scope for the whole function body. Every
+   `ON CONFLICT (epoch, ...)` clause in the function (there are four: one in
+   the `season2_epoch_price` upsert, three in the `season2_iq_ledger`
+   inserts) then has a genuine ambiguity — Postgres can't tell whether
+   `epoch` means the OUT variable or the table column — and raises `column
+   reference "epoch" is ambiguous`. Fix: `#variable_conflict use_column` at
+   the top of the function body, which tells PL/pgSQL to prefer the column
+   interpretation everywhere in the function. Safe here because the function
+   never intentionally references its OUT columns by their bare names (it
+   consistently uses `v_`-prefixed locals and `p_`-prefixed parameters
+   instead).
+2. **`get_pnl_leaderboard_period`'s temp tables collide on a second call
+   in the same transaction.** That function creates seven `ON COMMIT DROP`
+   temp tables (`_tmp_active_accounts`, `_tmp_position_data`,
+   `_tmp_prices_at_start`, `_tmp_prices_at_end`, `_tmp_vault_state_at_start`,
+   `_tmp_vault_state_at_end`, `_tmp_realized_fifo`). `ON COMMIT DROP` only
+   fires at actual transaction commit — never between statements within the
+   same transaction/session. `settle_season2_epoch` calls
+   `get_pnl_leaderboard_period` twice every time it settles an epoch at or
+   under the cutoff (once for the nominal-PnL board, once for the ROI
+   board), so the second call's `CREATE TEMP TABLE` always failed with
+   `relation "..." already exists` — discovered one table at a time against
+   `intuition-testnet-next` as each was reached. The same collision also
+   hits a *later* `settle_season2_epoch` call in the same session, against
+   temp tables left behind by an *earlier* call's ROI board query. Fix:
+   `DROP TABLE IF EXISTS` for all seven, added in `settle_season2_epoch` in
+   two places — right before the pnl block, and again between the pnl and
+   roi blocks — so every `get_pnl_leaderboard_period` call starts clean
+   regardless of what ran before it in the same session. This only touches
+   `settle_season2_epoch`'s own body; `get_pnl_leaderboard_period` itself
+   (a live, portal-facing function) is untouched, since those temp tables
+   are self-contained scratch state used only inside its own body.
+
+Both fixes are pre-existing-bug fixes, not part of the leaderboard cutoff
+behaviour itself — `down.sql` deliberately reintroduces both when rolling
+back, since a true revert to the pre-migration `settle_season2_epoch` has to
+restore its pre-migration body verbatim, bugs included (see `down.sql`'s own
+comments).
+
+A third thing surfaced while building the verification script itself, not
+the migration: `protocol_fee_accrued.epoch` turns out **not** to follow
+`season2_epoch`'s 8-30 calendar. It's a separate, far more finely grained,
+densely populated counter — real `intuition-testnet-next` data has rows for
+nearly every integer from 1 to 322+ as of 2026-09-10. This is why the
+verification script's synthetic fixture epochs are `-7` and `90000041`
+rather than small positive numbers like `7` and `41` (an earlier version
+used those and the byte-identical-fee assertion failed, correctly, because
+real `protocol_fee_accrued` rows at epoch 7 and 41 leaked into the totals).
+This is worth knowing about independently of this ticket: it means
+`settle_season2_epoch`'s fee INSERT (`WHERE pfa.epoch = p_epoch::NUMERIC`)
+has always been matching `protocol_fee_accrued` rows against a number that
+isn't actually a Season 2 epoch number in the sense `season2_epoch` defines
+it. Whether that's the intended design (`protocol_fee_accrued.epoch` means
+something else that was always meant to be compared directly, e.g. a raw
+on-chain epoch counter that happens to be fed the same integers) or a
+latent correctness bug in the fee IQ formula is a separate, substantive
+question this ticket did not investigate further and does not change —
+fixing or even fully diagnosing it would mean understanding what emits
+`protocol_fee_accrued` and what "epoch" is supposed to mean there, which is
+out of scope for a migration that only touches the leaderboard cutoff. Flagging
+it here so it isn't lost.
+
+## Validation
+
+`scripts/season2_verify_leaderboard_cutoff.sql` — a self-contained,
+`BEGIN; ... ROLLBACK;`-wrapped differential test — proves the guard is
+selective (blocks leaderboard IQ, not fee IQ) rather than the function being
+broken. See the script header for the fixture design and
+`docs/leaderboard-wind-down-epoch-20.md`'s sibling migration for what it
+verifies against `intuition-testnet-next`.

--- a/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/down.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/down.sql
@@ -1,0 +1,299 @@
+-- GWTH-4354: revert the leaderboard wind-down.
+--
+-- Restores settle_season2_epoch(...) to the verbatim pre-migration body
+-- from migration 1771526400000_add_season2_iq_points_mvp (unconditional
+-- leaderboard_pnl / leaderboard_roi inserts for every epoch), and drops
+-- the season2_last_leaderboard_epoch() cutoff constant.
+--
+-- NOTE: this cannot resurrect any leaderboard_pnl / leaderboard_roi rows
+-- that up.sql's DELETE removed (or that were never inserted because the
+-- guard skipped them). If leaderboard IQ needs to exist for those epochs
+-- again, it must be re-settled (e.g. `settle_season2_epoch(N, TRUE)`)
+-- after this rollback — there is no way to recover the original values
+-- from a DELETE.
+--
+-- NOTE: this also reintroduces two pre-existing bugs that up.sql happened
+-- to fix as a side effect (see up.sql's changes 4 and 5, and
+-- docs/leaderboard-wind-down-epoch-20.md):
+--   - Without `#variable_conflict use_column`, every
+--     `ON CONFLICT (epoch, ...)` clause in this function raises "column
+--     reference \"epoch\" is ambiguous", because the function's
+--     RETURNS TABLE OUT column is also named `epoch`.
+--   - Without the two `DROP TABLE IF EXISTS` for get_pnl_leaderboard_period's
+--     seven `ON COMMIT DROP` temp tables (one before the pnl INSERT
+--     block, one before the roi INSERT block), a second call to
+--     get_pnl_leaderboard_period() — whether the roi call within one
+--     settle_season2_epoch execution, or the pnl call of a later
+--     settle_season2_epoch invocation in the same session — fails with
+--     'relation "..." already exists', because those tables only drop at
+--     transaction commit, not between calls within the same
+--     transaction/session.
+-- Both predate this migration (present verbatim in
+-- 1771526400000_add_season2_iq_points_mvp) and were never triggered in
+-- production because settle_season2_epoch has never been successfully
+-- run anywhere — between them, the original function could never
+-- successfully settle any epoch at all. A true "restore pre-migration
+-- state" rollback has to bring both back too — this is intentional, not
+-- an oversight. If this rollback is ever actually run, re-apply both
+-- fixes (or new ones) before calling settle_season2_epoch again.
+
+CREATE OR REPLACE FUNCTION settle_season2_epoch(
+  p_epoch INTEGER,
+  p_force BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (
+  epoch INTEGER,
+  snapshot_count INTEGER,
+  average_trust_usd NUMERIC(20, 10),
+  fee_entries_inserted BIGINT,
+  pnl_entries_inserted BIGINT,
+  roi_entries_inserted BIGINT,
+  fee_iq_total NUMERIC(30, 0),
+  pnl_iq_total NUMERIC(30, 0),
+  roi_iq_total NUMERIC(30, 0),
+  total_iq NUMERIC(30, 0)
+) AS $$
+DECLARE
+  v_start_at TIMESTAMPTZ;
+  v_end_at TIMESTAMPTZ;
+  v_settle_after TIMESTAMPTZ;
+  v_is_final BOOLEAN;
+  v_snapshot_count INTEGER;
+  v_avg_price NUMERIC(20, 10);
+
+  v_fee_entries_inserted BIGINT := 0;
+  v_pnl_entries_inserted BIGINT := 0;
+  v_roi_entries_inserted BIGINT := 0;
+
+  v_fee_iq_total NUMERIC(30, 0) := 0;
+  v_pnl_iq_total NUMERIC(30, 0) := 0;
+  v_roi_iq_total NUMERIC(30, 0) := 0;
+BEGIN
+  SELECT
+    se.start_at,
+    se.end_at,
+    se.settle_after,
+    se.is_final
+  INTO
+    v_start_at,
+    v_end_at,
+    v_settle_after,
+    v_is_final
+  FROM season2_epoch se
+  WHERE se.epoch = p_epoch;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Season 2 epoch % not found', p_epoch;
+  END IF;
+
+  IF v_is_final THEN
+    RAISE EXCEPTION 'Season 2 epoch % is already finalized', p_epoch;
+  END IF;
+
+  IF NOW() < v_settle_after THEN
+    RAISE EXCEPTION
+      'Season 2 epoch % cannot be settled before settle_after (%)',
+      p_epoch,
+      v_settle_after;
+  END IF;
+
+  SELECT
+    COUNT(*)::INTEGER,
+    AVG(stps.price_usd)::NUMERIC(20, 10)
+  INTO
+    v_snapshot_count,
+    v_avg_price
+  FROM season2_trust_price_snapshot stps
+  WHERE stps.snapshot_at >= v_start_at
+    AND stps.snapshot_at < v_end_at;
+
+  IF v_snapshot_count = 0 OR v_avg_price IS NULL THEN
+    RAISE EXCEPTION 'No TRUST/USD snapshots found for Season 2 epoch %', p_epoch;
+  END IF;
+
+  INSERT INTO season2_epoch_price (
+    epoch,
+    snapshot_count,
+    average_price_usd,
+    computed_at,
+    updated_at
+  )
+  VALUES (
+    p_epoch,
+    v_snapshot_count,
+    v_avg_price,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (epoch) DO UPDATE
+  SET
+    snapshot_count = EXCLUDED.snapshot_count,
+    average_price_usd = EXCLUDED.average_price_usd,
+    computed_at = EXCLUDED.computed_at,
+    updated_at = NOW();
+
+  IF p_force THEN
+    DELETE FROM season2_iq_ledger
+    WHERE epoch = p_epoch;
+  END IF;
+
+  -- Fee IQ:  amount(wei TRUST) -> TRUST -> USD via epoch avg -> IQ at 2000/$1
+  WITH inserted_fee AS (
+    INSERT INTO season2_iq_ledger (
+      epoch,
+      account_id,
+      entry_type,
+      source_id,
+      iq_points,
+      metadata
+    )
+    SELECT
+      p_epoch,
+      pfa.sender_id,
+      'fee',
+      pfa.id,
+      ROUND((((pfa.amount / 1000000000000000000::NUMERIC) * v_avg_price) * 2000), 0)::NUMERIC(30, 0),
+      jsonb_build_object(
+        'fee_amount_raw', pfa.amount,
+        'average_trust_usd', v_avg_price,
+        'formula', '(amount_trust * average_trust_usd) * 2000'
+      )
+    FROM protocol_fee_accrued pfa
+    WHERE pfa.epoch = p_epoch::NUMERIC
+    ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+    RETURNING iq_points
+  )
+  SELECT
+    COUNT(*)::BIGINT,
+    COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+  INTO
+    v_fee_entries_inserted,
+    v_fee_iq_total
+  FROM inserted_fee;
+
+  -- Nominal PnL leaderboard IQ
+  WITH inserted_pnl AS (
+    INSERT INTO season2_iq_ledger (
+      epoch,
+      account_id,
+      entry_type,
+      source_id,
+      iq_points,
+      metadata
+    )
+    SELECT
+      p_epoch,
+      lb.account_id,
+      'leaderboard_pnl',
+      lb.account_id,
+      slp.iq_points,
+      jsonb_build_object(
+        'rank', lb.rank,
+        'leaderboard', 'pnl',
+        'sort_by', 'total_pnl'
+      )
+    FROM get_pnl_leaderboard_period(
+      v_start_at,
+      v_end_at,
+      25,
+      0,
+      'total_pnl',
+      'DESC',
+      TRUE,
+      1,
+      0,
+      NULL
+    ) lb
+    JOIN season2_leaderboard_payout slp
+      ON slp.rank = lb.rank::INTEGER
+    ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+    RETURNING iq_points
+  )
+  SELECT
+    COUNT(*)::BIGINT,
+    COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+  INTO
+    v_pnl_entries_inserted,
+    v_pnl_iq_total
+  FROM inserted_pnl;
+
+  -- ROI leaderboard IQ
+  WITH inserted_roi AS (
+    INSERT INTO season2_iq_ledger (
+      epoch,
+      account_id,
+      entry_type,
+      source_id,
+      iq_points,
+      metadata
+    )
+    SELECT
+      p_epoch,
+      lb.account_id,
+      'leaderboard_roi',
+      lb.account_id,
+      slp.iq_points,
+      jsonb_build_object(
+        'rank', lb.rank,
+        'leaderboard', 'roi',
+        'sort_by', 'pnl_pct'
+      )
+    FROM get_pnl_leaderboard_period(
+      v_start_at,
+      v_end_at,
+      25,
+      0,
+      'pnl_pct',
+      'DESC',
+      TRUE,
+      1,
+      0,
+      NULL
+    ) lb
+    JOIN season2_leaderboard_payout slp
+      ON slp.rank = lb.rank::INTEGER
+    ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+    RETURNING iq_points
+  )
+  SELECT
+    COUNT(*)::BIGINT,
+    COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+  INTO
+    v_roi_entries_inserted,
+    v_roi_iq_total
+  FROM inserted_roi;
+
+  UPDATE season2_epoch
+  SET
+    settled_at = NOW(),
+    last_settlement_force = p_force,
+    updated_at = NOW()
+  WHERE season2_epoch.epoch = p_epoch;
+
+  SELECT
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'fee'), 0)::NUMERIC(30, 0),
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'leaderboard_pnl'), 0)::NUMERIC(30, 0),
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'leaderboard_roi'), 0)::NUMERIC(30, 0)
+  INTO
+    v_fee_iq_total,
+    v_pnl_iq_total,
+    v_roi_iq_total
+  FROM season2_iq_ledger sil
+  WHERE sil.epoch = p_epoch;
+
+  RETURN QUERY
+  SELECT
+    p_epoch,
+    v_snapshot_count,
+    v_avg_price,
+    v_fee_entries_inserted,
+    v_pnl_entries_inserted,
+    v_roi_entries_inserted,
+    COALESCE(v_fee_iq_total, 0)::NUMERIC(30, 0),
+    COALESCE(v_pnl_iq_total, 0)::NUMERIC(30, 0),
+    COALESCE(v_roi_iq_total, 0)::NUMERIC(30, 0),
+    (COALESCE(v_fee_iq_total, 0) + COALESCE(v_pnl_iq_total, 0) + COALESCE(v_roi_iq_total, 0))::NUMERIC(30, 0);
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+DROP FUNCTION IF EXISTS season2_last_leaderboard_epoch();

--- a/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/down.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/down.sql
@@ -297,3 +297,7 @@ END;
 $$ LANGUAGE plpgsql VOLATILE;
 
 DROP FUNCTION IF EXISTS season2_last_leaderboard_epoch();
+
+DO $$ BEGIN
+  RAISE WARNING 'GWTH-4354 rollback: settle_season2_epoch restored to its pre-migration body, which cannot successfully settle ANY epoch (ON CONFLICT "epoch" ambiguity + get_pnl_leaderboard_period temp-table collision). See down.sql header.';
+END $$;

--- a/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/up.sql
@@ -106,19 +106,45 @@ RETURNS TABLE (
 -- GWTH-4354: pre-existing bug fix, unrelated to the leaderboard cutoff.
 -- This RETURNS TABLE's first OUT column is named `epoch`, which shadows
 -- the `epoch` column of `season2_epoch_price` and `season2_iq_ledger`
--- inside every `ON CONFLICT (epoch, ...)` clause below, making Postgres
--- raise "column reference \"epoch\" is ambiguous". This was never caught
--- because settle_season2_epoch has never been successfully run in any
--- environment (season2_iq_ledger is empty and settled_at is NULL for
--- every epoch everywhere, verified 2026-09-10) — see
--- docs/leaderboard-wind-down-epoch-20.md for how this was found (this
--- migration's own verification script, scripts/season2_verify_leaderboard_cutoff.sql,
--- failed against the unpatched body on first run). `use_column` makes
--- plpgsql prefer the column interpretation for every such ambiguity in
--- this function; the function already never references its OUT columns
--- by their bare names as variables (it consistently uses v_-prefixed
--- locals and p_-prefixed params instead), so this cannot change any
--- other behaviour.
+-- everywhere a bare `epoch` reference appears in a DML statement below,
+-- making Postgres raise "column reference \"epoch\" is ambiguous". There
+-- are FIVE such sites, not four: the `ON CONFLICT (epoch)` clause in the
+-- season2_epoch_price upsert, the three `ON CONFLICT (epoch, entry_type,
+-- source_id)` clauses in the season2_iq_ledger inserts (fee, pnl, roi) —
+-- and a fifth that is easy to miss because it is not an ON CONFLICT
+-- clause at all: `DELETE FROM season2_iq_ledger WHERE epoch = p_epoch`
+-- inside the `IF p_force THEN` branch a few lines below. That fifth site
+-- is exactly as ambiguous as the other four, but it never surfaced during
+-- development because p_force has never been exercised — every
+-- verification and live call so far used p_force = FALSE (see
+-- scripts/season2_verify_leaderboard_cutoff.sql's p_force test, added to
+-- cover this). This was never caught because settle_season2_epoch has
+-- never been successfully run in any environment (season2_iq_ledger is
+-- empty and settled_at is NULL for every epoch everywhere, verified
+-- 2026-09-10) — see docs/leaderboard-wind-down-epoch-20.md for how this
+-- was found (this migration's own verification script,
+-- scripts/season2_verify_leaderboard_cutoff.sql, failed against the
+-- unpatched body on first run). `use_column` makes plpgsql prefer the
+-- column interpretation for every such ambiguity in this function; the
+-- function already never references its OUT columns by their bare names
+-- as variables (it consistently uses v_-prefixed locals and p_-prefixed
+-- params instead), so this cannot change any other behaviour.
+--
+-- CAUTION for future edits: `#variable_conflict use_column` disables
+-- Postgres's 42702 ambiguity detection for every bare identifier in THIS
+-- ENTIRE FUNCTION, not just the five sites above — it is a function-wide
+-- pragma, not a per-statement one. If a future edit adds a bare
+-- reference that collides with a column name but actually intends the
+-- VARIABLE (not the column), it will silently resolve to the column
+-- instead of raising 42702 — a correctness bug with no warning at
+-- CREATE FUNCTION time or at call time. If this function is revisited,
+-- prefer a more surgical fix over relying further on this function-wide
+-- pragma: `ON CONFLICT ON CONSTRAINT <constraint_name>` (e.g.
+-- `season2_iq_ledger_epoch_entry_source_unique` for the ledger inserts,
+-- `season2_epoch_price_pkey` for the price upsert) resolves each site's
+-- ambiguity individually, by naming the constraint instead of the column
+-- list, without touching the function's global identifier resolution
+-- rule.
 DECLARE
   v_start_at TIMESTAMPTZ;
   v_end_at TIMESTAMPTZ;

--- a/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/up.sql
@@ -1,0 +1,439 @@
+-- GWTH-4354: Leaderboard wind-down — freeze leaderboard IQ at Epoch 20.
+--
+-- Season 2 leaderboard rewards ("Support the Trenches") are winding down.
+-- Epoch 20 (2026-08-11 -> 2026-08-25) is the LAST epoch that pays out
+-- leaderboard IQ (the `leaderboard_pnl` and `leaderboard_roi` entry types).
+-- From Epoch 21 onward, `settle_season2_epoch` must skip those two INSERT
+-- blocks entirely.
+--
+-- Fee IQ (`fee` entry type, protocol fees converted to IQ) is NOT part of
+-- this wind-down and MUST keep accruing unchanged for every epoch,
+-- including 21+. See docs/leaderboard-wind-down-epoch-20.md for the full
+-- rationale and the live-DB evidence this was based on.
+--
+-- Three changes, plus two unrelated bug fixes discovered while validating them:
+--   1. A greppable, auditable cutoff constant (season2_last_leaderboard_epoch()),
+--      instead of a bare literal buried in the settlement function body.
+--   2. CREATE OR REPLACE settle_season2_epoch(...) with the IDENTICAL
+--      signature and RETURNS TABLE column list as the original definition
+--      in migration 1771526400000_add_season2_iq_points_mvp (Postgres
+--      cannot change a function's return type via CREATE OR REPLACE). The
+--      body is copied verbatim except the `leaderboard_pnl` and
+--      `leaderboard_roi` INSERT blocks are now wrapped in
+--      `IF p_epoch <= season2_last_leaderboard_epoch() THEN ... END IF;`.
+--      Everything else (epoch validation, snapshot averaging, the `fee`
+--      INSERT block, `settled_at` update, final recompute-and-return) is
+--      untouched, so settling epoch 21+ still succeeds and still awards
+--      fee IQ.
+--   3. An idempotent cleanup DELETE that reverses any leaderboard IQ that
+--      may already have been settled past the cutoff. In practice this is
+--      a no-op today: `season2_iq_ledger` is empty in every environment
+--      (settlement has never been run — verified 2026-09-10), so there is
+--      nothing to delete. It is kept so this migration is safe to apply
+--      even after a manual settlement run, and so it remains idempotent
+--      if applied more than once.
+--   4. PRE-EXISTING BUG FIX (unrelated to the wind-down, required for
+--      settle_season2_epoch to run at all): added `#variable_conflict
+--      use_column` to the top of the function body. Without it, every
+--      `ON CONFLICT (epoch, ...)` clause in the function raises "column
+--      reference \"epoch\" is ambiguous", because the function's own
+--      RETURNS TABLE OUT column is also named `epoch`. This bug has
+--      existed since the function was first created in migration
+--      1771526400000_add_season2_iq_points_mvp and was never caught
+--      because settle_season2_epoch has never been successfully run
+--      anywhere (verified 2026-09-10: season2_iq_ledger is empty and
+--      settled_at is NULL for every epoch in every environment). It
+--      surfaced when this migration's own verification script
+--      (scripts/season2_verify_leaderboard_cutoff.sql) first called the
+--      function for real. See docs/leaderboard-wind-down-epoch-20.md for
+--      the full writeup. Fixed here rather than deferred, since an
+--      unfixed settle_season2_epoch cannot award fee IQ for epoch 21+
+--      either — the exact thing requirement 2 needs to keep working.
+--   5. SECOND PRE-EXISTING BUG FIX (unrelated to the wind-down): added
+--      `DROP TABLE IF EXISTS` for all seven of get_pnl_leaderboard_period's
+--      `ON COMMIT DROP` temp tables, in TWO places — right before the pnl
+--      INSERT block, and again between the pnl and roi INSERT blocks.
+--      Those tables only drop at transaction commit, never between calls
+--      within the same transaction/session, and this function calls
+--      get_pnl_leaderboard_period() twice (pnl, then roi) every time it
+--      settles an epoch <= the cutoff — so without both DROPs, either the
+--      roi call within one execution, or the pnl call of a LATER
+--      settle_season2_epoch invocation in the same session, fails with
+--      'relation "..." already exists'. Also pre-existing, also never
+--      triggered because settlement has never run. See both DROP
+--      statements' own comments and docs/leaderboard-wind-down-epoch-20.md
+--      for the full writeup.
+--
+-- season2_epoch is NOT touched: epochs 21-30 must keep existing so fee IQ
+-- can still be settled for them.
+
+-- ========================================
+-- 1. CUTOFF CONSTANT
+-- ========================================
+
+-- GWTH-4354: last Season 2 epoch that pays out leaderboard IQ
+-- (leaderboard_pnl / leaderboard_roi). Fee IQ is unaffected and keeps
+-- accruing for every epoch after this one.
+CREATE OR REPLACE FUNCTION season2_last_leaderboard_epoch()
+RETURNS INTEGER AS $$
+  SELECT 20;
+$$ LANGUAGE sql IMMUTABLE;
+
+COMMENT ON FUNCTION season2_last_leaderboard_epoch() IS
+  'GWTH-4354: last Season 2 epoch that pays out leaderboard_pnl/leaderboard_roi IQ. Fee IQ is unaffected.';
+
+-- ========================================
+-- 2. SETTLEMENT FUNCTION — leaderboard cutoff guard
+-- ========================================
+
+CREATE OR REPLACE FUNCTION settle_season2_epoch(
+  p_epoch INTEGER,
+  p_force BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (
+  epoch INTEGER,
+  snapshot_count INTEGER,
+  average_trust_usd NUMERIC(20, 10),
+  fee_entries_inserted BIGINT,
+  pnl_entries_inserted BIGINT,
+  roi_entries_inserted BIGINT,
+  fee_iq_total NUMERIC(30, 0),
+  pnl_iq_total NUMERIC(30, 0),
+  roi_iq_total NUMERIC(30, 0),
+  total_iq NUMERIC(30, 0)
+) AS $$
+#variable_conflict use_column
+-- GWTH-4354: pre-existing bug fix, unrelated to the leaderboard cutoff.
+-- This RETURNS TABLE's first OUT column is named `epoch`, which shadows
+-- the `epoch` column of `season2_epoch_price` and `season2_iq_ledger`
+-- inside every `ON CONFLICT (epoch, ...)` clause below, making Postgres
+-- raise "column reference \"epoch\" is ambiguous". This was never caught
+-- because settle_season2_epoch has never been successfully run in any
+-- environment (season2_iq_ledger is empty and settled_at is NULL for
+-- every epoch everywhere, verified 2026-09-10) — see
+-- docs/leaderboard-wind-down-epoch-20.md for how this was found (this
+-- migration's own verification script, scripts/season2_verify_leaderboard_cutoff.sql,
+-- failed against the unpatched body on first run). `use_column` makes
+-- plpgsql prefer the column interpretation for every such ambiguity in
+-- this function; the function already never references its OUT columns
+-- by their bare names as variables (it consistently uses v_-prefixed
+-- locals and p_-prefixed params instead), so this cannot change any
+-- other behaviour.
+DECLARE
+  v_start_at TIMESTAMPTZ;
+  v_end_at TIMESTAMPTZ;
+  v_settle_after TIMESTAMPTZ;
+  v_is_final BOOLEAN;
+  v_snapshot_count INTEGER;
+  v_avg_price NUMERIC(20, 10);
+
+  v_fee_entries_inserted BIGINT := 0;
+  v_pnl_entries_inserted BIGINT := 0;
+  v_roi_entries_inserted BIGINT := 0;
+
+  v_fee_iq_total NUMERIC(30, 0) := 0;
+  v_pnl_iq_total NUMERIC(30, 0) := 0;
+  v_roi_iq_total NUMERIC(30, 0) := 0;
+BEGIN
+  SELECT
+    se.start_at,
+    se.end_at,
+    se.settle_after,
+    se.is_final
+  INTO
+    v_start_at,
+    v_end_at,
+    v_settle_after,
+    v_is_final
+  FROM season2_epoch se
+  WHERE se.epoch = p_epoch;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Season 2 epoch % not found', p_epoch;
+  END IF;
+
+  IF v_is_final THEN
+    RAISE EXCEPTION 'Season 2 epoch % is already finalized', p_epoch;
+  END IF;
+
+  IF NOW() < v_settle_after THEN
+    RAISE EXCEPTION
+      'Season 2 epoch % cannot be settled before settle_after (%)',
+      p_epoch,
+      v_settle_after;
+  END IF;
+
+  SELECT
+    COUNT(*)::INTEGER,
+    AVG(stps.price_usd)::NUMERIC(20, 10)
+  INTO
+    v_snapshot_count,
+    v_avg_price
+  FROM season2_trust_price_snapshot stps
+  WHERE stps.snapshot_at >= v_start_at
+    AND stps.snapshot_at < v_end_at;
+
+  IF v_snapshot_count = 0 OR v_avg_price IS NULL THEN
+    RAISE EXCEPTION 'No TRUST/USD snapshots found for Season 2 epoch %', p_epoch;
+  END IF;
+
+  INSERT INTO season2_epoch_price (
+    epoch,
+    snapshot_count,
+    average_price_usd,
+    computed_at,
+    updated_at
+  )
+  VALUES (
+    p_epoch,
+    v_snapshot_count,
+    v_avg_price,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (epoch) DO UPDATE
+  SET
+    snapshot_count = EXCLUDED.snapshot_count,
+    average_price_usd = EXCLUDED.average_price_usd,
+    computed_at = EXCLUDED.computed_at,
+    updated_at = NOW();
+
+  IF p_force THEN
+    DELETE FROM season2_iq_ledger
+    WHERE epoch = p_epoch;
+  END IF;
+
+  -- Fee IQ:  amount(wei TRUST) -> TRUST -> USD via epoch avg -> IQ at 2000/$1
+  -- GWTH-4354: unaffected by the leaderboard cutoff — fee IQ keeps accruing
+  -- for every epoch, including 21+.
+  WITH inserted_fee AS (
+    INSERT INTO season2_iq_ledger (
+      epoch,
+      account_id,
+      entry_type,
+      source_id,
+      iq_points,
+      metadata
+    )
+    SELECT
+      p_epoch,
+      pfa.sender_id,
+      'fee',
+      pfa.id,
+      ROUND((((pfa.amount / 1000000000000000000::NUMERIC) * v_avg_price) * 2000), 0)::NUMERIC(30, 0),
+      jsonb_build_object(
+        'fee_amount_raw', pfa.amount,
+        'average_trust_usd', v_avg_price,
+        'formula', '(amount_trust * average_trust_usd) * 2000'
+      )
+    FROM protocol_fee_accrued pfa
+    WHERE pfa.epoch = p_epoch::NUMERIC
+    ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+    RETURNING iq_points
+  )
+  SELECT
+    COUNT(*)::BIGINT,
+    COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+  INTO
+    v_fee_entries_inserted,
+    v_fee_iq_total
+  FROM inserted_fee;
+
+  -- GWTH-4354: leaderboard IQ (nominal PnL + ROI) is frozen after Epoch 20.
+  -- No leaderboard_pnl/leaderboard_roi entries are inserted for epochs
+  -- past season2_last_leaderboard_epoch(); v_pnl_entries_inserted and
+  -- v_roi_entries_inserted stay at their initialised 0.
+  IF p_epoch <= season2_last_leaderboard_epoch() THEN
+    -- GWTH-4354: same pre-existing bug fix as below (see that DROP
+    -- statement's comment), applied here too: a PRIOR settle_season2_epoch
+    -- call earlier in the same session/transaction (e.g. someone settling
+    -- several missed epochs back to back in one psql session) can leave
+    -- get_pnl_leaderboard_period's temp tables behind from ITS roi call,
+    -- since they are session-scoped and only ever dropped at actual
+    -- transaction commit. Dropping them here too, before this call's own
+    -- pnl block, makes each settle_season2_epoch execution self-cleaning
+    -- regardless of what ran before it in the same session — discovered
+    -- against intuition-testnet-next when a third settle_season2_epoch
+    -- call in the same verification script collided with the previous
+    -- call's leftover roi-call tables.
+    DROP TABLE IF EXISTS
+      _tmp_active_accounts,
+      _tmp_position_data,
+      _tmp_prices_at_start,
+      _tmp_prices_at_end,
+      _tmp_vault_state_at_start,
+      _tmp_vault_state_at_end,
+      _tmp_realized_fifo;
+
+    -- Nominal PnL leaderboard IQ
+    WITH inserted_pnl AS (
+      INSERT INTO season2_iq_ledger (
+        epoch,
+        account_id,
+        entry_type,
+        source_id,
+        iq_points,
+        metadata
+      )
+      SELECT
+        p_epoch,
+        lb.account_id,
+        'leaderboard_pnl',
+        lb.account_id,
+        slp.iq_points,
+        jsonb_build_object(
+          'rank', lb.rank,
+          'leaderboard', 'pnl',
+          'sort_by', 'total_pnl'
+        )
+      FROM get_pnl_leaderboard_period(
+        v_start_at,
+        v_end_at,
+        25,
+        0,
+        'total_pnl',
+        'DESC',
+        TRUE,
+        1,
+        0,
+        NULL
+      ) lb
+      JOIN season2_leaderboard_payout slp
+        ON slp.rank = lb.rank::INTEGER
+      ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+      RETURNING iq_points
+    )
+    SELECT
+      COUNT(*)::BIGINT,
+      COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+    INTO
+      v_pnl_entries_inserted,
+      v_pnl_iq_total
+    FROM inserted_pnl;
+
+    -- GWTH-4354: second pre-existing bug fix, also unrelated to the
+    -- leaderboard cutoff. get_pnl_leaderboard_period() creates SEVEN
+    -- `ON COMMIT DROP` temp tables (_tmp_active_accounts,
+    -- _tmp_position_data, _tmp_prices_at_start, _tmp_prices_at_end,
+    -- _tmp_vault_state_at_start, _tmp_vault_state_at_end,
+    -- _tmp_realized_fifo), which are only dropped when the enclosing
+    -- transaction actually commits — not between calls inside the same
+    -- transaction. This function calls get_pnl_leaderboard_period() a
+    -- second time immediately below (for the ROI board), so without
+    -- these DROPs the second call's CREATE TEMP TABLE statements fail
+    -- with 'relation "..." already exists' (discovered one table at a
+    -- time against intuition-testnet-next: _tmp_active_accounts first,
+    -- then _tmp_position_data). This means the ORIGINAL, unpatched
+    -- settle_season2_epoch could never successfully settle any epoch that
+    -- reached both the pnl and roi INSERT blocks — i.e. it could never
+    -- successfully settle any epoch, period — which is consistent with
+    -- settlement never having been run anywhere (see
+    -- docs/leaderboard-wind-down-epoch-20.md). All seven are
+    -- self-contained scratch tables used only inside
+    -- get_pnl_leaderboard_period's own body (created, [ANALYZEd where
+    -- applicable,] and joined against there, and nowhere else) — by the
+    -- time it returns its result rows to this caller, none of them have
+    -- any further purpose, so dropping them here is safe and does not
+    -- touch get_pnl_leaderboard_period itself (a live, portal-facing
+    -- function outside this migration's scope).
+    DROP TABLE IF EXISTS
+      _tmp_active_accounts,
+      _tmp_position_data,
+      _tmp_prices_at_start,
+      _tmp_prices_at_end,
+      _tmp_vault_state_at_start,
+      _tmp_vault_state_at_end,
+      _tmp_realized_fifo;
+
+    -- ROI leaderboard IQ
+    WITH inserted_roi AS (
+      INSERT INTO season2_iq_ledger (
+        epoch,
+        account_id,
+        entry_type,
+        source_id,
+        iq_points,
+        metadata
+      )
+      SELECT
+        p_epoch,
+        lb.account_id,
+        'leaderboard_roi',
+        lb.account_id,
+        slp.iq_points,
+        jsonb_build_object(
+          'rank', lb.rank,
+          'leaderboard', 'roi',
+          'sort_by', 'pnl_pct'
+        )
+      FROM get_pnl_leaderboard_period(
+        v_start_at,
+        v_end_at,
+        25,
+        0,
+        'pnl_pct',
+        'DESC',
+        TRUE,
+        1,
+        0,
+        NULL
+      ) lb
+      JOIN season2_leaderboard_payout slp
+        ON slp.rank = lb.rank::INTEGER
+      ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+      RETURNING iq_points
+    )
+    SELECT
+      COUNT(*)::BIGINT,
+      COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+    INTO
+      v_roi_entries_inserted,
+      v_roi_iq_total
+    FROM inserted_roi;
+  END IF;
+
+  UPDATE season2_epoch
+  SET
+    settled_at = NOW(),
+    last_settlement_force = p_force,
+    updated_at = NOW()
+  WHERE season2_epoch.epoch = p_epoch;
+
+  SELECT
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'fee'), 0)::NUMERIC(30, 0),
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'leaderboard_pnl'), 0)::NUMERIC(30, 0),
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'leaderboard_roi'), 0)::NUMERIC(30, 0)
+  INTO
+    v_fee_iq_total,
+    v_pnl_iq_total,
+    v_roi_iq_total
+  FROM season2_iq_ledger sil
+  WHERE sil.epoch = p_epoch;
+
+  RETURN QUERY
+  SELECT
+    p_epoch,
+    v_snapshot_count,
+    v_avg_price,
+    v_fee_entries_inserted,
+    v_pnl_entries_inserted,
+    v_roi_entries_inserted,
+    COALESCE(v_fee_iq_total, 0)::NUMERIC(30, 0),
+    COALESCE(v_pnl_iq_total, 0)::NUMERIC(30, 0),
+    COALESCE(v_roi_iq_total, 0)::NUMERIC(30, 0),
+    (COALESCE(v_fee_iq_total, 0) + COALESCE(v_pnl_iq_total, 0) + COALESCE(v_roi_iq_total, 0))::NUMERIC(30, 0);
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+-- ========================================
+-- 3. REVERSE ANY LEADERBOARD IQ ALREADY SETTLED PAST THE CUTOFF
+-- ========================================
+
+-- Idempotent: `season2_iq_ledger` is empty in every environment as of
+-- 2026-09-10 (settlement has never been run), so this deletes 0 rows
+-- today. It exists so this migration is correct even if a manual
+-- settlement is run between the ticket being written and this migration
+-- landing, and so re-applying it is always safe.
+DELETE FROM season2_iq_ledger
+WHERE epoch > season2_last_leaderboard_epoch()
+  AND entry_type IN ('leaderboard_pnl', 'leaderboard_roi');

--- a/infrastructure/hasura/migrations/intuition/1771526445000_fix_pnl_leaderboard_period_temp_tables/down.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526445000_fix_pnl_leaderboard_period_temp_tables/down.sql
@@ -1,0 +1,659 @@
+-- GWTH-4354 rollback: restore get_pnl_leaderboard_period verbatim, without
+-- the self-cleaning DROP added by up.sql.
+
+CREATE OR REPLACE FUNCTION get_pnl_leaderboard_period(
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ,
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0,
+  p_sort_by TEXT DEFAULT 'total_pnl',
+  p_sort_order TEXT DEFAULT 'DESC',
+  p_exclude_protocol_accounts BOOLEAN DEFAULT TRUE,
+  p_min_positions INTEGER DEFAULT 1,
+  p_min_volume NUMERIC DEFAULT 0,
+  p_term_id TEXT DEFAULT NULL,
+  p_min_deposit NUMERIC DEFAULT 0
+)
+RETURNS SETOF pnl_leaderboard_entry AS $$
+DECLARE
+  v_start_timestamp      BIGINT;
+  v_end_timestamp        BIGINT;
+  v_bucket_start         TIMESTAMPTZ;
+  v_bucket_end           TIMESTAMPTZ;
+  v_limit                INTEGER;
+  v_offset               INTEGER;
+  v_cagg_cutoff          TIMESTAMPTZ;
+BEGIN
+  IF p_start_date IS NULL OR p_end_date IS NULL THEN
+    RAISE EXCEPTION 'p_start_date and p_end_date are required';
+  END IF;
+
+  IF p_start_date >= p_end_date THEN
+    RAISE EXCEPTION 'p_start_date must be before p_end_date';
+  END IF;
+
+  v_limit  := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 10000);
+  v_offset := GREATEST(COALESCE(p_offset, 0), 0);
+
+  v_start_timestamp := EXTRACT(EPOCH FROM p_start_date)::BIGINT;
+  v_end_timestamp   := EXTRACT(EPOCH FROM p_end_date)::BIGINT;
+
+  v_bucket_start := date_trunc('hour', p_start_date);
+  v_bucket_end   := date_trunc('hour', p_end_date);
+
+  v_cagg_cutoff := date_trunc('hour', NOW());
+
+  SET LOCAL work_mem = '64MB';
+
+  -- Step 1: Active accounts (unchanged)
+  CREATE TEMP TABLE _tmp_active_accounts ON COMMIT DROP AS
+  SELECT DISTINCT pc.account_id
+  FROM position_change_hourly pc
+  WHERE pc.bucket >= v_bucket_start
+    AND pc.bucket <= v_bucket_end
+    AND (p_term_id IS NULL OR pc.term_id = p_term_id)
+    AND (NOT p_exclude_protocol_accounts
+         OR pc.account_id NOT IN (
+           SELECT id FROM account
+           WHERE type IN ('ProtocolVault', 'AtomWallet')
+         ));
+
+  ANALYZE _tmp_active_accounts;
+
+  -- Step 2: OPTIMIZED position data -- LATERAL per account (not per position)
+  -- Uses two DISTINCT ON queries per account instead of one global DISTINCT ON
+  -- + 67K LATERAL calls. Forces narrow index seeks via account_id binding.
+  CREATE TEMP TABLE _tmp_position_data ON COMMIT DROP AS
+  SELECT pd.*
+  FROM _tmp_active_accounts aa
+  CROSS JOIN LATERAL (
+    SELECT
+      aa.account_id,
+      se.term_id,
+      se.curve_id,
+      COALESCE(ss.cumulative_shares, 0)::NUMERIC(78,0)     AS shares_at_start,
+      se.cumulative_shares::NUMERIC(78,0)                   AS shares_at_end,
+      (se.cumulative_assets_in  - COALESCE(ss.cumulative_assets_in,  0))::NUMERIC AS period_deposits,
+      (se.cumulative_assets_out - COALESCE(ss.cumulative_assets_out, 0))::NUMERIC AS period_redemptions,
+      ((se.cumulative_assets_in  - COALESCE(ss.cumulative_assets_in,  0)) > 0
+       OR
+       (se.cumulative_assets_out - COALESCE(ss.cumulative_assets_out, 0)) > 0
+      ) AS had_activity,
+      se.cumulative_assets_in::NUMERIC                      AS cumulative_deposits,
+      (se.cumulative_shares_in  - COALESCE(ss.cumulative_shares_in,  0))::NUMERIC AS shares_acquired_in_period,
+      (se.cumulative_shares_out - COALESCE(ss.cumulative_shares_out, 0))::NUMERIC AS shares_redeemed_in_period
+    FROM (
+      -- snap_end: latest cumulative for all (term, curve) for this account
+      SELECT DISTINCT ON (pch.term_id, pch.curve_id)
+        pch.term_id, pch.curve_id,
+        pch.cumulative_shares, pch.cumulative_assets_in, pch.cumulative_assets_out,
+        pch.cumulative_shares_in, pch.cumulative_shares_out
+      FROM position_cumulative_hourly pch
+      WHERE pch.account_id = aa.account_id
+        AND pch.bucket <= v_bucket_end
+        AND (p_term_id IS NULL OR pch.term_id = p_term_id)
+      ORDER BY pch.term_id, pch.curve_id, pch.bucket DESC
+    ) se
+    LEFT JOIN (
+      -- snap_start: latest cumulative before period start for this account
+      SELECT DISTINCT ON (pch.term_id, pch.curve_id)
+        pch.term_id, pch.curve_id,
+        pch.cumulative_shares, pch.cumulative_assets_in, pch.cumulative_assets_out,
+        pch.cumulative_shares_in, pch.cumulative_shares_out
+      FROM position_cumulative_hourly pch
+      WHERE pch.account_id = aa.account_id
+        AND pch.bucket < v_bucket_start
+        AND (p_term_id IS NULL OR pch.term_id = p_term_id)
+      ORDER BY pch.term_id, pch.curve_id, pch.bucket DESC
+    ) ss ON se.term_id = ss.term_id AND se.curve_id = ss.curve_id
+  ) pd;
+
+  ANALYZE _tmp_position_data;
+
+  -- Steps 3-5: Price and vault state lookups (unchanged from 1771526434000)
+  CREATE TEMP TABLE _tmp_prices_at_start ON COMMIT DROP AS
+  SELECT DISTINCT ON (c.term_id, c.curve_id)
+    c.term_id, c.curve_id, c.last_share_price AS share_price
+  FROM share_price_change_stats_hourly c
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+    WHERE COALESCE(shares_at_start, 0) > 0
+  ) pd ON c.term_id = pd.term_id AND c.curve_id = pd.curve_id
+  WHERE c.bucket <= date_trunc('hour', p_start_date)
+  ORDER BY c.term_id, c.curve_id, c.bucket DESC;
+
+  CREATE TEMP TABLE _tmp_prices_at_end ON COMMIT DROP AS
+  SELECT DISTINCT ON (c.term_id, c.curve_id)
+    c.term_id, c.curve_id, c.last_share_price AS share_price
+  FROM share_price_change_stats_hourly c
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+    WHERE shares_at_end > 0
+  ) pd ON c.term_id = pd.term_id AND c.curve_id = pd.curve_id
+  WHERE c.bucket <= date_trunc('hour', p_end_date)
+  ORDER BY c.term_id, c.curve_id, c.bucket DESC;
+
+  IF p_end_date > v_cagg_cutoff THEN
+    WITH raw_current_hour AS (
+      SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+        spc.term_id, spc.curve_id, spc.share_price
+      FROM share_price_change spc
+      WHERE spc.block_timestamp > EXTRACT(EPOCH FROM v_cagg_cutoff)::BIGINT
+        AND spc.block_timestamp <= v_end_timestamp
+        AND EXISTS (
+          SELECT 1 FROM _tmp_prices_at_end pe
+          WHERE pe.term_id = spc.term_id AND pe.curve_id = spc.curve_id
+        )
+      ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC
+    )
+    UPDATE _tmp_prices_at_end pe
+    SET share_price = rch.share_price
+    FROM raw_current_hour rch
+    WHERE pe.term_id = rch.term_id AND pe.curve_id = rch.curve_id;
+
+    INSERT INTO _tmp_prices_at_end (term_id, curve_id, share_price)
+    SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+      spc.term_id, spc.curve_id, spc.share_price
+    FROM share_price_change spc
+    INNER JOIN (
+      SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+      WHERE shares_at_end > 0
+    ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+    WHERE spc.block_timestamp <= v_end_timestamp
+      AND NOT EXISTS (
+        SELECT 1 FROM _tmp_prices_at_end pe
+        WHERE pe.term_id = spc.term_id AND pe.curve_id = spc.curve_id
+      )
+    ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+  END IF;
+
+  CREATE TEMP TABLE _tmp_vault_state_at_start ON COMMIT DROP AS
+  SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+    spc.term_id,
+    spc.curve_id,
+    spc.total_shares AS vault_total_shares
+  FROM share_price_change spc
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id
+    FROM _tmp_position_data
+    WHERE COALESCE(shares_at_start, 0) > 0
+      AND curve_id = 2
+  ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+  WHERE spc.block_timestamp <= v_start_timestamp
+  ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+
+  CREATE TEMP TABLE _tmp_vault_state_at_end ON COMMIT DROP AS
+  SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+    spc.term_id,
+    spc.curve_id,
+    spc.total_shares AS vault_total_shares
+  FROM share_price_change spc
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id
+    FROM _tmp_position_data
+    WHERE shares_at_end > 0
+      AND curve_id = 2
+  ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+  WHERE spc.block_timestamp <= v_end_timestamp
+  ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+
+  -- ---- FIFO REALIZED PnL FOR MIXED POSITIONS ----
+  -- For positions with pre-existing shares + in-epoch deposits + in-epoch redemptions,
+  -- process hourly events chronologically to correctly attribute realized PnL.
+  -- Within each hour: deposits first, then redemptions. FIFO: pre-existing shares consumed first.
+  CREATE TEMP TABLE _tmp_realized_fifo ON COMMIT DROP AS
+  WITH RECURSIVE
+  events AS (
+    SELECT pd.account_id, pd.term_id, pd.curve_id, pd.shares_at_start,
+      pc.bucket,
+      COALESCE(pc.assets_in_period, 0)::NUMERIC AS ai,
+      COALESCE(pc.assets_out_period, 0)::NUMERIC AS ao,
+      COALESCE(pc.shares_in_period, 0)::NUMERIC AS si,
+      COALESCE(pc.shares_out_period, 0)::NUMERIC AS so,
+      ROW_NUMBER() OVER (
+        PARTITION BY pd.account_id, pd.term_id, pd.curve_id ORDER BY pc.bucket
+      ) AS rn
+    FROM _tmp_position_data pd
+    JOIN position_change_hourly pc
+      ON pc.account_id = pd.account_id
+      AND pc.term_id = pd.term_id
+      AND pc.curve_id = pd.curve_id
+    WHERE pd.shares_at_start > 0
+      AND pd.period_deposits > 0
+      AND pd.period_redemptions > 0
+      AND pc.bucket >= v_bucket_start
+      AND pc.bucket <= v_bucket_end
+  ),
+  fifo AS (
+    -- Base case: first hourly bucket
+    SELECT account_id, term_id, curve_id, rn,
+      -- After deposit (first) then redeem (second), FIFO consumes pre-existing first
+      CASE WHEN so <= shares_at_start THEN shares_at_start - so
+           ELSE 0::NUMERIC END AS pre_sh,
+      CASE WHEN so <= shares_at_start THEN si
+           ELSE GREATEST(si - (so - shares_at_start), 0) END AS ep_sh,
+      CASE WHEN so <= shares_at_start THEN ai
+           WHEN si > 0 THEN ai * GREATEST(si - (so - shares_at_start), 0) / si
+           ELSE 0::NUMERIC END AS ep_cost,
+      CASE WHEN so <= shares_at_start OR si = 0 THEN 0::NUMERIC
+           ELSE ao * LEAST(so - shares_at_start, si) / NULLIF(so, 0)
+                - ai * LEAST(so - shares_at_start, si) / NULLIF(si, 0)
+      END AS rpnl
+    FROM events WHERE rn = 1
+
+    UNION ALL
+
+    -- Recursive step: subsequent hourly buckets
+    SELECT e.account_id, e.term_id, e.curve_id, e.rn,
+      CASE WHEN e.so <= f.pre_sh THEN f.pre_sh - e.so
+           ELSE 0::NUMERIC END,
+      CASE WHEN e.so <= f.pre_sh THEN f.ep_sh + e.si
+           ELSE GREATEST(f.ep_sh + e.si - (e.so - f.pre_sh), 0) END,
+      CASE WHEN e.so <= f.pre_sh THEN f.ep_cost + e.ai
+           WHEN (f.ep_sh + e.si) > 0 THEN
+             (f.ep_cost + e.ai) * GREATEST(f.ep_sh + e.si - (e.so - f.pre_sh), 0)
+             / (f.ep_sh + e.si)
+           ELSE 0::NUMERIC END,
+      CASE WHEN e.so <= f.pre_sh OR (f.ep_sh + e.si) = 0 THEN 0::NUMERIC
+           ELSE e.ao * LEAST(e.so - f.pre_sh, f.ep_sh + e.si) / NULLIF(e.so, 0)
+                - (f.ep_cost + e.ai) * LEAST(e.so - f.pre_sh, f.ep_sh + e.si)
+                  / NULLIF(f.ep_sh + e.si, 0)
+      END
+    FROM fifo f
+    JOIN events e ON e.account_id = f.account_id
+      AND e.term_id = f.term_id
+      AND e.curve_id = f.curve_id
+      AND e.rn = f.rn + 1
+  )
+  SELECT account_id, term_id, curve_id, SUM(rpnl) AS realized_pnl
+  FROM fifo
+  GROUP BY account_id, term_id, curve_id;
+
+  ANALYZE _tmp_realized_fifo;
+
+  -- Main query: CTE chain (from 1771526440000 + unrealized PnL fix for pre-epoch redemptions)
+  RETURN QUERY
+  WITH
+  position_period_metrics AS (
+    SELECT
+      pd.account_id,
+      pd.term_id,
+      pd.curve_id,
+      COALESCE(pd.shares_at_start, 0)           AS shares_at_start,
+      pd.shares_at_end                          AS shares_at_end,
+      COALESCE(pd.period_deposits, 0)           AS period_deposits,
+      COALESCE(pd.period_redemptions, 0)        AS period_redemptions,
+      pd.had_activity,
+      COALESCE(pd.cumulative_deposits, 0)       AS cumulative_deposits,
+      COALESCE(pd.shares_acquired_in_period, 0) AS shares_acquired_in_period,
+      COALESCE(pd.shares_redeemed_in_period, 0) AS shares_redeemed_in_period,
+      CASE
+        WHEN pd.curve_id = 2 AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (vs.vault_total_shares + cc."offset")
+                * (vs.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (vs.vault_total_shares + cc."offset" - pd.shares_at_start)
+                  * (vs.vault_total_shares + cc."offset" - pd.shares_at_start)
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        ELSE
+          TRUNC(
+            COALESCE(pd.shares_at_start, 0)
+            * COALESCE(ps.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+      END AS equity_at_start,
+      CASE
+        WHEN pd.curve_id = 2 AND pd.shares_at_end > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (ve.vault_total_shares + cc."offset")
+                * (ve.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (ve.vault_total_shares + cc."offset" - pd.shares_at_end)
+                  * (ve.vault_total_shares + cc."offset" - pd.shares_at_end)
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        ELSE
+          TRUNC(
+            pd.shares_at_end
+            * COALESCE(pe.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+      END AS equity_at_end,
+      -- Value of remaining shares (shares_at_end) at epoch-start prices.
+      -- Used to compute correct unrealized PnL for pre-epoch positions with
+      -- redemptions, so unrealized only reflects change in remaining equity.
+      CASE
+        WHEN pd.curve_id = 2
+             AND pd.shares_at_end > 0
+             AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (vs.vault_total_shares + cc."offset")
+                * (vs.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (vs.vault_total_shares + cc."offset" - GREATEST(pd.shares_at_end, 0))
+                  * (vs.vault_total_shares + cc."offset" - GREATEST(pd.shares_at_end, 0))
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        WHEN pd.shares_at_end > 0
+             AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            GREATEST(pd.shares_at_end, 0)
+            * COALESCE(ps.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+        ELSE 0
+      END AS equity_of_remaining_at_start
+    FROM _tmp_position_data pd
+    LEFT JOIN _tmp_prices_at_start ps
+      ON pd.term_id = ps.term_id AND pd.curve_id = ps.curve_id
+    LEFT JOIN _tmp_prices_at_end pe
+      ON pd.term_id = pe.term_id AND pd.curve_id = pe.curve_id
+    LEFT JOIN curve_config cc
+      ON pd.curve_id = cc.curve_id
+    LEFT JOIN _tmp_vault_state_at_start vs
+      ON pd.term_id = vs.term_id AND pd.curve_id = vs.curve_id
+    LEFT JOIN _tmp_vault_state_at_end ve
+      ON pd.term_id = ve.term_id AND pd.curve_id = ve.curve_id
+  ),
+
+  position_pnl AS (
+    SELECT
+      ppm.account_id,
+      ppm.term_id,
+      ppm.curve_id,
+      ppm.shares_at_start,
+      ppm.shares_at_end,
+      ppm.period_deposits,
+      ppm.period_redemptions,
+      ppm.equity_at_start,
+      ppm.equity_at_end,
+      ppm.equity_of_remaining_at_start,
+      ppm.had_activity,
+      ppm.cumulative_deposits,
+      ppm.shares_acquired_in_period,
+      ppm.shares_redeemed_in_period,
+      (ppm.equity_at_end - ppm.equity_at_start
+        + ppm.period_redemptions - ppm.period_deposits)::NUMERIC AS period_total_pnl,
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start
+                  + ppm.period_redemptions - ppm.period_deposits) > 0
+           THEN 1 ELSE 0 END AS is_winning,
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start
+                  + ppm.period_redemptions - ppm.period_deposits) < 0
+           THEN 1 ELSE 0 END AS is_losing,
+      -- ---- EPOCH-ONLY REALIZED PnL ----
+      -- Cases 1-3: unchanged from 1771526434000
+      -- Case 4 (mixed): uses FIFO chronological computation from _tmp_realized_fifo
+      CASE
+        WHEN ppm.period_redemptions <= 0 THEN 0::NUMERIC
+        WHEN ppm.period_deposits <= 0 THEN 0::NUMERIC
+        WHEN ppm.shares_at_start <= 0 THEN
+          (ppm.period_redemptions - TRUNC(
+            ppm.period_deposits * ppm.shares_redeemed_in_period
+            / NULLIF(ppm.shares_acquired_in_period, 0)
+          ))::NUMERIC
+        ELSE
+          -- Mixed position: use FIFO-computed realized PnL
+          COALESCE(rf.realized_pnl, 0)::NUMERIC
+      END AS realized_pnl
+    FROM position_period_metrics ppm
+    LEFT JOIN _tmp_realized_fifo rf
+      ON ppm.account_id = rf.account_id
+      AND ppm.term_id = rf.term_id
+      AND ppm.curve_id = rf.curve_id
+  ),
+
+  filtered_pnl AS (
+    SELECT * FROM position_pnl pp
+    WHERE p_min_deposit <= 0
+       OR pp.cumulative_deposits >= p_min_deposit * 1e18
+  ),
+
+  account_metrics AS (
+    SELECT
+      fp.account_id,
+      COUNT(DISTINCT (fp.term_id, fp.curve_id))
+        FILTER (WHERE fp.had_activity)                           AS period_position_count,
+      COUNT(DISTINCT (fp.term_id, fp.curve_id))
+        FILTER (WHERE fp.shares_at_end > 0)                      AS active_position_count,
+      SUM(fp.is_winning) FILTER (WHERE fp.had_activity)          AS winning_positions,
+      SUM(fp.is_losing)  FILTER (WHERE fp.had_activity)          AS losing_positions,
+      SUM(fp.period_deposits)::NUMERIC                           AS period_deposits_raw,
+      SUM(fp.period_redemptions)::NUMERIC                        AS period_redemptions_raw,
+      SUM(fp.period_total_pnl)::NUMERIC                          AS total_pnl_raw,
+      SUM(fp.realized_pnl)::NUMERIC                              AS realized_pnl_raw,
+      -- Unrealized PnL: for pre-epoch positions with redemptions, use change in
+      -- remaining equity only (not the residual total_pnl - realized_pnl, which
+      -- would include already-cashed-out redemption profit).
+      SUM(
+        CASE
+          WHEN fp.period_deposits <= 0 AND fp.period_redemptions > 0 THEN
+            GREATEST(fp.equity_at_end, 0) - fp.equity_of_remaining_at_start
+          ELSE
+            fp.period_total_pnl - fp.realized_pnl
+        END
+      )::NUMERIC                                                  AS unrealized_pnl_raw,
+      SUM(fp.equity_at_start)::NUMERIC                           AS equity_at_start,
+      SUM(fp.equity_at_end)::NUMERIC                             AS equity_at_end,
+      MAX(fp.period_total_pnl)                                   AS best_trade_pnl_raw,
+      MIN(fp.period_total_pnl)                                   AS worst_trade_pnl_raw,
+      -- ---- EPOCH-ONLY DENOMINATORS (unchanged from 1771526434000) ----
+      SUM(CASE
+        WHEN fp.period_redemptions <= 0 OR fp.period_deposits <= 0 THEN 0
+        WHEN fp.shares_at_start <= 0 THEN
+          TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_acquired_in_period, 0))
+        ELSE
+          TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_at_start + fp.shares_acquired_in_period, 0))
+      END)::NUMERIC                                              AS denominator_closed,
+      SUM(CASE
+        WHEN fp.period_deposits <= 0 OR fp.shares_at_end <= 0 THEN 0
+        WHEN fp.period_redemptions <= 0 THEN fp.period_deposits
+        WHEN fp.shares_at_start <= 0 THEN
+          fp.period_deposits - TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_acquired_in_period, 0))
+        ELSE
+          fp.period_deposits - TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_at_start + fp.shares_acquired_in_period, 0))
+      END)::NUMERIC                                              AS denominator_open
+    FROM filtered_pnl fp
+    GROUP BY fp.account_id
+    HAVING
+      COUNT(DISTINCT (fp.term_id, fp.curve_id)) FILTER (WHERE fp.had_activity)
+        >= GREATEST(p_min_positions, 1)
+      AND (SUM(fp.period_deposits) + SUM(fp.period_redemptions))
+        >= COALESCE(p_min_volume * 1e18, 0)
+  ),
+
+  enriched AS (
+    SELECT
+      am.account_id,
+      a.label AS account_label,
+      a.image AS account_image,
+      am.total_pnl_raw,
+      COALESCE(am.realized_pnl_raw, 0)   AS realized_pnl_raw,
+      COALESCE(am.unrealized_pnl_raw, 0) AS unrealized_pnl_raw,
+      COALESCE(
+        (am.total_pnl_raw * 100.0 / NULLIF(
+          am.equity_at_start + am.period_deposits_raw
+        , 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS pnl_pct,
+      COALESCE(
+        (COALESCE(am.realized_pnl_raw, 0) * 100.0 / NULLIF(am.denominator_closed, 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS realized_pnl_pct,
+      COALESCE(
+        (COALESCE(am.unrealized_pnl_raw, 0) * 100.0 / NULLIF(am.denominator_open, 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS unrealized_pnl_pct,
+      am.total_pnl_raw                    AS pnl_change_raw,
+      am.period_position_count            AS total_position_count,
+      am.active_position_count,
+      am.winning_positions,
+      am.losing_positions,
+      COALESCE(
+        (am.winning_positions * 100.0 / NULLIF(am.period_position_count, 0))::NUMERIC(10, 2),
+        0::NUMERIC(10, 2)
+      ) AS win_rate,
+      am.period_deposits_raw              AS total_deposits_raw,
+      am.period_redemptions_raw           AS total_redemptions_raw,
+      (am.period_deposits_raw + am.period_redemptions_raw)::NUMERIC AS total_volume_raw,
+      am.equity_at_end                    AS current_equity_value_raw,
+      am.best_trade_pnl_raw,
+      am.worst_trade_pnl_raw,
+      p_start_date                        AS first_position_at,
+      p_end_date                          AS last_activity_at
+    FROM account_metrics am
+    JOIN account a ON am.account_id = a.id
+    WHERE NOT p_exclude_protocol_accounts
+       OR a.type NOT IN ('ProtocolVault', 'AtomWallet')
+  ),
+
+  ranked AS (
+    SELECT
+      e.*,
+      CASE
+        WHEN p_sort_by IN ('total_pnl', 'pnl') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('pnl_pct', 'roi') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'realized_pnl' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.realized_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.realized_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'unrealized_pnl' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'realized_pnl_pct' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.realized_pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.realized_pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'unrealized_pnl_pct' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'win_rate' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.win_rate ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.win_rate DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('total_volume', 'volume') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_volume_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('position_count', 'positions') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_position_count ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_position_count DESC NULLS LAST)
+          END
+        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
+      END AS rank
+    FROM enriched e
+  )
+
+  SELECT
+    r.rank,
+    r.account_id,
+    r.account_label,
+    r.account_image,
+    r.total_pnl_raw,
+    ROUND(r.total_pnl_raw    / 1e18, 4)::NUMERIC(30, 4) AS total_pnl_formatted,
+    r.realized_pnl_raw,
+    ROUND(r.realized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS realized_pnl_formatted,
+    r.unrealized_pnl_raw,
+    ROUND(r.unrealized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS unrealized_pnl_formatted,
+    r.pnl_pct,
+    r.realized_pnl_pct,
+    r.unrealized_pnl_pct,
+    r.pnl_change_raw,
+    ROUND(r.pnl_change_raw   / 1e18, 4)::NUMERIC(30, 4) AS pnl_change_formatted,
+    r.total_position_count,
+    r.active_position_count,
+    r.winning_positions,
+    r.losing_positions,
+    r.win_rate,
+    r.total_deposits_raw,
+    ROUND(r.total_deposits_raw    / 1e18, 4)::NUMERIC(30, 4) AS total_deposits_formatted,
+    r.total_redemptions_raw,
+    ROUND(r.total_redemptions_raw / 1e18, 4)::NUMERIC(30, 4) AS total_redemptions_formatted,
+    r.total_volume_raw,
+    ROUND(r.total_volume_raw      / 1e18, 4)::NUMERIC(30, 4) AS total_volume_formatted,
+    r.current_equity_value_raw,
+    ROUND(r.current_equity_value_raw / 1e18, 4)::NUMERIC(30, 4) AS current_equity_value_formatted,
+    r.best_trade_pnl_raw,
+    ROUND(r.best_trade_pnl_raw  / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
+    r.worst_trade_pnl_raw,
+    ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    NULL::NUMERIC         AS redeemable_assets_raw,
+    NULL::NUMERIC(30, 4)  AS redeemable_assets_formatted,
+    r.first_position_at,
+    r.last_activity_at
+  FROM ranked r
+  ORDER BY r.rank
+  LIMIT v_limit OFFSET v_offset;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION get_pnl_leaderboard_period IS
+  'Period-specific PnL leaderboard with hourly-granularity period boundaries. '
+  'Uses LATERAL-per-account pattern for position_cumulative_hourly lookups (19x faster). '
+  'Realized PnL uses FIFO chronological processing for mixed positions '
+  '(pre-existing shares + in-epoch deposits + in-epoch redemptions). '
+  'p_min_deposit (in ETH/TRUST units, default 0) filters out positions where '
+  'cumulative all-time deposits are below the threshold. '
+  'Sort options: total_pnl/pnl, pnl_pct/roi, realized_pnl, unrealized_pnl, '
+  'realized_pnl_pct, unrealized_pnl_pct, win_rate, total_volume/volume, position_count/positions.';
+
+-- NOTE: this restores the pre-fix body verbatim, which means it also restores
+-- the 42P07 collision on a second call within one transaction. That is the
+-- correct meaning of a revert -- the defect IS the pre-migration state.
+-- settle_season2_epoch is unaffected either way: it carries its own
+-- caller-side DROP blocks from 1771526444000.
+DO $$ BEGIN
+  RAISE WARNING 'GWTH-4354 rollback: get_pnl_leaderboard_period restored to its pre-migration body; calling it twice in one transaction raises 42P07 again.';
+END $$;

--- a/infrastructure/hasura/migrations/intuition/1771526445000_fix_pnl_leaderboard_period_temp_tables/up.sql
+++ b/infrastructure/hasura/migrations/intuition/1771526445000_fix_pnl_leaderboard_period_temp_tables/up.sql
@@ -1,0 +1,701 @@
+-- GWTH-4354: make get_pnl_leaderboard_period safe to call twice in one transaction.
+--
+-- Split out of 1771526444000_leaderboard_wind_down_epoch_20 so it can be
+-- reviewed, approved and reverted on its own terms: this touches a live,
+-- portal-facing read-path function, while the wind-down migration only
+-- touches Season 2 settlement.
+--
+-- THE DEFECT
+-- get_pnl_leaderboard_period builds seven temp tables with ON COMMIT DROP.
+-- That fires only at real transaction COMMIT, never between calls inside one
+-- transaction, so a second call in the same transaction raised
+-- `42P07 relation "_tmp_active_accounts" already exists`. The function
+-- carried an undocumented "call me at most once per transaction" contract.
+--
+-- Reproduced against the deployed function on intuition-testnet-next before
+-- this fix: two back-to-back calls in one transaction, second one raised.
+--
+-- WHY IT WAS NEVER HIT IN PRODUCTION
+-- chart-api (apps/chart-api/src/services/leaderboard.rs) opens its own
+-- transaction per request and calls the function exactly once, so the portal
+-- read path always committed cleanly. settle_season2_epoch is the only caller
+-- that calls it twice (pnl, then roi) -- and settlement had never run, because
+-- of a separate defect fixed in 1771526444000.
+--
+-- THE FIX
+-- One DROP TABLE IF EXISTS at the top of the function body. Everything else is
+-- copied verbatim from 1771526443000_fix_unrealized_pnl_pre_epoch_redemptions,
+-- the most recent definition. The signature and RETURNS type are unchanged --
+-- CREATE OR REPLACE cannot alter a return type, and nothing here tries to.
+--
+-- 1771526444000 keeps its own caller-side DROP blocks. They become redundant
+-- once this migration is applied, but they are idempotent no-ops, and keeping
+-- them means THIS migration can be reverted without breaking settlement.
+
+CREATE OR REPLACE FUNCTION get_pnl_leaderboard_period(
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ,
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0,
+  p_sort_by TEXT DEFAULT 'total_pnl',
+  p_sort_order TEXT DEFAULT 'DESC',
+  p_exclude_protocol_accounts BOOLEAN DEFAULT TRUE,
+  p_min_positions INTEGER DEFAULT 1,
+  p_min_volume NUMERIC DEFAULT 0,
+  p_term_id TEXT DEFAULT NULL,
+  p_min_deposit NUMERIC DEFAULT 0
+)
+RETURNS SETOF pnl_leaderboard_entry AS $$
+DECLARE
+  v_start_timestamp      BIGINT;
+  v_end_timestamp        BIGINT;
+  v_bucket_start         TIMESTAMPTZ;
+  v_bucket_end           TIMESTAMPTZ;
+  v_limit                INTEGER;
+  v_offset               INTEGER;
+  v_cagg_cutoff          TIMESTAMPTZ;
+BEGIN
+
+  -- GWTH-4354: self-cleaning temp tables.
+  --
+  -- The seven temp tables below are created ON COMMIT DROP, which only fires
+  -- at real transaction COMMIT -- never between calls inside one transaction.
+  -- A second call to this function in the same transaction therefore failed
+  -- with `42P07 relation "_tmp_active_accounts" already exists`.
+  --
+  -- settle_season2_epoch calls this function twice per settlement (once for
+  -- the nominal PnL board, once for ROI), which is how the defect surfaced.
+  -- Dropping here makes EVERY call self-cleaning, so no caller has to know
+  -- about the implicit "call me at most once per transaction" contract.
+  DROP TABLE IF EXISTS
+    _tmp_active_accounts,
+    _tmp_position_data,
+    _tmp_prices_at_start,
+    _tmp_prices_at_end,
+    _tmp_vault_state_at_start,
+    _tmp_vault_state_at_end,
+    _tmp_realized_fifo;
+  IF p_start_date IS NULL OR p_end_date IS NULL THEN
+    RAISE EXCEPTION 'p_start_date and p_end_date are required';
+  END IF;
+
+  IF p_start_date >= p_end_date THEN
+    RAISE EXCEPTION 'p_start_date must be before p_end_date';
+  END IF;
+
+  v_limit  := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 10000);
+  v_offset := GREATEST(COALESCE(p_offset, 0), 0);
+
+  v_start_timestamp := EXTRACT(EPOCH FROM p_start_date)::BIGINT;
+  v_end_timestamp   := EXTRACT(EPOCH FROM p_end_date)::BIGINT;
+
+  v_bucket_start := date_trunc('hour', p_start_date);
+  v_bucket_end   := date_trunc('hour', p_end_date);
+
+  v_cagg_cutoff := date_trunc('hour', NOW());
+
+  SET LOCAL work_mem = '64MB';
+
+  -- Step 1: Active accounts (unchanged)
+  CREATE TEMP TABLE _tmp_active_accounts ON COMMIT DROP AS
+  SELECT DISTINCT pc.account_id
+  FROM position_change_hourly pc
+  WHERE pc.bucket >= v_bucket_start
+    AND pc.bucket <= v_bucket_end
+    AND (p_term_id IS NULL OR pc.term_id = p_term_id)
+    AND (NOT p_exclude_protocol_accounts
+         OR pc.account_id NOT IN (
+           SELECT id FROM account
+           WHERE type IN ('ProtocolVault', 'AtomWallet')
+         ));
+
+  ANALYZE _tmp_active_accounts;
+
+  -- Step 2: OPTIMIZED position data -- LATERAL per account (not per position)
+  -- Uses two DISTINCT ON queries per account instead of one global DISTINCT ON
+  -- + 67K LATERAL calls. Forces narrow index seeks via account_id binding.
+  CREATE TEMP TABLE _tmp_position_data ON COMMIT DROP AS
+  SELECT pd.*
+  FROM _tmp_active_accounts aa
+  CROSS JOIN LATERAL (
+    SELECT
+      aa.account_id,
+      se.term_id,
+      se.curve_id,
+      COALESCE(ss.cumulative_shares, 0)::NUMERIC(78,0)     AS shares_at_start,
+      se.cumulative_shares::NUMERIC(78,0)                   AS shares_at_end,
+      (se.cumulative_assets_in  - COALESCE(ss.cumulative_assets_in,  0))::NUMERIC AS period_deposits,
+      (se.cumulative_assets_out - COALESCE(ss.cumulative_assets_out, 0))::NUMERIC AS period_redemptions,
+      ((se.cumulative_assets_in  - COALESCE(ss.cumulative_assets_in,  0)) > 0
+       OR
+       (se.cumulative_assets_out - COALESCE(ss.cumulative_assets_out, 0)) > 0
+      ) AS had_activity,
+      se.cumulative_assets_in::NUMERIC                      AS cumulative_deposits,
+      (se.cumulative_shares_in  - COALESCE(ss.cumulative_shares_in,  0))::NUMERIC AS shares_acquired_in_period,
+      (se.cumulative_shares_out - COALESCE(ss.cumulative_shares_out, 0))::NUMERIC AS shares_redeemed_in_period
+    FROM (
+      -- snap_end: latest cumulative for all (term, curve) for this account
+      SELECT DISTINCT ON (pch.term_id, pch.curve_id)
+        pch.term_id, pch.curve_id,
+        pch.cumulative_shares, pch.cumulative_assets_in, pch.cumulative_assets_out,
+        pch.cumulative_shares_in, pch.cumulative_shares_out
+      FROM position_cumulative_hourly pch
+      WHERE pch.account_id = aa.account_id
+        AND pch.bucket <= v_bucket_end
+        AND (p_term_id IS NULL OR pch.term_id = p_term_id)
+      ORDER BY pch.term_id, pch.curve_id, pch.bucket DESC
+    ) se
+    LEFT JOIN (
+      -- snap_start: latest cumulative before period start for this account
+      SELECT DISTINCT ON (pch.term_id, pch.curve_id)
+        pch.term_id, pch.curve_id,
+        pch.cumulative_shares, pch.cumulative_assets_in, pch.cumulative_assets_out,
+        pch.cumulative_shares_in, pch.cumulative_shares_out
+      FROM position_cumulative_hourly pch
+      WHERE pch.account_id = aa.account_id
+        AND pch.bucket < v_bucket_start
+        AND (p_term_id IS NULL OR pch.term_id = p_term_id)
+      ORDER BY pch.term_id, pch.curve_id, pch.bucket DESC
+    ) ss ON se.term_id = ss.term_id AND se.curve_id = ss.curve_id
+  ) pd;
+
+  ANALYZE _tmp_position_data;
+
+  -- Steps 3-5: Price and vault state lookups (unchanged from 1771526434000)
+  CREATE TEMP TABLE _tmp_prices_at_start ON COMMIT DROP AS
+  SELECT DISTINCT ON (c.term_id, c.curve_id)
+    c.term_id, c.curve_id, c.last_share_price AS share_price
+  FROM share_price_change_stats_hourly c
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+    WHERE COALESCE(shares_at_start, 0) > 0
+  ) pd ON c.term_id = pd.term_id AND c.curve_id = pd.curve_id
+  WHERE c.bucket <= date_trunc('hour', p_start_date)
+  ORDER BY c.term_id, c.curve_id, c.bucket DESC;
+
+  CREATE TEMP TABLE _tmp_prices_at_end ON COMMIT DROP AS
+  SELECT DISTINCT ON (c.term_id, c.curve_id)
+    c.term_id, c.curve_id, c.last_share_price AS share_price
+  FROM share_price_change_stats_hourly c
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+    WHERE shares_at_end > 0
+  ) pd ON c.term_id = pd.term_id AND c.curve_id = pd.curve_id
+  WHERE c.bucket <= date_trunc('hour', p_end_date)
+  ORDER BY c.term_id, c.curve_id, c.bucket DESC;
+
+  IF p_end_date > v_cagg_cutoff THEN
+    WITH raw_current_hour AS (
+      SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+        spc.term_id, spc.curve_id, spc.share_price
+      FROM share_price_change spc
+      WHERE spc.block_timestamp > EXTRACT(EPOCH FROM v_cagg_cutoff)::BIGINT
+        AND spc.block_timestamp <= v_end_timestamp
+        AND EXISTS (
+          SELECT 1 FROM _tmp_prices_at_end pe
+          WHERE pe.term_id = spc.term_id AND pe.curve_id = spc.curve_id
+        )
+      ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC
+    )
+    UPDATE _tmp_prices_at_end pe
+    SET share_price = rch.share_price
+    FROM raw_current_hour rch
+    WHERE pe.term_id = rch.term_id AND pe.curve_id = rch.curve_id;
+
+    INSERT INTO _tmp_prices_at_end (term_id, curve_id, share_price)
+    SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+      spc.term_id, spc.curve_id, spc.share_price
+    FROM share_price_change spc
+    INNER JOIN (
+      SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+      WHERE shares_at_end > 0
+    ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+    WHERE spc.block_timestamp <= v_end_timestamp
+      AND NOT EXISTS (
+        SELECT 1 FROM _tmp_prices_at_end pe
+        WHERE pe.term_id = spc.term_id AND pe.curve_id = spc.curve_id
+      )
+    ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+  END IF;
+
+  CREATE TEMP TABLE _tmp_vault_state_at_start ON COMMIT DROP AS
+  SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+    spc.term_id,
+    spc.curve_id,
+    spc.total_shares AS vault_total_shares
+  FROM share_price_change spc
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id
+    FROM _tmp_position_data
+    WHERE COALESCE(shares_at_start, 0) > 0
+      AND curve_id = 2
+  ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+  WHERE spc.block_timestamp <= v_start_timestamp
+  ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+
+  CREATE TEMP TABLE _tmp_vault_state_at_end ON COMMIT DROP AS
+  SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+    spc.term_id,
+    spc.curve_id,
+    spc.total_shares AS vault_total_shares
+  FROM share_price_change spc
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id
+    FROM _tmp_position_data
+    WHERE shares_at_end > 0
+      AND curve_id = 2
+  ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+  WHERE spc.block_timestamp <= v_end_timestamp
+  ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+
+  -- ---- FIFO REALIZED PnL FOR MIXED POSITIONS ----
+  -- For positions with pre-existing shares + in-epoch deposits + in-epoch redemptions,
+  -- process hourly events chronologically to correctly attribute realized PnL.
+  -- Within each hour: deposits first, then redemptions. FIFO: pre-existing shares consumed first.
+  CREATE TEMP TABLE _tmp_realized_fifo ON COMMIT DROP AS
+  WITH RECURSIVE
+  events AS (
+    SELECT pd.account_id, pd.term_id, pd.curve_id, pd.shares_at_start,
+      pc.bucket,
+      COALESCE(pc.assets_in_period, 0)::NUMERIC AS ai,
+      COALESCE(pc.assets_out_period, 0)::NUMERIC AS ao,
+      COALESCE(pc.shares_in_period, 0)::NUMERIC AS si,
+      COALESCE(pc.shares_out_period, 0)::NUMERIC AS so,
+      ROW_NUMBER() OVER (
+        PARTITION BY pd.account_id, pd.term_id, pd.curve_id ORDER BY pc.bucket
+      ) AS rn
+    FROM _tmp_position_data pd
+    JOIN position_change_hourly pc
+      ON pc.account_id = pd.account_id
+      AND pc.term_id = pd.term_id
+      AND pc.curve_id = pd.curve_id
+    WHERE pd.shares_at_start > 0
+      AND pd.period_deposits > 0
+      AND pd.period_redemptions > 0
+      AND pc.bucket >= v_bucket_start
+      AND pc.bucket <= v_bucket_end
+  ),
+  fifo AS (
+    -- Base case: first hourly bucket
+    SELECT account_id, term_id, curve_id, rn,
+      -- After deposit (first) then redeem (second), FIFO consumes pre-existing first
+      CASE WHEN so <= shares_at_start THEN shares_at_start - so
+           ELSE 0::NUMERIC END AS pre_sh,
+      CASE WHEN so <= shares_at_start THEN si
+           ELSE GREATEST(si - (so - shares_at_start), 0) END AS ep_sh,
+      CASE WHEN so <= shares_at_start THEN ai
+           WHEN si > 0 THEN ai * GREATEST(si - (so - shares_at_start), 0) / si
+           ELSE 0::NUMERIC END AS ep_cost,
+      CASE WHEN so <= shares_at_start OR si = 0 THEN 0::NUMERIC
+           ELSE ao * LEAST(so - shares_at_start, si) / NULLIF(so, 0)
+                - ai * LEAST(so - shares_at_start, si) / NULLIF(si, 0)
+      END AS rpnl
+    FROM events WHERE rn = 1
+
+    UNION ALL
+
+    -- Recursive step: subsequent hourly buckets
+    SELECT e.account_id, e.term_id, e.curve_id, e.rn,
+      CASE WHEN e.so <= f.pre_sh THEN f.pre_sh - e.so
+           ELSE 0::NUMERIC END,
+      CASE WHEN e.so <= f.pre_sh THEN f.ep_sh + e.si
+           ELSE GREATEST(f.ep_sh + e.si - (e.so - f.pre_sh), 0) END,
+      CASE WHEN e.so <= f.pre_sh THEN f.ep_cost + e.ai
+           WHEN (f.ep_sh + e.si) > 0 THEN
+             (f.ep_cost + e.ai) * GREATEST(f.ep_sh + e.si - (e.so - f.pre_sh), 0)
+             / (f.ep_sh + e.si)
+           ELSE 0::NUMERIC END,
+      CASE WHEN e.so <= f.pre_sh OR (f.ep_sh + e.si) = 0 THEN 0::NUMERIC
+           ELSE e.ao * LEAST(e.so - f.pre_sh, f.ep_sh + e.si) / NULLIF(e.so, 0)
+                - (f.ep_cost + e.ai) * LEAST(e.so - f.pre_sh, f.ep_sh + e.si)
+                  / NULLIF(f.ep_sh + e.si, 0)
+      END
+    FROM fifo f
+    JOIN events e ON e.account_id = f.account_id
+      AND e.term_id = f.term_id
+      AND e.curve_id = f.curve_id
+      AND e.rn = f.rn + 1
+  )
+  SELECT account_id, term_id, curve_id, SUM(rpnl) AS realized_pnl
+  FROM fifo
+  GROUP BY account_id, term_id, curve_id;
+
+  ANALYZE _tmp_realized_fifo;
+
+  -- Main query: CTE chain (from 1771526440000 + unrealized PnL fix for pre-epoch redemptions)
+  RETURN QUERY
+  WITH
+  position_period_metrics AS (
+    SELECT
+      pd.account_id,
+      pd.term_id,
+      pd.curve_id,
+      COALESCE(pd.shares_at_start, 0)           AS shares_at_start,
+      pd.shares_at_end                          AS shares_at_end,
+      COALESCE(pd.period_deposits, 0)           AS period_deposits,
+      COALESCE(pd.period_redemptions, 0)        AS period_redemptions,
+      pd.had_activity,
+      COALESCE(pd.cumulative_deposits, 0)       AS cumulative_deposits,
+      COALESCE(pd.shares_acquired_in_period, 0) AS shares_acquired_in_period,
+      COALESCE(pd.shares_redeemed_in_period, 0) AS shares_redeemed_in_period,
+      CASE
+        WHEN pd.curve_id = 2 AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (vs.vault_total_shares + cc."offset")
+                * (vs.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (vs.vault_total_shares + cc."offset" - pd.shares_at_start)
+                  * (vs.vault_total_shares + cc."offset" - pd.shares_at_start)
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        ELSE
+          TRUNC(
+            COALESCE(pd.shares_at_start, 0)
+            * COALESCE(ps.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+      END AS equity_at_start,
+      CASE
+        WHEN pd.curve_id = 2 AND pd.shares_at_end > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (ve.vault_total_shares + cc."offset")
+                * (ve.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (ve.vault_total_shares + cc."offset" - pd.shares_at_end)
+                  * (ve.vault_total_shares + cc."offset" - pd.shares_at_end)
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        ELSE
+          TRUNC(
+            pd.shares_at_end
+            * COALESCE(pe.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+      END AS equity_at_end,
+      -- Value of remaining shares (shares_at_end) at epoch-start prices.
+      -- Used to compute correct unrealized PnL for pre-epoch positions with
+      -- redemptions, so unrealized only reflects change in remaining equity.
+      CASE
+        WHEN pd.curve_id = 2
+             AND pd.shares_at_end > 0
+             AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (vs.vault_total_shares + cc."offset")
+                * (vs.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (vs.vault_total_shares + cc."offset" - GREATEST(pd.shares_at_end, 0))
+                  * (vs.vault_total_shares + cc."offset" - GREATEST(pd.shares_at_end, 0))
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        WHEN pd.shares_at_end > 0
+             AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            GREATEST(pd.shares_at_end, 0)
+            * COALESCE(ps.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+        ELSE 0
+      END AS equity_of_remaining_at_start
+    FROM _tmp_position_data pd
+    LEFT JOIN _tmp_prices_at_start ps
+      ON pd.term_id = ps.term_id AND pd.curve_id = ps.curve_id
+    LEFT JOIN _tmp_prices_at_end pe
+      ON pd.term_id = pe.term_id AND pd.curve_id = pe.curve_id
+    LEFT JOIN curve_config cc
+      ON pd.curve_id = cc.curve_id
+    LEFT JOIN _tmp_vault_state_at_start vs
+      ON pd.term_id = vs.term_id AND pd.curve_id = vs.curve_id
+    LEFT JOIN _tmp_vault_state_at_end ve
+      ON pd.term_id = ve.term_id AND pd.curve_id = ve.curve_id
+  ),
+
+  position_pnl AS (
+    SELECT
+      ppm.account_id,
+      ppm.term_id,
+      ppm.curve_id,
+      ppm.shares_at_start,
+      ppm.shares_at_end,
+      ppm.period_deposits,
+      ppm.period_redemptions,
+      ppm.equity_at_start,
+      ppm.equity_at_end,
+      ppm.equity_of_remaining_at_start,
+      ppm.had_activity,
+      ppm.cumulative_deposits,
+      ppm.shares_acquired_in_period,
+      ppm.shares_redeemed_in_period,
+      (ppm.equity_at_end - ppm.equity_at_start
+        + ppm.period_redemptions - ppm.period_deposits)::NUMERIC AS period_total_pnl,
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start
+                  + ppm.period_redemptions - ppm.period_deposits) > 0
+           THEN 1 ELSE 0 END AS is_winning,
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start
+                  + ppm.period_redemptions - ppm.period_deposits) < 0
+           THEN 1 ELSE 0 END AS is_losing,
+      -- ---- EPOCH-ONLY REALIZED PnL ----
+      -- Cases 1-3: unchanged from 1771526434000
+      -- Case 4 (mixed): uses FIFO chronological computation from _tmp_realized_fifo
+      CASE
+        WHEN ppm.period_redemptions <= 0 THEN 0::NUMERIC
+        WHEN ppm.period_deposits <= 0 THEN 0::NUMERIC
+        WHEN ppm.shares_at_start <= 0 THEN
+          (ppm.period_redemptions - TRUNC(
+            ppm.period_deposits * ppm.shares_redeemed_in_period
+            / NULLIF(ppm.shares_acquired_in_period, 0)
+          ))::NUMERIC
+        ELSE
+          -- Mixed position: use FIFO-computed realized PnL
+          COALESCE(rf.realized_pnl, 0)::NUMERIC
+      END AS realized_pnl
+    FROM position_period_metrics ppm
+    LEFT JOIN _tmp_realized_fifo rf
+      ON ppm.account_id = rf.account_id
+      AND ppm.term_id = rf.term_id
+      AND ppm.curve_id = rf.curve_id
+  ),
+
+  filtered_pnl AS (
+    SELECT * FROM position_pnl pp
+    WHERE p_min_deposit <= 0
+       OR pp.cumulative_deposits >= p_min_deposit * 1e18
+  ),
+
+  account_metrics AS (
+    SELECT
+      fp.account_id,
+      COUNT(DISTINCT (fp.term_id, fp.curve_id))
+        FILTER (WHERE fp.had_activity)                           AS period_position_count,
+      COUNT(DISTINCT (fp.term_id, fp.curve_id))
+        FILTER (WHERE fp.shares_at_end > 0)                      AS active_position_count,
+      SUM(fp.is_winning) FILTER (WHERE fp.had_activity)          AS winning_positions,
+      SUM(fp.is_losing)  FILTER (WHERE fp.had_activity)          AS losing_positions,
+      SUM(fp.period_deposits)::NUMERIC                           AS period_deposits_raw,
+      SUM(fp.period_redemptions)::NUMERIC                        AS period_redemptions_raw,
+      SUM(fp.period_total_pnl)::NUMERIC                          AS total_pnl_raw,
+      SUM(fp.realized_pnl)::NUMERIC                              AS realized_pnl_raw,
+      -- Unrealized PnL: for pre-epoch positions with redemptions, use change in
+      -- remaining equity only (not the residual total_pnl - realized_pnl, which
+      -- would include already-cashed-out redemption profit).
+      SUM(
+        CASE
+          WHEN fp.period_deposits <= 0 AND fp.period_redemptions > 0 THEN
+            GREATEST(fp.equity_at_end, 0) - fp.equity_of_remaining_at_start
+          ELSE
+            fp.period_total_pnl - fp.realized_pnl
+        END
+      )::NUMERIC                                                  AS unrealized_pnl_raw,
+      SUM(fp.equity_at_start)::NUMERIC                           AS equity_at_start,
+      SUM(fp.equity_at_end)::NUMERIC                             AS equity_at_end,
+      MAX(fp.period_total_pnl)                                   AS best_trade_pnl_raw,
+      MIN(fp.period_total_pnl)                                   AS worst_trade_pnl_raw,
+      -- ---- EPOCH-ONLY DENOMINATORS (unchanged from 1771526434000) ----
+      SUM(CASE
+        WHEN fp.period_redemptions <= 0 OR fp.period_deposits <= 0 THEN 0
+        WHEN fp.shares_at_start <= 0 THEN
+          TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_acquired_in_period, 0))
+        ELSE
+          TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_at_start + fp.shares_acquired_in_period, 0))
+      END)::NUMERIC                                              AS denominator_closed,
+      SUM(CASE
+        WHEN fp.period_deposits <= 0 OR fp.shares_at_end <= 0 THEN 0
+        WHEN fp.period_redemptions <= 0 THEN fp.period_deposits
+        WHEN fp.shares_at_start <= 0 THEN
+          fp.period_deposits - TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_acquired_in_period, 0))
+        ELSE
+          fp.period_deposits - TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_at_start + fp.shares_acquired_in_period, 0))
+      END)::NUMERIC                                              AS denominator_open
+    FROM filtered_pnl fp
+    GROUP BY fp.account_id
+    HAVING
+      COUNT(DISTINCT (fp.term_id, fp.curve_id)) FILTER (WHERE fp.had_activity)
+        >= GREATEST(p_min_positions, 1)
+      AND (SUM(fp.period_deposits) + SUM(fp.period_redemptions))
+        >= COALESCE(p_min_volume * 1e18, 0)
+  ),
+
+  enriched AS (
+    SELECT
+      am.account_id,
+      a.label AS account_label,
+      a.image AS account_image,
+      am.total_pnl_raw,
+      COALESCE(am.realized_pnl_raw, 0)   AS realized_pnl_raw,
+      COALESCE(am.unrealized_pnl_raw, 0) AS unrealized_pnl_raw,
+      COALESCE(
+        (am.total_pnl_raw * 100.0 / NULLIF(
+          am.equity_at_start + am.period_deposits_raw
+        , 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS pnl_pct,
+      COALESCE(
+        (COALESCE(am.realized_pnl_raw, 0) * 100.0 / NULLIF(am.denominator_closed, 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS realized_pnl_pct,
+      COALESCE(
+        (COALESCE(am.unrealized_pnl_raw, 0) * 100.0 / NULLIF(am.denominator_open, 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS unrealized_pnl_pct,
+      am.total_pnl_raw                    AS pnl_change_raw,
+      am.period_position_count            AS total_position_count,
+      am.active_position_count,
+      am.winning_positions,
+      am.losing_positions,
+      COALESCE(
+        (am.winning_positions * 100.0 / NULLIF(am.period_position_count, 0))::NUMERIC(10, 2),
+        0::NUMERIC(10, 2)
+      ) AS win_rate,
+      am.period_deposits_raw              AS total_deposits_raw,
+      am.period_redemptions_raw           AS total_redemptions_raw,
+      (am.period_deposits_raw + am.period_redemptions_raw)::NUMERIC AS total_volume_raw,
+      am.equity_at_end                    AS current_equity_value_raw,
+      am.best_trade_pnl_raw,
+      am.worst_trade_pnl_raw,
+      p_start_date                        AS first_position_at,
+      p_end_date                          AS last_activity_at
+    FROM account_metrics am
+    JOIN account a ON am.account_id = a.id
+    WHERE NOT p_exclude_protocol_accounts
+       OR a.type NOT IN ('ProtocolVault', 'AtomWallet')
+  ),
+
+  ranked AS (
+    SELECT
+      e.*,
+      CASE
+        WHEN p_sort_by IN ('total_pnl', 'pnl') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('pnl_pct', 'roi') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'realized_pnl' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.realized_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.realized_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'unrealized_pnl' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'realized_pnl_pct' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.realized_pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.realized_pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'unrealized_pnl_pct' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'win_rate' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.win_rate ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.win_rate DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('total_volume', 'volume') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_volume_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('position_count', 'positions') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_position_count ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_position_count DESC NULLS LAST)
+          END
+        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
+      END AS rank
+    FROM enriched e
+  )
+
+  SELECT
+    r.rank,
+    r.account_id,
+    r.account_label,
+    r.account_image,
+    r.total_pnl_raw,
+    ROUND(r.total_pnl_raw    / 1e18, 4)::NUMERIC(30, 4) AS total_pnl_formatted,
+    r.realized_pnl_raw,
+    ROUND(r.realized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS realized_pnl_formatted,
+    r.unrealized_pnl_raw,
+    ROUND(r.unrealized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS unrealized_pnl_formatted,
+    r.pnl_pct,
+    r.realized_pnl_pct,
+    r.unrealized_pnl_pct,
+    r.pnl_change_raw,
+    ROUND(r.pnl_change_raw   / 1e18, 4)::NUMERIC(30, 4) AS pnl_change_formatted,
+    r.total_position_count,
+    r.active_position_count,
+    r.winning_positions,
+    r.losing_positions,
+    r.win_rate,
+    r.total_deposits_raw,
+    ROUND(r.total_deposits_raw    / 1e18, 4)::NUMERIC(30, 4) AS total_deposits_formatted,
+    r.total_redemptions_raw,
+    ROUND(r.total_redemptions_raw / 1e18, 4)::NUMERIC(30, 4) AS total_redemptions_formatted,
+    r.total_volume_raw,
+    ROUND(r.total_volume_raw      / 1e18, 4)::NUMERIC(30, 4) AS total_volume_formatted,
+    r.current_equity_value_raw,
+    ROUND(r.current_equity_value_raw / 1e18, 4)::NUMERIC(30, 4) AS current_equity_value_formatted,
+    r.best_trade_pnl_raw,
+    ROUND(r.best_trade_pnl_raw  / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
+    r.worst_trade_pnl_raw,
+    ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    NULL::NUMERIC         AS redeemable_assets_raw,
+    NULL::NUMERIC(30, 4)  AS redeemable_assets_formatted,
+    r.first_position_at,
+    r.last_activity_at
+  FROM ranked r
+  ORDER BY r.rank
+  LIMIT v_limit OFFSET v_offset;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION get_pnl_leaderboard_period IS
+  'Period-specific PnL leaderboard with hourly-granularity period boundaries. '
+  'Uses LATERAL-per-account pattern for position_cumulative_hourly lookups (19x faster). '
+  'Realized PnL uses FIFO chronological processing for mixed positions '
+  '(pre-existing shares + in-epoch deposits + in-epoch redemptions). '
+  'p_min_deposit (in ETH/TRUST units, default 0) filters out positions where '
+  'cumulative all-time deposits are below the threshold. '
+  'Sort options: total_pnl/pnl, pnl_pct/roi, realized_pnl, unrealized_pnl, '
+  'realized_pnl_pct, unrealized_pnl_pct, win_rate, total_volume/volume, position_count/positions.';

--- a/scripts/season2_check_verify_script_sync.sh
+++ b/scripts/season2_check_verify_script_sync.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# GWTH-4354: drift guard for scripts/season2_verify_leaderboard_cutoff.sql's
-# embedded copies of up.sql / down.sql.
+# GWTH-4354: drift guard for the embedded migration copies inside the
+# season2 verification scripts.
 #
 # scripts/season2_verify_leaderboard_cutoff.sql embeds both migration files
 # verbatim (see that script's own header for why: it runs via `psql -f -`
@@ -26,6 +26,9 @@ verify_script="$repo_root/scripts/season2_verify_leaderboard_cutoff.sql"
 migration_dir="$repo_root/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20"
 up_sql="$migration_dir/up.sql"
 down_sql="$migration_dir/down.sql"
+temp_tables_script="$repo_root/scripts/season2_verify_leaderboard_period_temp_tables.sql"
+temp_tables_migration_dir="$repo_root/infrastructure/hasura/migrations/intuition/1771526445000_fix_pnl_leaderboard_period_temp_tables"
+temp_tables_up_sql="$temp_tables_migration_dir/up.sql"
 
 if [ ! -f "$verify_script" ]; then
   echo "FAIL: verify script not found: $verify_script" >&2
@@ -40,6 +43,15 @@ if [ ! -f "$down_sql" ]; then
   exit 2
 fi
 
+if [ ! -f "$temp_tables_script" ]; then
+  echo "FAIL: temp-tables verify script not found: $temp_tables_script" >&2
+  exit 2
+fi
+if [ ! -f "$temp_tables_up_sql" ]; then
+  echo "FAIL: temp-tables migration up.sql not found: $temp_tables_up_sql" >&2
+  exit 2
+fi
+
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT INT TERM
 
@@ -50,9 +62,10 @@ status=0
 # marker lines found in $verify_script to out_file. Fails loudly (exit 2)
 # if either marker is missing, rather than silently diffing an empty block.
 extract_block() {
-  start_marker="$1"
-  end_marker="$2"
-  out_file="$3"
+  script_file="$1"
+  start_marker="$2"
+  end_marker="$3"
+  out_file="$4"
   awk -v start="$start_marker" -v end="$end_marker" '
     $0 == start { found_start = 1; in_block = 1; next }
     $0 == end   { found_end = 1; in_block = 0 }
@@ -61,19 +74,20 @@ extract_block() {
       if (!found_start) { print "MISSING_START_MARKER" > "/dev/stderr"; exit 2 }
       if (!found_end)   { print "MISSING_END_MARKER" > "/dev/stderr"; exit 2 }
     }
-  ' "$verify_script" > "$out_file"
+  ' "$script_file" > "$out_file"
 }
 
-# check_one label start_marker end_marker real_file
+# check_one script_file label start_marker end_marker real_file
 check_one() {
-  label="$1"
-  start_marker="$2"
-  end_marker="$3"
-  real_file="$4"
+  script_file="$1"
+  label="$2"
+  start_marker="$3"
+  end_marker="$4"
+  real_file="$5"
   embedded_file="$tmp_dir/embedded-$label"
 
-  if ! extract_block "$start_marker" "$end_marker" "$embedded_file"; then
-    echo "FAIL: could not find the $label sentinel markers in $(basename "$verify_script")" >&2
+  if ! extract_block "$script_file" "$start_marker" "$end_marker" "$embedded_file"; then
+    echo "FAIL: could not find the $label sentinel markers in $(basename "$script_file")" >&2
     echo "      expected to find these two lines, unindented, exactly as shown:" >&2
     echo "        $start_marker" >&2
     echo "        $end_marker" >&2
@@ -82,9 +96,9 @@ check_one() {
   fi
 
   if diff -u "$real_file" "$embedded_file" > "$tmp_dir/diff-$label"; then
-    echo "OK: embedded $label copy in $(basename "$verify_script") matches $real_file"
+    echo "OK: embedded $label copy in $(basename "$script_file") matches $real_file"
   else
-    echo "FAIL: embedded $label copy in $(basename "$verify_script") has drifted from $real_file" >&2
+    echo "FAIL: embedded $label copy in $(basename "$script_file") has drifted from $real_file" >&2
     echo "      re-sync the embedded block from $real_file (verbatim, between the" >&2
     echo "      BEGIN/END EMBEDDED sentinel comments) and re-run this script." >&2
     cat "$tmp_dir/diff-$label" >&2
@@ -92,14 +106,19 @@ check_one() {
   fi
 }
 
-check_one "up.sql" \
+check_one "$verify_script" "up.sql" \
   "-- BEGIN EMBEDDED up.sql (verbatim - keep byte-identical, see scripts/season2_check_verify_script_sync.sh)" \
   "-- END EMBEDDED up.sql" \
   "$up_sql"
 
-check_one "down.sql" \
+check_one "$verify_script" "down.sql" \
   "-- BEGIN EMBEDDED down.sql (verbatim - keep byte-identical, see scripts/season2_check_verify_script_sync.sh)" \
   "-- END EMBEDDED down.sql" \
   "$down_sql"
+
+check_one "$temp_tables_script" "1771526445000-up.sql" \
+  "-- BEGIN EMBEDDED 1771526445000/up.sql (verbatim - keep byte-identical, see scripts/season2_check_verify_script_sync.sh)" \
+  "-- END EMBEDDED 1771526445000/up.sql" \
+  "$temp_tables_up_sql"
 
 exit $status

--- a/scripts/season2_check_verify_script_sync.sh
+++ b/scripts/season2_check_verify_script_sync.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# GWTH-4354: drift guard for scripts/season2_verify_leaderboard_cutoff.sql's
+# embedded copies of up.sql / down.sql.
+#
+# scripts/season2_verify_leaderboard_cutoff.sql embeds both migration files
+# verbatim (see that script's own header for why: it runs via `psql -f -`
+# piped over `kubectl exec -i` stdin, where a `\i` include would try to open
+# a path that does not exist on the pod's filesystem). Nothing at parse time
+# enforces that those embedded copies stay in sync with the real migration
+# files when either changes -- this script is that enforcement.
+#
+# This is a standalone script, run by hand. It is NOT wired into CI -- this
+# repo has no DB-backed CI yet (see docs/leaderboard-wind-down-epoch-20.md).
+#
+# Usage:
+#   scripts/season2_check_verify_script_sync.sh
+#
+# Exits 0 and prints an OK line per file if both embedded copies match the
+# real migration files byte-for-byte. Exits non-zero with a diff and a clear
+# message otherwise.
+
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+verify_script="$repo_root/scripts/season2_verify_leaderboard_cutoff.sql"
+migration_dir="$repo_root/infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20"
+up_sql="$migration_dir/up.sql"
+down_sql="$migration_dir/down.sql"
+
+if [ ! -f "$verify_script" ]; then
+  echo "FAIL: verify script not found: $verify_script" >&2
+  exit 2
+fi
+if [ ! -f "$up_sql" ]; then
+  echo "FAIL: migration up.sql not found: $up_sql" >&2
+  exit 2
+fi
+if [ ! -f "$down_sql" ]; then
+  echo "FAIL: migration down.sql not found: $down_sql" >&2
+  exit 2
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+
+status=0
+
+# extract_block start_marker end_marker out_file
+# Prints the lines strictly between (not including) the two exact-match
+# marker lines found in $verify_script to out_file. Fails loudly (exit 2)
+# if either marker is missing, rather than silently diffing an empty block.
+extract_block() {
+  start_marker="$1"
+  end_marker="$2"
+  out_file="$3"
+  awk -v start="$start_marker" -v end="$end_marker" '
+    $0 == start { found_start = 1; in_block = 1; next }
+    $0 == end   { found_end = 1; in_block = 0 }
+    in_block    { print }
+    END {
+      if (!found_start) { print "MISSING_START_MARKER" > "/dev/stderr"; exit 2 }
+      if (!found_end)   { print "MISSING_END_MARKER" > "/dev/stderr"; exit 2 }
+    }
+  ' "$verify_script" > "$out_file"
+}
+
+# check_one label start_marker end_marker real_file
+check_one() {
+  label="$1"
+  start_marker="$2"
+  end_marker="$3"
+  real_file="$4"
+  embedded_file="$tmp_dir/embedded-$label"
+
+  if ! extract_block "$start_marker" "$end_marker" "$embedded_file"; then
+    echo "FAIL: could not find the $label sentinel markers in $(basename "$verify_script")" >&2
+    echo "      expected to find these two lines, unindented, exactly as shown:" >&2
+    echo "        $start_marker" >&2
+    echo "        $end_marker" >&2
+    status=1
+    return
+  fi
+
+  if diff -u "$real_file" "$embedded_file" > "$tmp_dir/diff-$label"; then
+    echo "OK: embedded $label copy in $(basename "$verify_script") matches $real_file"
+  else
+    echo "FAIL: embedded $label copy in $(basename "$verify_script") has drifted from $real_file" >&2
+    echo "      re-sync the embedded block from $real_file (verbatim, between the" >&2
+    echo "      BEGIN/END EMBEDDED sentinel comments) and re-run this script." >&2
+    cat "$tmp_dir/diff-$label" >&2
+    status=1
+  fi
+}
+
+check_one "up.sql" \
+  "-- BEGIN EMBEDDED up.sql (verbatim - keep byte-identical, see scripts/season2_check_verify_script_sync.sh)" \
+  "-- END EMBEDDED up.sql" \
+  "$up_sql"
+
+check_one "down.sql" \
+  "-- BEGIN EMBEDDED down.sql (verbatim - keep byte-identical, see scripts/season2_check_verify_script_sync.sh)" \
+  "-- END EMBEDDED down.sql" \
+  "$down_sql"
+
+exit $status

--- a/scripts/season2_verify_leaderboard_cutoff.sql
+++ b/scripts/season2_verify_leaderboard_cutoff.sql
@@ -1,0 +1,701 @@
+-- GWTH-4354: differential verification for the leaderboard wind-down at
+-- Epoch 20 (infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20).
+--
+-- Run with psql, e.g.:
+--   kubectl exec -i -n intuition-testnet-next intuition-testnet-next-timescale-db-0 -- \
+--     bash -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -f -' < scripts/season2_verify_leaderboard_cutoff.sql
+--
+-- Everything runs inside BEGIN; ... ROLLBACK; so nothing persists, regardless
+-- of pass/fail. Assertions use plpgsql ASSERT, which raises (and, combined
+-- with -v ON_ERROR_STOP=1, aborts the script with a nonzero exit) on
+-- failure — a broken or no-op implementation of the guard cannot pass this
+-- script silently.
+--
+-- WHY THE MIGRATION IS EMBEDDED VERBATIM BELOW (not `\i`-included):
+-- psql is invoked here with `-f -` reading the script over `kubectl exec -i`
+-- stdin, so a `\i`/`\ir` meta-command would try to open a path on the POD's
+-- filesystem, where this repo does not exist. Copy-pasting the migration's
+-- up.sql content into this script (byte-for-byte — see the marked block
+-- below) is the reliable way to make this script runnable via that exact
+-- invocation while staying self-contained. If the migration changes, this
+-- block must be re-synced from
+-- infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/up.sql.
+--
+-- FIXTURE DESIGN (why real data for some assertions, synthetic for others):
+-- `get_pnl_leaderboard_period` depends on deep, interdependent machinery
+-- (hourly position snapshots, continuous aggregates, bonding-curve equity
+-- valuation) that is impractical to seed realistically from scratch. So:
+--   - The "an epoch <=20 inserts leaderboard entries" assertion uses REAL
+--     intuition-testnet-next trading data, via a synthetic season2_epoch
+--     fixture (epoch 6) whose window is deliberately wide (2020-01-01 ..
+--     now()) to be virtually guaranteed to contain real PnL activity —
+--     empirically confirmed against intuition-testnet-next on 2026-09-10
+--     (25 rows for both the total_pnl and pnl_pct sorts over that window;
+--     0 rows for the real epoch 20 window specifically, which is why epoch
+--     20 itself isn't reused directly here).
+--   - The "fee IQ totals are byte-identical whether the epoch is <=20 or
+--     >20" assertion instead uses two fully synthetic, mutually isolated
+--     season2_epoch fixtures (epoch -7 <=20, epoch 90000041 >20) that
+--     share an IDENTICAL synthetic time window (2099-01-01 .. 2099-01-02,
+--     far outside any real epoch, so it cannot collide with real snapshot
+--     or position data) and an identical seeded protocol_fee_accrued
+--     amount. The epoch numbers themselves are deliberately far from
+--     season2_epoch's real 8..30 range AND from protocol_fee_accrued's
+--     own real epoch values (see the fixture section below for why that
+--     second collision is real and was hit during development). Because
+--     both fixtures see the same avg TRUST/USD price and the same fee
+--     amount, and the fee code path is untouched by the guard, their
+--     computed fee_iq_total must be exactly equal by construction — this
+--     is a real equality check, not a coincidence of live data.
+--   - The "pre-seeded leaderboard_pnl row for epoch 21 is deleted, a
+--     pre-seeded fee row for epoch 21 survives" assertion seeds directly
+--     into season2_iq_ledger against the REAL epoch 21 (bypassing
+--     settle_season2_epoch entirely) and checks the migration's own
+--     cleanup DELETE, run as part of applying the embedded migration below.
+--
+-- Fixture epoch numbers 6, -7 and 90000041 are chosen to be outside the
+-- real season2_epoch calendar (8..30 today), so they cannot collide with
+-- real rows in season2_epoch, and their season2_iq_ledger /
+-- season2_epoch_price rows are equally isolated (both FK on epoch). -7
+-- and 90000041 are additionally chosen to avoid protocol_fee_accrued's
+-- own real epoch values — see the fixture section below.
+
+\pset pager off
+\timing off
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- ========================================
+-- 0. FIXTURE: account + pre-existing epoch-21 ledger rows
+--    (seeded BEFORE the migration so its DELETE has something to act on)
+-- ========================================
+
+INSERT INTO account (id, label, type)
+VALUES ('fixture-gwth4354-account', 'GWTH-4354 verification fixture', 'Default');
+
+-- Pre-existing leaderboard_pnl row for the REAL epoch 21 (>20). The
+-- migration's cleanup DELETE must remove this.
+INSERT INTO season2_iq_ledger (epoch, account_id, entry_type, source_id, iq_points, metadata)
+VALUES (
+  21,
+  'fixture-gwth4354-account',
+  'leaderboard_pnl',
+  'fixture-gwth4354-pnl-epoch21-preexisting',
+  1000,
+  '{"fixture": "gwth4354-delete-survival-test"}'::jsonb
+);
+
+-- Pre-existing fee row for the same REAL epoch 21. The migration's cleanup
+-- DELETE only targets entry_type IN ('leaderboard_pnl','leaderboard_roi'),
+-- so this must survive.
+INSERT INTO season2_iq_ledger (epoch, account_id, entry_type, source_id, iq_points, metadata)
+VALUES (
+  21,
+  'fixture-gwth4354-account',
+  'fee',
+  'fixture-gwth4354-fee-epoch21-preexisting',
+  500,
+  '{"fixture": "gwth4354-delete-survival-test"}'::jsonb
+);
+
+-- ========================================
+-- 1. APPLY THE MIGRATION (embedded verbatim — see header comment above)
+--    Source: infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/up.sql
+-- ========================================
+
+-- GWTH-4354: Leaderboard wind-down — freeze leaderboard IQ at Epoch 20.
+--
+-- Season 2 leaderboard rewards ("Support the Trenches") are winding down.
+-- Epoch 20 (2026-08-11 -> 2026-08-25) is the LAST epoch that pays out
+-- leaderboard IQ (the `leaderboard_pnl` and `leaderboard_roi` entry types).
+-- From Epoch 21 onward, `settle_season2_epoch` must skip those two INSERT
+-- blocks entirely.
+--
+-- Fee IQ (`fee` entry type, protocol fees converted to IQ) is NOT part of
+-- this wind-down and MUST keep accruing unchanged for every epoch,
+-- including 21+. See docs/leaderboard-wind-down-epoch-20.md for the full
+-- rationale and the live-DB evidence this was based on.
+--
+-- Three changes, plus two unrelated bug fixes discovered while validating them:
+--   1. A greppable, auditable cutoff constant (season2_last_leaderboard_epoch()),
+--      instead of a bare literal buried in the settlement function body.
+--   2. CREATE OR REPLACE settle_season2_epoch(...) with the IDENTICAL
+--      signature and RETURNS TABLE column list as the original definition
+--      in migration 1771526400000_add_season2_iq_points_mvp (Postgres
+--      cannot change a function's return type via CREATE OR REPLACE). The
+--      body is copied verbatim except the `leaderboard_pnl` and
+--      `leaderboard_roi` INSERT blocks are now wrapped in
+--      `IF p_epoch <= season2_last_leaderboard_epoch() THEN ... END IF;`.
+--      Everything else (epoch validation, snapshot averaging, the `fee`
+--      INSERT block, `settled_at` update, final recompute-and-return) is
+--      untouched, so settling epoch 21+ still succeeds and still awards
+--      fee IQ.
+--   3. An idempotent cleanup DELETE that reverses any leaderboard IQ that
+--      may already have been settled past the cutoff. In practice this is
+--      a no-op today: `season2_iq_ledger` is empty in every environment
+--      (settlement has never been run — verified 2026-09-10), so there is
+--      nothing to delete. It is kept so this migration is safe to apply
+--      even after a manual settlement run, and so it remains idempotent
+--      if applied more than once.
+--   4. PRE-EXISTING BUG FIX (unrelated to the wind-down, required for
+--      settle_season2_epoch to run at all): added `#variable_conflict
+--      use_column` to the top of the function body. Without it, every
+--      `ON CONFLICT (epoch, ...)` clause in the function raises "column
+--      reference \"epoch\" is ambiguous", because the function's own
+--      RETURNS TABLE OUT column is also named `epoch`. This bug has
+--      existed since the function was first created in migration
+--      1771526400000_add_season2_iq_points_mvp and was never caught
+--      because settle_season2_epoch has never been successfully run
+--      anywhere (verified 2026-09-10: season2_iq_ledger is empty and
+--      settled_at is NULL for every epoch in every environment). It
+--      surfaced when this migration's own verification script
+--      (scripts/season2_verify_leaderboard_cutoff.sql) first called the
+--      function for real. See docs/leaderboard-wind-down-epoch-20.md for
+--      the full writeup. Fixed here rather than deferred, since an
+--      unfixed settle_season2_epoch cannot award fee IQ for epoch 21+
+--      either — the exact thing requirement 2 needs to keep working.
+--   5. SECOND PRE-EXISTING BUG FIX (unrelated to the wind-down): added
+--      `DROP TABLE IF EXISTS` for all seven of get_pnl_leaderboard_period's
+--      `ON COMMIT DROP` temp tables, in TWO places — right before the pnl
+--      INSERT block, and again between the pnl and roi INSERT blocks.
+--      Those tables only drop at transaction commit, never between calls
+--      within the same transaction/session, and this function calls
+--      get_pnl_leaderboard_period() twice (pnl, then roi) every time it
+--      settles an epoch <= the cutoff — so without both DROPs, either the
+--      roi call within one execution, or the pnl call of a LATER
+--      settle_season2_epoch invocation in the same session, fails with
+--      'relation "..." already exists'. Also pre-existing, also never
+--      triggered because settlement has never run. See both DROP
+--      statements' own comments and docs/leaderboard-wind-down-epoch-20.md
+--      for the full writeup.
+--
+-- season2_epoch is NOT touched: epochs 21-30 must keep existing so fee IQ
+-- can still be settled for them.
+
+-- ========================================
+-- 1. CUTOFF CONSTANT
+-- ========================================
+
+-- GWTH-4354: last Season 2 epoch that pays out leaderboard IQ
+-- (leaderboard_pnl / leaderboard_roi). Fee IQ is unaffected and keeps
+-- accruing for every epoch after this one.
+CREATE OR REPLACE FUNCTION season2_last_leaderboard_epoch()
+RETURNS INTEGER AS $$
+  SELECT 20;
+$$ LANGUAGE sql IMMUTABLE;
+
+COMMENT ON FUNCTION season2_last_leaderboard_epoch() IS
+  'GWTH-4354: last Season 2 epoch that pays out leaderboard_pnl/leaderboard_roi IQ. Fee IQ is unaffected.';
+
+-- ========================================
+-- 2. SETTLEMENT FUNCTION — leaderboard cutoff guard
+-- ========================================
+
+CREATE OR REPLACE FUNCTION settle_season2_epoch(
+  p_epoch INTEGER,
+  p_force BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (
+  epoch INTEGER,
+  snapshot_count INTEGER,
+  average_trust_usd NUMERIC(20, 10),
+  fee_entries_inserted BIGINT,
+  pnl_entries_inserted BIGINT,
+  roi_entries_inserted BIGINT,
+  fee_iq_total NUMERIC(30, 0),
+  pnl_iq_total NUMERIC(30, 0),
+  roi_iq_total NUMERIC(30, 0),
+  total_iq NUMERIC(30, 0)
+) AS $$
+#variable_conflict use_column
+-- GWTH-4354: pre-existing bug fix, unrelated to the leaderboard cutoff.
+-- This RETURNS TABLE's first OUT column is named `epoch`, which shadows
+-- the `epoch` column of `season2_epoch_price` and `season2_iq_ledger`
+-- inside every `ON CONFLICT (epoch, ...)` clause below, making Postgres
+-- raise "column reference \"epoch\" is ambiguous". This was never caught
+-- because settle_season2_epoch has never been successfully run in any
+-- environment (season2_iq_ledger is empty and settled_at is NULL for
+-- every epoch everywhere, verified 2026-09-10) — see
+-- docs/leaderboard-wind-down-epoch-20.md for how this was found (this
+-- migration's own verification script, scripts/season2_verify_leaderboard_cutoff.sql,
+-- failed against the unpatched body on first run). `use_column` makes
+-- plpgsql prefer the column interpretation for every such ambiguity in
+-- this function; the function already never references its OUT columns
+-- by their bare names as variables (it consistently uses v_-prefixed
+-- locals and p_-prefixed params instead), so this cannot change any
+-- other behaviour.
+DECLARE
+  v_start_at TIMESTAMPTZ;
+  v_end_at TIMESTAMPTZ;
+  v_settle_after TIMESTAMPTZ;
+  v_is_final BOOLEAN;
+  v_snapshot_count INTEGER;
+  v_avg_price NUMERIC(20, 10);
+
+  v_fee_entries_inserted BIGINT := 0;
+  v_pnl_entries_inserted BIGINT := 0;
+  v_roi_entries_inserted BIGINT := 0;
+
+  v_fee_iq_total NUMERIC(30, 0) := 0;
+  v_pnl_iq_total NUMERIC(30, 0) := 0;
+  v_roi_iq_total NUMERIC(30, 0) := 0;
+BEGIN
+  SELECT
+    se.start_at,
+    se.end_at,
+    se.settle_after,
+    se.is_final
+  INTO
+    v_start_at,
+    v_end_at,
+    v_settle_after,
+    v_is_final
+  FROM season2_epoch se
+  WHERE se.epoch = p_epoch;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Season 2 epoch % not found', p_epoch;
+  END IF;
+
+  IF v_is_final THEN
+    RAISE EXCEPTION 'Season 2 epoch % is already finalized', p_epoch;
+  END IF;
+
+  IF NOW() < v_settle_after THEN
+    RAISE EXCEPTION
+      'Season 2 epoch % cannot be settled before settle_after (%)',
+      p_epoch,
+      v_settle_after;
+  END IF;
+
+  SELECT
+    COUNT(*)::INTEGER,
+    AVG(stps.price_usd)::NUMERIC(20, 10)
+  INTO
+    v_snapshot_count,
+    v_avg_price
+  FROM season2_trust_price_snapshot stps
+  WHERE stps.snapshot_at >= v_start_at
+    AND stps.snapshot_at < v_end_at;
+
+  IF v_snapshot_count = 0 OR v_avg_price IS NULL THEN
+    RAISE EXCEPTION 'No TRUST/USD snapshots found for Season 2 epoch %', p_epoch;
+  END IF;
+
+  INSERT INTO season2_epoch_price (
+    epoch,
+    snapshot_count,
+    average_price_usd,
+    computed_at,
+    updated_at
+  )
+  VALUES (
+    p_epoch,
+    v_snapshot_count,
+    v_avg_price,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (epoch) DO UPDATE
+  SET
+    snapshot_count = EXCLUDED.snapshot_count,
+    average_price_usd = EXCLUDED.average_price_usd,
+    computed_at = EXCLUDED.computed_at,
+    updated_at = NOW();
+
+  IF p_force THEN
+    DELETE FROM season2_iq_ledger
+    WHERE epoch = p_epoch;
+  END IF;
+
+  -- Fee IQ:  amount(wei TRUST) -> TRUST -> USD via epoch avg -> IQ at 2000/$1
+  -- GWTH-4354: unaffected by the leaderboard cutoff — fee IQ keeps accruing
+  -- for every epoch, including 21+.
+  WITH inserted_fee AS (
+    INSERT INTO season2_iq_ledger (
+      epoch,
+      account_id,
+      entry_type,
+      source_id,
+      iq_points,
+      metadata
+    )
+    SELECT
+      p_epoch,
+      pfa.sender_id,
+      'fee',
+      pfa.id,
+      ROUND((((pfa.amount / 1000000000000000000::NUMERIC) * v_avg_price) * 2000), 0)::NUMERIC(30, 0),
+      jsonb_build_object(
+        'fee_amount_raw', pfa.amount,
+        'average_trust_usd', v_avg_price,
+        'formula', '(amount_trust * average_trust_usd) * 2000'
+      )
+    FROM protocol_fee_accrued pfa
+    WHERE pfa.epoch = p_epoch::NUMERIC
+    ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+    RETURNING iq_points
+  )
+  SELECT
+    COUNT(*)::BIGINT,
+    COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+  INTO
+    v_fee_entries_inserted,
+    v_fee_iq_total
+  FROM inserted_fee;
+
+  -- GWTH-4354: leaderboard IQ (nominal PnL + ROI) is frozen after Epoch 20.
+  -- No leaderboard_pnl/leaderboard_roi entries are inserted for epochs
+  -- past season2_last_leaderboard_epoch(); v_pnl_entries_inserted and
+  -- v_roi_entries_inserted stay at their initialised 0.
+  IF p_epoch <= season2_last_leaderboard_epoch() THEN
+    -- GWTH-4354: same pre-existing bug fix as below (see that DROP
+    -- statement's comment), applied here too: a PRIOR settle_season2_epoch
+    -- call earlier in the same session/transaction (e.g. someone settling
+    -- several missed epochs back to back in one psql session) can leave
+    -- get_pnl_leaderboard_period's temp tables behind from ITS roi call,
+    -- since they are session-scoped and only ever dropped at actual
+    -- transaction commit. Dropping them here too, before this call's own
+    -- pnl block, makes each settle_season2_epoch execution self-cleaning
+    -- regardless of what ran before it in the same session — discovered
+    -- against intuition-testnet-next when a third settle_season2_epoch
+    -- call in the same verification script collided with the previous
+    -- call's leftover roi-call tables.
+    DROP TABLE IF EXISTS
+      _tmp_active_accounts,
+      _tmp_position_data,
+      _tmp_prices_at_start,
+      _tmp_prices_at_end,
+      _tmp_vault_state_at_start,
+      _tmp_vault_state_at_end,
+      _tmp_realized_fifo;
+
+    -- Nominal PnL leaderboard IQ
+    WITH inserted_pnl AS (
+      INSERT INTO season2_iq_ledger (
+        epoch,
+        account_id,
+        entry_type,
+        source_id,
+        iq_points,
+        metadata
+      )
+      SELECT
+        p_epoch,
+        lb.account_id,
+        'leaderboard_pnl',
+        lb.account_id,
+        slp.iq_points,
+        jsonb_build_object(
+          'rank', lb.rank,
+          'leaderboard', 'pnl',
+          'sort_by', 'total_pnl'
+        )
+      FROM get_pnl_leaderboard_period(
+        v_start_at,
+        v_end_at,
+        25,
+        0,
+        'total_pnl',
+        'DESC',
+        TRUE,
+        1,
+        0,
+        NULL
+      ) lb
+      JOIN season2_leaderboard_payout slp
+        ON slp.rank = lb.rank::INTEGER
+      ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+      RETURNING iq_points
+    )
+    SELECT
+      COUNT(*)::BIGINT,
+      COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+    INTO
+      v_pnl_entries_inserted,
+      v_pnl_iq_total
+    FROM inserted_pnl;
+
+    -- GWTH-4354: second pre-existing bug fix, also unrelated to the
+    -- leaderboard cutoff. get_pnl_leaderboard_period() creates SEVEN
+    -- `ON COMMIT DROP` temp tables (_tmp_active_accounts,
+    -- _tmp_position_data, _tmp_prices_at_start, _tmp_prices_at_end,
+    -- _tmp_vault_state_at_start, _tmp_vault_state_at_end,
+    -- _tmp_realized_fifo), which are only dropped when the enclosing
+    -- transaction actually commits — not between calls inside the same
+    -- transaction. This function calls get_pnl_leaderboard_period() a
+    -- second time immediately below (for the ROI board), so without
+    -- these DROPs the second call's CREATE TEMP TABLE statements fail
+    -- with 'relation "..." already exists' (discovered one table at a
+    -- time against intuition-testnet-next: _tmp_active_accounts first,
+    -- then _tmp_position_data). This means the ORIGINAL, unpatched
+    -- settle_season2_epoch could never successfully settle any epoch that
+    -- reached both the pnl and roi INSERT blocks — i.e. it could never
+    -- successfully settle any epoch, period — which is consistent with
+    -- settlement never having been run anywhere (see
+    -- docs/leaderboard-wind-down-epoch-20.md). All seven are
+    -- self-contained scratch tables used only inside
+    -- get_pnl_leaderboard_period's own body (created, [ANALYZEd where
+    -- applicable,] and joined against there, and nowhere else) — by the
+    -- time it returns its result rows to this caller, none of them have
+    -- any further purpose, so dropping them here is safe and does not
+    -- touch get_pnl_leaderboard_period itself (a live, portal-facing
+    -- function outside this migration's scope).
+    DROP TABLE IF EXISTS
+      _tmp_active_accounts,
+      _tmp_position_data,
+      _tmp_prices_at_start,
+      _tmp_prices_at_end,
+      _tmp_vault_state_at_start,
+      _tmp_vault_state_at_end,
+      _tmp_realized_fifo;
+
+    -- ROI leaderboard IQ
+    WITH inserted_roi AS (
+      INSERT INTO season2_iq_ledger (
+        epoch,
+        account_id,
+        entry_type,
+        source_id,
+        iq_points,
+        metadata
+      )
+      SELECT
+        p_epoch,
+        lb.account_id,
+        'leaderboard_roi',
+        lb.account_id,
+        slp.iq_points,
+        jsonb_build_object(
+          'rank', lb.rank,
+          'leaderboard', 'roi',
+          'sort_by', 'pnl_pct'
+        )
+      FROM get_pnl_leaderboard_period(
+        v_start_at,
+        v_end_at,
+        25,
+        0,
+        'pnl_pct',
+        'DESC',
+        TRUE,
+        1,
+        0,
+        NULL
+      ) lb
+      JOIN season2_leaderboard_payout slp
+        ON slp.rank = lb.rank::INTEGER
+      ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+      RETURNING iq_points
+    )
+    SELECT
+      COUNT(*)::BIGINT,
+      COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+    INTO
+      v_roi_entries_inserted,
+      v_roi_iq_total
+    FROM inserted_roi;
+  END IF;
+
+  UPDATE season2_epoch
+  SET
+    settled_at = NOW(),
+    last_settlement_force = p_force,
+    updated_at = NOW()
+  WHERE season2_epoch.epoch = p_epoch;
+
+  SELECT
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'fee'), 0)::NUMERIC(30, 0),
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'leaderboard_pnl'), 0)::NUMERIC(30, 0),
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'leaderboard_roi'), 0)::NUMERIC(30, 0)
+  INTO
+    v_fee_iq_total,
+    v_pnl_iq_total,
+    v_roi_iq_total
+  FROM season2_iq_ledger sil
+  WHERE sil.epoch = p_epoch;
+
+  RETURN QUERY
+  SELECT
+    p_epoch,
+    v_snapshot_count,
+    v_avg_price,
+    v_fee_entries_inserted,
+    v_pnl_entries_inserted,
+    v_roi_entries_inserted,
+    COALESCE(v_fee_iq_total, 0)::NUMERIC(30, 0),
+    COALESCE(v_pnl_iq_total, 0)::NUMERIC(30, 0),
+    COALESCE(v_roi_iq_total, 0)::NUMERIC(30, 0),
+    (COALESCE(v_fee_iq_total, 0) + COALESCE(v_pnl_iq_total, 0) + COALESCE(v_roi_iq_total, 0))::NUMERIC(30, 0);
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+-- ========================================
+-- 3. REVERSE ANY LEADERBOARD IQ ALREADY SETTLED PAST THE CUTOFF
+-- ========================================
+
+-- Idempotent: `season2_iq_ledger` is empty in every environment as of
+-- 2026-09-10 (settlement has never been run), so this deletes 0 rows
+-- today. It exists so this migration is correct even if a manual
+-- settlement is run between the ticket being written and this migration
+-- landing, and so re-applying it is always safe.
+DELETE FROM season2_iq_ledger
+WHERE epoch > season2_last_leaderboard_epoch()
+  AND entry_type IN ('leaderboard_pnl', 'leaderboard_roi');
+
+-- ========================================
+-- 2. ASSERT: migration's cleanup DELETE removed the pre-existing
+--    leaderboard_pnl row for epoch 21, and left the fee row alone
+-- ========================================
+
+DO $$
+DECLARE
+  v_pnl_gone_count INTEGER;
+  v_fee_survives_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_pnl_gone_count
+  FROM season2_iq_ledger
+  WHERE epoch = 21
+    AND entry_type = 'leaderboard_pnl'
+    AND source_id = 'fixture-gwth4354-pnl-epoch21-preexisting';
+
+  SELECT COUNT(*) INTO v_fee_survives_count
+  FROM season2_iq_ledger
+  WHERE epoch = 21
+    AND entry_type = 'fee'
+    AND source_id = 'fixture-gwth4354-fee-epoch21-preexisting';
+
+  ASSERT v_pnl_gone_count = 0,
+    format('expected pre-existing epoch-21 leaderboard_pnl fixture row to be deleted by the migration, but %s row(s) remain', v_pnl_gone_count);
+
+  ASSERT v_fee_survives_count = 1,
+    format('expected pre-existing epoch-21 fee fixture row to survive the migration''s DELETE, but found %s row(s)', v_fee_survives_count);
+
+  RAISE NOTICE 'PASS: migration DELETE removed the epoch-21 leaderboard_pnl fixture and left the fee fixture untouched';
+END $$;
+
+-- ========================================
+-- 3. FIXTURES for the settle_season2_epoch() behavioural assertions
+-- ========================================
+
+-- Epoch 6 (<=20): wide real-data window on intuition-testnet-next, used to
+-- prove leaderboard entries are still inserted for epochs at/under the
+-- cutoff. settle_after is far in the past so NOW() >= settle_after always
+-- holds.
+INSERT INTO season2_epoch (epoch, start_at, end_at, settle_after)
+VALUES (6, TIMESTAMPTZ '2020-01-01 00:00:00+00', NOW(), TIMESTAMPTZ '2000-01-01 00:00:00+00');
+
+-- Epochs -7 (<=20) and 90000041 (>20): fully synthetic, mutually isolated,
+-- and share an IDENTICAL window so they see an identical average
+-- TRUST/USD price — required for the byte-identical fee assertion below.
+--
+-- Epoch numbers deliberately avoid small integers: protocol_fee_accrued's
+-- `epoch` column turns out NOT to follow season2_epoch's 8..30 calendar —
+-- it is a separate, much finer-grained, densely-populated counter (real
+-- intuition-testnet-next data has rows for nearly every integer from 1 to
+-- 322+ as of 2026-09-10, unrelated to Season 2's 14-day epochs). A first
+-- version of this script used epoch 7 and 41 here and the byte-identical
+-- assertion failed — not because settle_season2_epoch was wrong, but
+-- because real protocol_fee_accrued rows at epoch=7 (820 rows) and
+-- epoch=41 (96 rows) leaked into the fee totals alongside the fixture
+-- rows, and those real counts differ between 7 and 41. -7 (negative,
+-- impossible for a counter that only ever counts up from a small positive
+-- number) and 90000041 (many orders of magnitude past the real counter's
+-- current ~322) are chosen so this fixture can never collide with real
+-- protocol_fee_accrued data, regardless of how far that counter grows.
+INSERT INTO season2_epoch (epoch, start_at, end_at, settle_after)
+VALUES
+  (-7, TIMESTAMPTZ '2099-01-01 00:00:00+00', TIMESTAMPTZ '2099-01-02 00:00:00+00', TIMESTAMPTZ '2000-01-01 00:00:00+00'),
+  (90000041, TIMESTAMPTZ '2099-01-01 00:00:00+00', TIMESTAMPTZ '2099-01-02 00:00:00+00', TIMESTAMPTZ '2000-01-01 00:00:00+00');
+
+-- Shared TRUST/USD snapshots inside the epoch -7 / epoch 90000041 window.
+-- Two snapshots (the canonical 00:00 / 12:00 cadence) at a fixed price so
+-- the computed average is deterministic and identical for both epochs.
+INSERT INTO season2_trust_price_snapshot (snapshot_at, price_usd, source)
+VALUES
+  (TIMESTAMPTZ '2099-01-01 00:00:00+00', 1.2345000000, 'fixture-gwth4354'),
+  (TIMESTAMPTZ '2099-01-01 12:00:00+00', 1.2345000000, 'fixture-gwth4354');
+
+-- Identical protocol_fee_accrued amount for epoch -7 and epoch 90000041 —
+-- same sender, same amount, different id/epoch/tx hash only. With the
+-- identical snapshot price above, and with both epoch numbers collision-free
+-- against real protocol_fee_accrued rows (see the comment above), this
+-- makes the resulting fee_iq_total identical by construction for both
+-- epochs.
+INSERT INTO protocol_fee_accrued (id, epoch, sender_id, amount, block_number, created_at, transaction_hash)
+VALUES
+  ('fixture-gwth4354-fee-epoch-neg7', -7, 'fixture-gwth4354-account', 1000000000000000000, 1, NOW(), '0xfixturegwth4354epochneg7'),
+  ('fixture-gwth4354-fee-epoch90000041', 90000041, 'fixture-gwth4354-account', 1000000000000000000, 1, NOW(), '0xfixturegwth4354epoch90000041');
+
+-- ========================================
+-- 4. SETTLE all three fixture epochs and ASSERT the differential behaviour
+-- ========================================
+
+DO $$
+DECLARE
+  -- epoch 6 (<=20, real data)
+  r6_pnl_entries BIGINT;
+  r6_roi_entries BIGINT;
+
+  -- epoch 90000041 (>20, synthetic, isolated)
+  rhi_pnl_entries BIGINT;
+  rhi_roi_entries BIGINT;
+  rhi_fee_entries BIGINT;
+  rhi_fee_iq_total NUMERIC(30, 0);
+  rhi_settled_at TIMESTAMPTZ;
+
+  -- epoch -7 (<=20, synthetic, isolated — same fee inputs as epoch 90000041)
+  rlo_fee_iq_total NUMERIC(30, 0);
+BEGIN
+  -- --- Epoch 6: <=20 must still insert leaderboard entries ---
+  SELECT pnl_entries_inserted, roi_entries_inserted
+  INTO r6_pnl_entries, r6_roi_entries
+  FROM settle_season2_epoch(6, FALSE);
+
+  ASSERT r6_pnl_entries > 0,
+    format('expected epoch 6 (<=20) to insert >0 leaderboard_pnl entries, got %s', r6_pnl_entries);
+  ASSERT r6_roi_entries > 0,
+    format('expected epoch 6 (<=20) to insert >0 leaderboard_roi entries, got %s', r6_roi_entries);
+
+  RAISE NOTICE 'PASS: epoch 6 (<=20, real testnet-next data) inserted % leaderboard_pnl and % leaderboard_roi entries', r6_pnl_entries, r6_roi_entries;
+
+  -- --- Epoch 90000041: >20 must insert exactly 0 leaderboard entries
+  --     while still inserting fee entries and setting settled_at, without
+  --     raising. (If settle_season2_epoch(90000041, FALSE) raised, this DO
+  --     block would abort right here and -v ON_ERROR_STOP=1 would fail the
+  --     whole script — so reaching the assertions below already proves it
+  --     did not raise.) ---
+  SELECT pnl_entries_inserted, roi_entries_inserted, fee_entries_inserted, fee_iq_total
+  INTO rhi_pnl_entries, rhi_roi_entries, rhi_fee_entries, rhi_fee_iq_total
+  FROM settle_season2_epoch(90000041, FALSE);
+
+  SELECT settled_at INTO rhi_settled_at FROM season2_epoch WHERE epoch = 90000041;
+
+  ASSERT rhi_pnl_entries = 0,
+    format('expected epoch 90000041 (>20) to insert exactly 0 leaderboard_pnl entries, got %s', rhi_pnl_entries);
+  ASSERT rhi_roi_entries = 0,
+    format('expected epoch 90000041 (>20) to insert exactly 0 leaderboard_roi entries, got %s', rhi_roi_entries);
+  ASSERT rhi_fee_entries = 1,
+    format('expected epoch 90000041 (>20) to insert exactly the 1 fixture fee entry in the SAME run, got %s', rhi_fee_entries);
+  ASSERT rhi_settled_at IS NOT NULL,
+    'expected epoch 90000041 (>20) settled_at to be set after settlement';
+
+  RAISE NOTICE 'PASS: epoch 90000041 (>20) settled without raising — 0 leaderboard entries, % fee entries, settled_at=%', rhi_fee_entries, rhi_settled_at;
+
+  -- --- Epoch -7: <=20 counterpart with the SAME fee inputs as epoch
+  --     90000041 ---
+  SELECT fee_iq_total INTO rlo_fee_iq_total
+  FROM settle_season2_epoch(-7, FALSE);
+
+  ASSERT rlo_fee_iq_total = rhi_fee_iq_total,
+    format('expected byte-identical fee_iq_total for the same fixture whether epoch is <=20 or >20: epoch -7 = %s, epoch 90000041 = %s', rlo_fee_iq_total, rhi_fee_iq_total);
+  ASSERT rlo_fee_iq_total > 0,
+    format('expected the shared fixture to produce a nonzero fee_iq_total, got %s', rlo_fee_iq_total);
+
+  RAISE NOTICE 'PASS: fee_iq_total is byte-identical for the same fixture regardless of the leaderboard cutoff (epoch -7 = epoch 90000041 = %)', rlo_fee_iq_total;
+END $$;
+
+SELECT 'ALL ASSERTIONS PASSED for GWTH-4354 leaderboard cutoff at Epoch 20' AS result;
+
+ROLLBACK;

--- a/scripts/season2_verify_leaderboard_cutoff.sql
+++ b/scripts/season2_verify_leaderboard_cutoff.sql
@@ -9,56 +9,85 @@
 -- of pass/fail. Assertions use plpgsql ASSERT, which raises (and, combined
 -- with -v ON_ERROR_STOP=1, aborts the script with a nonzero exit) on
 -- failure — a broken or no-op implementation of the guard cannot pass this
--- script silently.
+-- script silently, PROVIDED plpgsql.check_asserts is on (see Step 0 below,
+-- which pins it: ASSERT is a silent no-op when that GUC is off).
+--
+-- DRIFT GUARD: this script embeds up.sql and down.sql verbatim (see the next
+-- comment block for why). Nothing at parse time enforces those copies stay
+-- in sync with the real migration files. Run
+-- `scripts/season2_check_verify_script_sync.sh` after editing either this
+-- script or the migration to confirm the embedded copies still match
+-- byte-for-byte — it is a standalone script, not wired into CI (this repo
+-- has no DB-backed CI yet).
 --
 -- WHY THE MIGRATION IS EMBEDDED VERBATIM BELOW (not `\i`-included):
 -- psql is invoked here with `-f -` reading the script over `kubectl exec -i`
 -- stdin, so a `\i`/`\ir` meta-command would try to open a path on the POD's
 -- filesystem, where this repo does not exist. Copy-pasting the migration's
--- up.sql content into this script (byte-for-byte — see the marked block
--- below) is the reliable way to make this script runnable via that exact
--- invocation while staying self-contained. If the migration changes, this
--- block must be re-synced from
--- infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/up.sql.
+-- up.sql (Step B below) and down.sql (Step H below) content into this script
+-- byte-for-byte is the reliable way to make this script runnable via that
+-- exact invocation while staying self-contained. If either migration file
+-- changes, both embedded blocks must be re-synced — see the drift guard
+-- above.
 --
 -- FIXTURE DESIGN (why real data for some assertions, synthetic for others):
 -- `get_pnl_leaderboard_period` depends on deep, interdependent machinery
 -- (hourly position snapshots, continuous aggregates, bonding-curve equity
 -- valuation) that is impractical to seed realistically from scratch. So:
---   - The "an epoch <=20 inserts leaderboard entries" assertion uses REAL
---     intuition-testnet-next trading data, via a synthetic season2_epoch
---     fixture (epoch 6) whose window is deliberately wide (2020-01-01 ..
---     now()) to be virtually guaranteed to contain real PnL activity —
---     empirically confirmed against intuition-testnet-next on 2026-09-10
---     (25 rows for both the total_pnl and pnl_pct sorts over that window;
---     0 rows for the real epoch 20 window specifically, which is why epoch
---     20 itself isn't reused directly here).
+--   - The "an epoch <=20 inserts leaderboard entries" assertion (Step E)
+--     uses REAL intuition-testnet-next trading data, via a synthetic
+--     season2_epoch fixture (epoch 6) whose window is deliberately wide
+--     (2020-01-01 .. now()) to be virtually guaranteed to contain real PnL
+--     activity — empirically confirmed against intuition-testnet-next on
+--     2026-09-10 (25 rows for both the total_pnl and pnl_pct sorts over
+--     that window; 0 rows for the real epoch 20 window specifically, which
+--     is why epoch 20 itself isn't reused directly here).
 --   - The "fee IQ totals are byte-identical whether the epoch is <=20 or
---     >20" assertion instead uses two fully synthetic, mutually isolated
---     season2_epoch fixtures (epoch -7 <=20, epoch 90000041 >20) that
---     share an IDENTICAL synthetic time window (2099-01-01 .. 2099-01-02,
---     far outside any real epoch, so it cannot collide with real snapshot
---     or position data) and an identical seeded protocol_fee_accrued
---     amount. The epoch numbers themselves are deliberately far from
---     season2_epoch's real 8..30 range AND from protocol_fee_accrued's
---     own real epoch values (see the fixture section below for why that
---     second collision is real and was hit during development). Because
---     both fixtures see the same avg TRUST/USD price and the same fee
---     amount, and the fee code path is untouched by the guard, their
---     computed fee_iq_total must be exactly equal by construction — this
---     is a real equality check, not a coincidence of live data.
+--     >20" assertion (Step E) instead uses two fully synthetic, mutually
+--     isolated season2_epoch fixtures (epoch -7 <=20, epoch 90000041 >20)
+--     that share an IDENTICAL synthetic time window (2099-01-01 ..
+--     2099-01-02, far outside any real epoch, so it cannot collide with
+--     real snapshot or position data) and an identical seeded
+--     protocol_fee_accrued amount. The epoch numbers themselves are
+--     deliberately far from season2_epoch's real 8..30 range AND from
+--     protocol_fee_accrued's own real epoch values (see the fixture
+--     section below for why that second collision is real and was hit
+--     during development). Because both fixtures see the same avg
+--     TRUST/USD price and the same fee amount, and the fee code path is
+--     untouched by the guard, their computed fee_iq_total must be exactly
+--     equal by construction — this is a real equality check, not a
+--     coincidence of live data.
 --   - The "pre-seeded leaderboard_pnl row for epoch 21 is deleted, a
---     pre-seeded fee row for epoch 21 survives" assertion seeds directly
---     into season2_iq_ledger against the REAL epoch 21 (bypassing
+--     pre-seeded fee row for epoch 21 survives" assertion (Step C) seeds
+--     directly into season2_iq_ledger against the REAL epoch 21 (bypassing
 --     settle_season2_epoch entirely) and checks the migration's own
 --     cleanup DELETE, run as part of applying the embedded migration below.
+--   - The BOUNDARY test (Step F) — the single most important assertion in
+--     this script — cannot reuse epoch 6, -7 or 90000041 as-is: none of
+--     them sit exactly on the real cutoff (20), so an off-by-one in the
+--     guard (`<` instead of `<=`) would pass every assertion above without
+--     detection. Step F temporarily overrides season2_last_leaderboard_epoch()
+--     to a synthetic value (-100) and seeds epochs exactly AT that value
+--     and exactly one past it, reusing epoch 6's real-data window (per its
+--     own header comment: seeding fresh position/PnL data for two more
+--     synthetic epochs is impractical, so the boundary epochs inherit real
+--     qualifying data instead) so both boundary epochs get real leaderboard
+--     rows to test the guard against, before restoring the real constant.
+--   - The p_force = TRUE test (Step G) reuses epoch 90000041 (already
+--     settled once with p_force = FALSE in Step E) to prove force
+--     re-settlement past the cutoff cannot resurrect leaderboard IQ.
+--   - The down.sql smoke test (Step H) embeds down.sql verbatim and proves
+--     the rollback actually restores the pre-fix ambiguous-column bug. It
+--     is deliberately the LAST phase: down.sql leaves settle_season2_epoch
+--     unable to settle ANY epoch for the rest of the transaction.
 --
--- Fixture epoch numbers 6, -7 and 90000041 are chosen to be outside the
--- real season2_epoch calendar (8..30 today), so they cannot collide with
--- real rows in season2_epoch, and their season2_iq_ledger /
--- season2_epoch_price rows are equally isolated (both FK on epoch). -7
--- and 90000041 are additionally chosen to avoid protocol_fee_accrued's
--- own real epoch values — see the fixture section below.
+-- Fixture epoch numbers 6, -7, 90000041, -100 and -99 are all chosen to be
+-- outside the real season2_epoch calendar (8..30 today), so none of them
+-- can collide with real rows in season2_epoch, and their season2_iq_ledger
+-- / season2_epoch_price rows are equally isolated (both FK on epoch). -7,
+-- 90000041, -100 and -99 are additionally chosen to avoid
+-- protocol_fee_accrued's own real epoch values — see the fixture section
+-- below.
 
 \pset pager off
 \timing off
@@ -67,7 +96,23 @@
 BEGIN;
 
 -- ========================================
--- 0. FIXTURE: account + pre-existing epoch-21 ledger rows
+-- Step 0. PIN THE ASSERT GUC (must run first)
+-- ========================================
+--
+-- plpgsql ASSERT is a COMPLETE NO-OP when plpgsql.check_asserts is off —
+-- the condition is not even evaluated, so every `RAISE NOTICE 'PASS: ...'`
+-- in this script (which sits unconditionally right after its ASSERT) would
+-- still print, and the script would still reach 'ALL ASSERTIONS PASSED' and
+-- exit 0, having verified NOTHING. SET LOCAL scopes this to the current
+-- transaction only, so it never leaks past the ROLLBACK at the end of this
+-- script. Verified: this works as the first statement of a fresh session,
+-- and the default is already `on` — but pinning it here means this script's
+-- pass/fail no longer depends on an ambient session setting nobody is
+-- watching.
+SET LOCAL plpgsql.check_asserts = on;
+
+-- ========================================
+-- Step A. FIXTURE: account + pre-existing epoch-21 ledger rows
 --    (seeded BEFORE the migration so its DELETE has something to act on)
 -- ========================================
 
@@ -100,10 +145,13 @@ VALUES (
 );
 
 -- ========================================
--- 1. APPLY THE MIGRATION (embedded verbatim — see header comment above)
+-- Step B. APPLY THE MIGRATION (embedded verbatim — see header comment above)
 --    Source: infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/up.sql
+--    Keep this block byte-identical to that file. Checked by
+--    scripts/season2_check_verify_script_sync.sh.
 -- ========================================
 
+-- BEGIN EMBEDDED up.sql (verbatim - keep byte-identical, see scripts/season2_check_verify_script_sync.sh)
 -- GWTH-4354: Leaderboard wind-down — freeze leaderboard IQ at Epoch 20.
 --
 -- Season 2 leaderboard rewards ("Support the Trenches") are winding down.
@@ -212,19 +260,45 @@ RETURNS TABLE (
 -- GWTH-4354: pre-existing bug fix, unrelated to the leaderboard cutoff.
 -- This RETURNS TABLE's first OUT column is named `epoch`, which shadows
 -- the `epoch` column of `season2_epoch_price` and `season2_iq_ledger`
--- inside every `ON CONFLICT (epoch, ...)` clause below, making Postgres
--- raise "column reference \"epoch\" is ambiguous". This was never caught
--- because settle_season2_epoch has never been successfully run in any
--- environment (season2_iq_ledger is empty and settled_at is NULL for
--- every epoch everywhere, verified 2026-09-10) — see
--- docs/leaderboard-wind-down-epoch-20.md for how this was found (this
--- migration's own verification script, scripts/season2_verify_leaderboard_cutoff.sql,
--- failed against the unpatched body on first run). `use_column` makes
--- plpgsql prefer the column interpretation for every such ambiguity in
--- this function; the function already never references its OUT columns
--- by their bare names as variables (it consistently uses v_-prefixed
--- locals and p_-prefixed params instead), so this cannot change any
--- other behaviour.
+-- everywhere a bare `epoch` reference appears in a DML statement below,
+-- making Postgres raise "column reference \"epoch\" is ambiguous". There
+-- are FIVE such sites, not four: the `ON CONFLICT (epoch)` clause in the
+-- season2_epoch_price upsert, the three `ON CONFLICT (epoch, entry_type,
+-- source_id)` clauses in the season2_iq_ledger inserts (fee, pnl, roi) —
+-- and a fifth that is easy to miss because it is not an ON CONFLICT
+-- clause at all: `DELETE FROM season2_iq_ledger WHERE epoch = p_epoch`
+-- inside the `IF p_force THEN` branch a few lines below. That fifth site
+-- is exactly as ambiguous as the other four, but it never surfaced during
+-- development because p_force has never been exercised — every
+-- verification and live call so far used p_force = FALSE (see
+-- scripts/season2_verify_leaderboard_cutoff.sql's p_force test, added to
+-- cover this). This was never caught because settle_season2_epoch has
+-- never been successfully run in any environment (season2_iq_ledger is
+-- empty and settled_at is NULL for every epoch everywhere, verified
+-- 2026-09-10) — see docs/leaderboard-wind-down-epoch-20.md for how this
+-- was found (this migration's own verification script,
+-- scripts/season2_verify_leaderboard_cutoff.sql, failed against the
+-- unpatched body on first run). `use_column` makes plpgsql prefer the
+-- column interpretation for every such ambiguity in this function; the
+-- function already never references its OUT columns by their bare names
+-- as variables (it consistently uses v_-prefixed locals and p_-prefixed
+-- params instead), so this cannot change any other behaviour.
+--
+-- CAUTION for future edits: `#variable_conflict use_column` disables
+-- Postgres's 42702 ambiguity detection for every bare identifier in THIS
+-- ENTIRE FUNCTION, not just the five sites above — it is a function-wide
+-- pragma, not a per-statement one. If a future edit adds a bare
+-- reference that collides with a column name but actually intends the
+-- VARIABLE (not the column), it will silently resolve to the column
+-- instead of raising 42702 — a correctness bug with no warning at
+-- CREATE FUNCTION time or at call time. If this function is revisited,
+-- prefer a more surgical fix over relying further on this function-wide
+-- pragma: `ON CONFLICT ON CONSTRAINT <constraint_name>` (e.g.
+-- `season2_iq_ledger_epoch_entry_source_unique` for the ledger inserts,
+-- `season2_epoch_price_pkey` for the price upsert) resolves each site's
+-- ambiguity individually, by naming the constraint instead of the column
+-- list, without touching the function's global identifier resolution
+-- rule.
 DECLARE
   v_start_at TIMESTAMPTZ;
   v_end_at TIMESTAMPTZ;
@@ -543,9 +617,10 @@ $$ LANGUAGE plpgsql VOLATILE;
 DELETE FROM season2_iq_ledger
 WHERE epoch > season2_last_leaderboard_epoch()
   AND entry_type IN ('leaderboard_pnl', 'leaderboard_roi');
+-- END EMBEDDED up.sql
 
 -- ========================================
--- 2. ASSERT: migration's cleanup DELETE removed the pre-existing
+-- Step C. ASSERT: migration's cleanup DELETE removed the pre-existing
 --    leaderboard_pnl row for epoch 21, and left the fee row alone
 -- ========================================
 
@@ -576,7 +651,7 @@ BEGIN
 END $$;
 
 -- ========================================
--- 3. FIXTURES for the settle_season2_epoch() behavioural assertions
+-- Step D. FIXTURES for the settle_season2_epoch() behavioural assertions
 -- ========================================
 
 -- Epoch 6 (<=20): wide real-data window on intuition-testnet-next, used to
@@ -629,7 +704,8 @@ VALUES
   ('fixture-gwth4354-fee-epoch90000041', 90000041, 'fixture-gwth4354-account', 1000000000000000000, 1, NOW(), '0xfixturegwth4354epoch90000041');
 
 -- ========================================
--- 4. SETTLE all three fixture epochs and ASSERT the differential behaviour
+-- Step E. SETTLE all three fixture epochs and ASSERT the differential
+--    behaviour
 -- ========================================
 
 DO $$
@@ -653,10 +729,19 @@ BEGIN
   INTO r6_pnl_entries, r6_roi_entries
   FROM settle_season2_epoch(6, FALSE);
 
+  -- This is the only assertion in this script coupled to live data volume
+  -- (see the file header's FIXTURE DESIGN note). If it fails, first rule
+  -- out that the environment simply lacks live PnL/trading activity in the
+  -- 2020-01-01..now() window — e.g. a fresh/reset database, or a change to
+  -- get_pnl_leaderboard_period's own eligibility filtering that legitimately
+  -- shrank the qualifying set to 0 — BEFORE treating this as a cutoff-guard
+  -- regression. The cutoff guard itself is exhaustively covered on its own
+  -- terms by the boundary test in Step F below, which does not depend on
+  -- any particular volume of live data.
   ASSERT r6_pnl_entries > 0,
-    format('expected epoch 6 (<=20) to insert >0 leaderboard_pnl entries, got %s', r6_pnl_entries);
+    format('expected epoch 6 (<=20) to insert >0 leaderboard_pnl entries, got %s. Before treating this as a cutoff-guard regression, rule out that this environment simply has no live PnL activity in the 2020-01-01..now() window this fixture scans (e.g. a fresh/reset database) — this is the one assertion in this script that depends on live data volume rather than a synthetic, isolated fixture. See Step F below for a volume-independent boundary check.', r6_pnl_entries);
   ASSERT r6_roi_entries > 0,
-    format('expected epoch 6 (<=20) to insert >0 leaderboard_roi entries, got %s', r6_roi_entries);
+    format('expected epoch 6 (<=20) to insert >0 leaderboard_roi entries, got %s. Before treating this as a cutoff-guard regression, rule out that this environment simply has no live PnL activity in the 2020-01-01..now() window this fixture scans (e.g. a fresh/reset database) — this is the one assertion in this script that depends on live data volume rather than a synthetic, isolated fixture. See Step F below for a volume-independent boundary check.', r6_roi_entries);
 
   RAISE NOTICE 'PASS: epoch 6 (<=20, real testnet-next data) inserted % leaderboard_pnl and % leaderboard_roi entries', r6_pnl_entries, r6_roi_entries;
 
@@ -694,6 +779,507 @@ BEGIN
     format('expected the shared fixture to produce a nonzero fee_iq_total, got %s', rlo_fee_iq_total);
 
   RAISE NOTICE 'PASS: fee_iq_total is byte-identical for the same fixture regardless of the leaderboard cutoff (epoch -7 = epoch 90000041 = %)', rlo_fee_iq_total;
+END $$;
+
+-- ========================================
+-- Step F. BOUNDARY TEST: cutoff override, synthetic epochs pinned exactly
+--    at the boundary (cutoff and cutoff+1) — the most important assertion
+--    in this script
+-- ========================================
+--
+-- Every fixture above is deliberately FAR from the real cutoff (6 and -7
+-- for <=20, 90000041 for >20), so an off-by-one in the guard's `<=` (e.g.
+-- a typo'd `<`) would still pass every assertion above without detection.
+-- This phase closes that gap: it temporarily redefines
+-- season2_last_leaderboard_epoch() to return -100 (still outside
+-- season2_epoch's real 8..30 calendar, so it cannot collide with real
+-- rows), seeds one epoch AT the new cutoff (-100) and one epoch ONE PAST
+-- it (-99), and asserts the guard's boundary is exactly `<=`, not `<` or
+-- off by any other amount.
+--
+-- Postgres invalidates any cached plan that reads
+-- season2_last_leaderboard_epoch() when it is CREATE OR REPLACEd (a
+-- pg_proc catalog change triggers a dependency invalidation for anything
+-- that referenced the old definition), so settle_season2_epoch calls made
+-- AFTER the override below see -100, not 20, without needing a new
+-- session — this is the same CREATE OR REPLACE mechanism the migration
+-- itself relies on.
+--
+-- Getting real leaderboard rows for a synthetic epoch requires
+-- get_pnl_leaderboard_period to return rows for that window, and seeding
+-- enough position/PnL data to make that happen from scratch is impractical
+-- (see the file header). So -100 and -99 reuse the EXACT same
+-- [start_at, end_at) window as the epoch-6 fixture above (2020-01-01 ..
+-- now()), which is already exercised and known to yield real leaderboard
+-- rows on intuition-testnet-next (Step E, epoch 6) — they inherit that
+-- real qualifying data instead of needing their own. Each still gets its
+-- own synthetic protocol_fee_accrued row (mirroring the epoch -7 / 90000041
+-- pattern in Step D) so the fee-side assertion below doesn't depend on real
+-- fee data lining up with this window.
+
+CREATE OR REPLACE FUNCTION season2_last_leaderboard_epoch()
+RETURNS INTEGER AS $$ SELECT -100; $$ LANGUAGE sql IMMUTABLE;
+
+INSERT INTO season2_epoch (epoch, start_at, end_at, settle_after)
+VALUES
+  (-100, TIMESTAMPTZ '2020-01-01 00:00:00+00', NOW(), TIMESTAMPTZ '2000-01-01 00:00:00+00'),
+  (-99,  TIMESTAMPTZ '2020-01-01 00:00:00+00', NOW(), TIMESTAMPTZ '2000-01-01 00:00:00+00');
+
+INSERT INTO protocol_fee_accrued (id, epoch, sender_id, amount, block_number, created_at, transaction_hash)
+VALUES
+  ('fixture-gwth4354-fee-epoch-neg100', -100, 'fixture-gwth4354-account', 1000000000000000000, 1, NOW(), '0xfixturegwth4354epochneg100'),
+  ('fixture-gwth4354-fee-epoch-neg99', -99, 'fixture-gwth4354-account', 1000000000000000000, 1, NOW(), '0xfixturegwth4354epochneg99');
+
+DO $$
+DECLARE
+  bnd_at_pnl_entries BIGINT;
+  bnd_at_roi_entries BIGINT;
+  bnd_at_fee_entries BIGINT;
+  bnd_past_pnl_entries BIGINT;
+  bnd_past_roi_entries BIGINT;
+  bnd_past_fee_entries BIGINT;
+BEGIN
+  -- --- Epoch -100 (== overridden cutoff): must behave like a <=cutoff epoch ---
+  SELECT pnl_entries_inserted, roi_entries_inserted, fee_entries_inserted
+  INTO bnd_at_pnl_entries, bnd_at_roi_entries, bnd_at_fee_entries
+  FROM settle_season2_epoch(-100, FALSE);
+
+  ASSERT bnd_at_pnl_entries > 0,
+    format('boundary test: expected epoch -100 (== overridden cutoff -100) to insert >0 leaderboard_pnl entries, got %s — the guard may be using < instead of <=', bnd_at_pnl_entries);
+  ASSERT bnd_at_roi_entries > 0,
+    format('boundary test: expected epoch -100 (== overridden cutoff -100) to insert >0 leaderboard_roi entries, got %s — the guard may be using < instead of <=', bnd_at_roi_entries);
+  ASSERT bnd_at_fee_entries > 0,
+    format('boundary test: expected epoch -100 (== overridden cutoff -100) to insert >0 fee entries, got %s', bnd_at_fee_entries);
+
+  -- --- Epoch -99 (== overridden cutoff + 1): must behave like a >cutoff epoch ---
+  SELECT pnl_entries_inserted, roi_entries_inserted, fee_entries_inserted
+  INTO bnd_past_pnl_entries, bnd_past_roi_entries, bnd_past_fee_entries
+  FROM settle_season2_epoch(-99, FALSE);
+
+  ASSERT bnd_past_pnl_entries = 0,
+    format('boundary test: expected epoch -99 (== overridden cutoff -100 + 1) to insert exactly 0 leaderboard_pnl entries, got %s — the guard may be off by one', bnd_past_pnl_entries);
+  ASSERT bnd_past_roi_entries = 0,
+    format('boundary test: expected epoch -99 (== overridden cutoff -100 + 1) to insert exactly 0 leaderboard_roi entries, got %s — the guard may be off by one', bnd_past_roi_entries);
+  ASSERT bnd_past_fee_entries > 0,
+    format('boundary test: expected epoch -99 (== overridden cutoff -100 + 1) to insert >0 fee entries, got %s', bnd_past_fee_entries);
+
+  RAISE NOTICE 'PASS: boundary test — epoch -100 (== cutoff) inserted % pnl / % roi entries, epoch -99 (== cutoff+1) inserted 0 / 0, both inserted fee entries (% / %)',
+    bnd_at_pnl_entries, bnd_at_roi_entries, bnd_at_fee_entries, bnd_past_fee_entries;
+END $$;
+
+-- Restore the real cutoff constant immediately, so every phase below this
+-- point tests the ACTUAL production guard (epoch 20), not the -100
+-- override above.
+CREATE OR REPLACE FUNCTION season2_last_leaderboard_epoch()
+RETURNS INTEGER AS $$
+  SELECT 20;
+$$ LANGUAGE sql IMMUTABLE;
+
+-- Not decorative: this is what catches a botched restore (e.g. a typo
+-- left the override in place) instead of silently letting every phase
+-- below test the WRONG cutoff.
+DO $$
+DECLARE
+  v_restored_cutoff INTEGER;
+BEGIN
+  SELECT season2_last_leaderboard_epoch() INTO v_restored_cutoff;
+  ASSERT v_restored_cutoff = 20,
+    format('expected season2_last_leaderboard_epoch() to be restored to 20 after the Step F boundary override, got %s — every phase below this point would be testing the WRONG cutoff', v_restored_cutoff);
+  RAISE NOTICE 'PASS: season2_last_leaderboard_epoch() restored to the real cutoff (20)';
+END $$;
+
+-- ========================================
+-- Step G. p_force = TRUE PAST THE CUTOFF: force-resettling cannot
+--    resurrect leaderboard IQ, but does restore fee IQ after its own
+--    DELETE
+-- ========================================
+--
+-- p_force = TRUE makes settle_season2_epoch DELETE every existing
+-- season2_iq_ledger row for that epoch (ALL entry types, not just
+-- leaderboard ones — see the `IF p_force THEN DELETE ...` block near the
+-- top of the function, itself one of the five ambiguous-`epoch` sites
+-- documented in up.sql), then re-run the fee INSERT unconditionally and
+-- the leaderboard INSERTs only if the epoch is still <= the cutoff. This
+-- re-settles epoch 90000041 (already settled once with p_force = FALSE in
+-- Step E, which inserted its 1 fee row and 0 leaderboard rows) to prove
+-- force mode is not a backdoor around the cutoff guard.
+
+DO $$
+DECLARE
+  force_pnl_entries BIGINT;
+  force_roi_entries BIGINT;
+  force_fee_entries BIGINT;
+BEGIN
+  SELECT pnl_entries_inserted, roi_entries_inserted, fee_entries_inserted
+  INTO force_pnl_entries, force_roi_entries, force_fee_entries
+  FROM settle_season2_epoch(90000041, TRUE);
+
+  ASSERT force_pnl_entries = 0,
+    format('p_force test: expected force-resettling epoch 90000041 (>20) to insert exactly 0 leaderboard_pnl entries, got %s — p_force must not be able to resurrect leaderboard IQ past the cutoff', force_pnl_entries);
+  ASSERT force_roi_entries = 0,
+    format('p_force test: expected force-resettling epoch 90000041 (>20) to insert exactly 0 leaderboard_roi entries, got %s — p_force must not be able to resurrect leaderboard IQ past the cutoff', force_roi_entries);
+  ASSERT force_fee_entries > 0,
+    format('p_force test: expected force-resettling epoch 90000041 (>20) to insert >0 fee entries (restoring what its own DELETE just removed), got %s', force_fee_entries);
+
+  RAISE NOTICE 'PASS: p_force=TRUE on epoch 90000041 (>20) re-inserted % fee entries and 0 leaderboard entries — force cannot resurrect leaderboard IQ past the cutoff', force_fee_entries;
+END $$;
+
+-- ========================================
+-- Step H. DOWN.SQL SMOKE TEST (must run LAST — see warning below)
+--    Source: infrastructure/hasura/migrations/intuition/1771526444000_leaderboard_wind_down_epoch_20/down.sql
+--    Keep this block byte-identical to that file. Checked by
+--    scripts/season2_check_verify_script_sync.sh.
+-- ========================================
+--
+-- Embeds down.sql verbatim and asserts that, after it runs,
+-- settle_season2_epoch is back to raising the pre-fix ambiguity error.
+-- This is deliberately the LAST phase in this script: down.sql restores
+-- settle_season2_epoch to a body that cannot successfully settle ANY
+-- epoch (see down.sql's own header and its RAISE WARNING), so every
+-- phase above this point would break if this ran first. Nothing here
+-- persists — the whole script still rolls back at the end.
+
+-- BEGIN EMBEDDED down.sql (verbatim - keep byte-identical, see scripts/season2_check_verify_script_sync.sh)
+-- GWTH-4354: revert the leaderboard wind-down.
+--
+-- Restores settle_season2_epoch(...) to the verbatim pre-migration body
+-- from migration 1771526400000_add_season2_iq_points_mvp (unconditional
+-- leaderboard_pnl / leaderboard_roi inserts for every epoch), and drops
+-- the season2_last_leaderboard_epoch() cutoff constant.
+--
+-- NOTE: this cannot resurrect any leaderboard_pnl / leaderboard_roi rows
+-- that up.sql's DELETE removed (or that were never inserted because the
+-- guard skipped them). If leaderboard IQ needs to exist for those epochs
+-- again, it must be re-settled (e.g. `settle_season2_epoch(N, TRUE)`)
+-- after this rollback — there is no way to recover the original values
+-- from a DELETE.
+--
+-- NOTE: this also reintroduces two pre-existing bugs that up.sql happened
+-- to fix as a side effect (see up.sql's changes 4 and 5, and
+-- docs/leaderboard-wind-down-epoch-20.md):
+--   - Without `#variable_conflict use_column`, every
+--     `ON CONFLICT (epoch, ...)` clause in this function raises "column
+--     reference \"epoch\" is ambiguous", because the function's
+--     RETURNS TABLE OUT column is also named `epoch`.
+--   - Without the two `DROP TABLE IF EXISTS` for get_pnl_leaderboard_period's
+--     seven `ON COMMIT DROP` temp tables (one before the pnl INSERT
+--     block, one before the roi INSERT block), a second call to
+--     get_pnl_leaderboard_period() — whether the roi call within one
+--     settle_season2_epoch execution, or the pnl call of a later
+--     settle_season2_epoch invocation in the same session — fails with
+--     'relation "..." already exists', because those tables only drop at
+--     transaction commit, not between calls within the same
+--     transaction/session.
+-- Both predate this migration (present verbatim in
+-- 1771526400000_add_season2_iq_points_mvp) and were never triggered in
+-- production because settle_season2_epoch has never been successfully
+-- run anywhere — between them, the original function could never
+-- successfully settle any epoch at all. A true "restore pre-migration
+-- state" rollback has to bring both back too — this is intentional, not
+-- an oversight. If this rollback is ever actually run, re-apply both
+-- fixes (or new ones) before calling settle_season2_epoch again.
+
+CREATE OR REPLACE FUNCTION settle_season2_epoch(
+  p_epoch INTEGER,
+  p_force BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (
+  epoch INTEGER,
+  snapshot_count INTEGER,
+  average_trust_usd NUMERIC(20, 10),
+  fee_entries_inserted BIGINT,
+  pnl_entries_inserted BIGINT,
+  roi_entries_inserted BIGINT,
+  fee_iq_total NUMERIC(30, 0),
+  pnl_iq_total NUMERIC(30, 0),
+  roi_iq_total NUMERIC(30, 0),
+  total_iq NUMERIC(30, 0)
+) AS $$
+DECLARE
+  v_start_at TIMESTAMPTZ;
+  v_end_at TIMESTAMPTZ;
+  v_settle_after TIMESTAMPTZ;
+  v_is_final BOOLEAN;
+  v_snapshot_count INTEGER;
+  v_avg_price NUMERIC(20, 10);
+
+  v_fee_entries_inserted BIGINT := 0;
+  v_pnl_entries_inserted BIGINT := 0;
+  v_roi_entries_inserted BIGINT := 0;
+
+  v_fee_iq_total NUMERIC(30, 0) := 0;
+  v_pnl_iq_total NUMERIC(30, 0) := 0;
+  v_roi_iq_total NUMERIC(30, 0) := 0;
+BEGIN
+  SELECT
+    se.start_at,
+    se.end_at,
+    se.settle_after,
+    se.is_final
+  INTO
+    v_start_at,
+    v_end_at,
+    v_settle_after,
+    v_is_final
+  FROM season2_epoch se
+  WHERE se.epoch = p_epoch;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Season 2 epoch % not found', p_epoch;
+  END IF;
+
+  IF v_is_final THEN
+    RAISE EXCEPTION 'Season 2 epoch % is already finalized', p_epoch;
+  END IF;
+
+  IF NOW() < v_settle_after THEN
+    RAISE EXCEPTION
+      'Season 2 epoch % cannot be settled before settle_after (%)',
+      p_epoch,
+      v_settle_after;
+  END IF;
+
+  SELECT
+    COUNT(*)::INTEGER,
+    AVG(stps.price_usd)::NUMERIC(20, 10)
+  INTO
+    v_snapshot_count,
+    v_avg_price
+  FROM season2_trust_price_snapshot stps
+  WHERE stps.snapshot_at >= v_start_at
+    AND stps.snapshot_at < v_end_at;
+
+  IF v_snapshot_count = 0 OR v_avg_price IS NULL THEN
+    RAISE EXCEPTION 'No TRUST/USD snapshots found for Season 2 epoch %', p_epoch;
+  END IF;
+
+  INSERT INTO season2_epoch_price (
+    epoch,
+    snapshot_count,
+    average_price_usd,
+    computed_at,
+    updated_at
+  )
+  VALUES (
+    p_epoch,
+    v_snapshot_count,
+    v_avg_price,
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (epoch) DO UPDATE
+  SET
+    snapshot_count = EXCLUDED.snapshot_count,
+    average_price_usd = EXCLUDED.average_price_usd,
+    computed_at = EXCLUDED.computed_at,
+    updated_at = NOW();
+
+  IF p_force THEN
+    DELETE FROM season2_iq_ledger
+    WHERE epoch = p_epoch;
+  END IF;
+
+  -- Fee IQ:  amount(wei TRUST) -> TRUST -> USD via epoch avg -> IQ at 2000/$1
+  WITH inserted_fee AS (
+    INSERT INTO season2_iq_ledger (
+      epoch,
+      account_id,
+      entry_type,
+      source_id,
+      iq_points,
+      metadata
+    )
+    SELECT
+      p_epoch,
+      pfa.sender_id,
+      'fee',
+      pfa.id,
+      ROUND((((pfa.amount / 1000000000000000000::NUMERIC) * v_avg_price) * 2000), 0)::NUMERIC(30, 0),
+      jsonb_build_object(
+        'fee_amount_raw', pfa.amount,
+        'average_trust_usd', v_avg_price,
+        'formula', '(amount_trust * average_trust_usd) * 2000'
+      )
+    FROM protocol_fee_accrued pfa
+    WHERE pfa.epoch = p_epoch::NUMERIC
+    ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+    RETURNING iq_points
+  )
+  SELECT
+    COUNT(*)::BIGINT,
+    COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+  INTO
+    v_fee_entries_inserted,
+    v_fee_iq_total
+  FROM inserted_fee;
+
+  -- Nominal PnL leaderboard IQ
+  WITH inserted_pnl AS (
+    INSERT INTO season2_iq_ledger (
+      epoch,
+      account_id,
+      entry_type,
+      source_id,
+      iq_points,
+      metadata
+    )
+    SELECT
+      p_epoch,
+      lb.account_id,
+      'leaderboard_pnl',
+      lb.account_id,
+      slp.iq_points,
+      jsonb_build_object(
+        'rank', lb.rank,
+        'leaderboard', 'pnl',
+        'sort_by', 'total_pnl'
+      )
+    FROM get_pnl_leaderboard_period(
+      v_start_at,
+      v_end_at,
+      25,
+      0,
+      'total_pnl',
+      'DESC',
+      TRUE,
+      1,
+      0,
+      NULL
+    ) lb
+    JOIN season2_leaderboard_payout slp
+      ON slp.rank = lb.rank::INTEGER
+    ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+    RETURNING iq_points
+  )
+  SELECT
+    COUNT(*)::BIGINT,
+    COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+  INTO
+    v_pnl_entries_inserted,
+    v_pnl_iq_total
+  FROM inserted_pnl;
+
+  -- ROI leaderboard IQ
+  WITH inserted_roi AS (
+    INSERT INTO season2_iq_ledger (
+      epoch,
+      account_id,
+      entry_type,
+      source_id,
+      iq_points,
+      metadata
+    )
+    SELECT
+      p_epoch,
+      lb.account_id,
+      'leaderboard_roi',
+      lb.account_id,
+      slp.iq_points,
+      jsonb_build_object(
+        'rank', lb.rank,
+        'leaderboard', 'roi',
+        'sort_by', 'pnl_pct'
+      )
+    FROM get_pnl_leaderboard_period(
+      v_start_at,
+      v_end_at,
+      25,
+      0,
+      'pnl_pct',
+      'DESC',
+      TRUE,
+      1,
+      0,
+      NULL
+    ) lb
+    JOIN season2_leaderboard_payout slp
+      ON slp.rank = lb.rank::INTEGER
+    ON CONFLICT (epoch, entry_type, source_id) DO NOTHING
+    RETURNING iq_points
+  )
+  SELECT
+    COUNT(*)::BIGINT,
+    COALESCE(SUM(iq_points), 0)::NUMERIC(30, 0)
+  INTO
+    v_roi_entries_inserted,
+    v_roi_iq_total
+  FROM inserted_roi;
+
+  UPDATE season2_epoch
+  SET
+    settled_at = NOW(),
+    last_settlement_force = p_force,
+    updated_at = NOW()
+  WHERE season2_epoch.epoch = p_epoch;
+
+  SELECT
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'fee'), 0)::NUMERIC(30, 0),
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'leaderboard_pnl'), 0)::NUMERIC(30, 0),
+    COALESCE(SUM(sil.iq_points) FILTER (WHERE sil.entry_type = 'leaderboard_roi'), 0)::NUMERIC(30, 0)
+  INTO
+    v_fee_iq_total,
+    v_pnl_iq_total,
+    v_roi_iq_total
+  FROM season2_iq_ledger sil
+  WHERE sil.epoch = p_epoch;
+
+  RETURN QUERY
+  SELECT
+    p_epoch,
+    v_snapshot_count,
+    v_avg_price,
+    v_fee_entries_inserted,
+    v_pnl_entries_inserted,
+    v_roi_entries_inserted,
+    COALESCE(v_fee_iq_total, 0)::NUMERIC(30, 0),
+    COALESCE(v_pnl_iq_total, 0)::NUMERIC(30, 0),
+    COALESCE(v_roi_iq_total, 0)::NUMERIC(30, 0),
+    (COALESCE(v_fee_iq_total, 0) + COALESCE(v_pnl_iq_total, 0) + COALESCE(v_roi_iq_total, 0))::NUMERIC(30, 0);
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+DROP FUNCTION IF EXISTS season2_last_leaderboard_epoch();
+
+DO $$ BEGIN
+  RAISE WARNING 'GWTH-4354 rollback: settle_season2_epoch restored to its pre-migration body, which cannot successfully settle ANY epoch (ON CONFLICT "epoch" ambiguity + get_pnl_leaderboard_period temp-table collision). See down.sql header.';
+END $$;
+-- END EMBEDDED down.sql
+
+-- Reuses epoch 6 rather than the real epoch 21: epoch 6's fixture (Step D)
+-- already proved, earlier in this SAME transaction (Step E), that its
+-- window has real TRUST/USD snapshot data, so the pre-fix function is
+-- guaranteed to reach the ambiguous ON CONFLICT statement instead of
+-- failing earlier with an unrelated "No TRUST/USD snapshots found" error
+-- that would depend on real epoch 21 data lining up on whichever
+-- environment this runs against.
+--
+-- NOTE on test design: the "unexpectedly succeeded" failure below is
+-- raised OUTSIDE the BEGIN/EXCEPTION block below, via a flag, rather than
+-- as a RAISE EXCEPTION *inside* that block's try section. Raising it
+-- inside would have it caught by this same block's own `WHEN OTHERS`
+-- handler — and if that raised message happened to mention "ambiguous"
+-- (an easy word to reach for when describing this exact test), the
+-- ASSERT SQLERRM ILIKE '%ambiguous%' check below would then pass against
+-- OUR OWN synthetic message, letting a no-op/broken down.sql pass this
+-- test. Setting a flag and checking it after the block closes avoids that
+-- self-referential trap entirely.
+DO $$
+DECLARE
+  v_unexpectedly_succeeded BOOLEAN := FALSE;
+BEGIN
+  BEGIN
+    PERFORM * FROM settle_season2_epoch(6, FALSE);
+    v_unexpectedly_succeeded := TRUE;
+  EXCEPTION
+    WHEN OTHERS THEN
+      ASSERT SQLERRM ILIKE '%ambiguous%',
+        format('down.sql smoke test: expected the post-rollback error to mention "ambiguous" (the pre-fix ON CONFLICT "epoch" bug), got: %s', SQLERRM);
+      RAISE NOTICE 'PASS: down.sql restored the pre-fix ambiguous-column behaviour (error: %)', SQLERRM;
+  END;
+
+  IF v_unexpectedly_succeeded THEN
+    RAISE EXCEPTION 'down.sql smoke test FAILED: settle_season2_epoch(6) completed successfully after down.sql was applied, but it should have failed with a column-resolution error on the ON CONFLICT (epoch) clause -- down.sql may not be a true revert of the pre-fix state';
+  END IF;
 END $$;
 
 SELECT 'ALL ASSERTIONS PASSED for GWTH-4354 leaderboard cutoff at Epoch 20' AS result;

--- a/scripts/season2_verify_leaderboard_period_temp_tables.sql
+++ b/scripts/season2_verify_leaderboard_period_temp_tables.sql
@@ -1,0 +1,776 @@
+-- GWTH-4354: regression test for 1771526445000_fix_pnl_leaderboard_period_temp_tables.
+--
+-- Proves that get_pnl_leaderboard_period can be called repeatedly within a
+-- single transaction. Before the migration, the SECOND call raised
+--   42P07 relation "_tmp_active_accounts" already exists
+-- because the function's seven temp tables are ON COMMIT DROP, which fires
+-- only at real transaction COMMIT.
+--
+-- Run (credentials are read from the pod environment, never printed):
+--   kubectl exec -i -n <ns> <ns>-timescale-db-0 -- \
+--     bash -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -f -' \
+--     < scripts/season2_verify_leaderboard_period_temp_tables.sql
+--
+-- Wrapped in BEGIN;/ROLLBACK; -- nothing is ever persisted. Any ASSERT failure
+-- or SQL error aborts psql with a nonzero exit before ROLLBACK is reached; the
+-- connection teardown then rolls back the open transaction anyway.
+--
+-- The embedded copy of up.sql below is kept byte-identical to the real
+-- migration file; scripts/season2_check_verify_script_sync.sh enforces that.
+
+\set ON_ERROR_STOP on
+\timing off
+
+BEGIN;
+
+-- ASSERT is a complete no-op when plpgsql.check_asserts is off -- the
+-- condition is not even evaluated -- which would let every PASS notice below
+-- print while verifying nothing. Pin it.
+SET LOCAL plpgsql.check_asserts = on;
+
+-- BEGIN EMBEDDED 1771526445000/up.sql (verbatim - keep byte-identical, see scripts/season2_check_verify_script_sync.sh)
+-- GWTH-4354: make get_pnl_leaderboard_period safe to call twice in one transaction.
+--
+-- Split out of 1771526444000_leaderboard_wind_down_epoch_20 so it can be
+-- reviewed, approved and reverted on its own terms: this touches a live,
+-- portal-facing read-path function, while the wind-down migration only
+-- touches Season 2 settlement.
+--
+-- THE DEFECT
+-- get_pnl_leaderboard_period builds seven temp tables with ON COMMIT DROP.
+-- That fires only at real transaction COMMIT, never between calls inside one
+-- transaction, so a second call in the same transaction raised
+-- `42P07 relation "_tmp_active_accounts" already exists`. The function
+-- carried an undocumented "call me at most once per transaction" contract.
+--
+-- Reproduced against the deployed function on intuition-testnet-next before
+-- this fix: two back-to-back calls in one transaction, second one raised.
+--
+-- WHY IT WAS NEVER HIT IN PRODUCTION
+-- chart-api (apps/chart-api/src/services/leaderboard.rs) opens its own
+-- transaction per request and calls the function exactly once, so the portal
+-- read path always committed cleanly. settle_season2_epoch is the only caller
+-- that calls it twice (pnl, then roi) -- and settlement had never run, because
+-- of a separate defect fixed in 1771526444000.
+--
+-- THE FIX
+-- One DROP TABLE IF EXISTS at the top of the function body. Everything else is
+-- copied verbatim from 1771526443000_fix_unrealized_pnl_pre_epoch_redemptions,
+-- the most recent definition. The signature and RETURNS type are unchanged --
+-- CREATE OR REPLACE cannot alter a return type, and nothing here tries to.
+--
+-- 1771526444000 keeps its own caller-side DROP blocks. They become redundant
+-- once this migration is applied, but they are idempotent no-ops, and keeping
+-- them means THIS migration can be reverted without breaking settlement.
+
+CREATE OR REPLACE FUNCTION get_pnl_leaderboard_period(
+  p_start_date TIMESTAMPTZ,
+  p_end_date TIMESTAMPTZ,
+  p_limit INTEGER DEFAULT 100,
+  p_offset INTEGER DEFAULT 0,
+  p_sort_by TEXT DEFAULT 'total_pnl',
+  p_sort_order TEXT DEFAULT 'DESC',
+  p_exclude_protocol_accounts BOOLEAN DEFAULT TRUE,
+  p_min_positions INTEGER DEFAULT 1,
+  p_min_volume NUMERIC DEFAULT 0,
+  p_term_id TEXT DEFAULT NULL,
+  p_min_deposit NUMERIC DEFAULT 0
+)
+RETURNS SETOF pnl_leaderboard_entry AS $$
+DECLARE
+  v_start_timestamp      BIGINT;
+  v_end_timestamp        BIGINT;
+  v_bucket_start         TIMESTAMPTZ;
+  v_bucket_end           TIMESTAMPTZ;
+  v_limit                INTEGER;
+  v_offset               INTEGER;
+  v_cagg_cutoff          TIMESTAMPTZ;
+BEGIN
+
+  -- GWTH-4354: self-cleaning temp tables.
+  --
+  -- The seven temp tables below are created ON COMMIT DROP, which only fires
+  -- at real transaction COMMIT -- never between calls inside one transaction.
+  -- A second call to this function in the same transaction therefore failed
+  -- with `42P07 relation "_tmp_active_accounts" already exists`.
+  --
+  -- settle_season2_epoch calls this function twice per settlement (once for
+  -- the nominal PnL board, once for ROI), which is how the defect surfaced.
+  -- Dropping here makes EVERY call self-cleaning, so no caller has to know
+  -- about the implicit "call me at most once per transaction" contract.
+  DROP TABLE IF EXISTS
+    _tmp_active_accounts,
+    _tmp_position_data,
+    _tmp_prices_at_start,
+    _tmp_prices_at_end,
+    _tmp_vault_state_at_start,
+    _tmp_vault_state_at_end,
+    _tmp_realized_fifo;
+  IF p_start_date IS NULL OR p_end_date IS NULL THEN
+    RAISE EXCEPTION 'p_start_date and p_end_date are required';
+  END IF;
+
+  IF p_start_date >= p_end_date THEN
+    RAISE EXCEPTION 'p_start_date must be before p_end_date';
+  END IF;
+
+  v_limit  := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 10000);
+  v_offset := GREATEST(COALESCE(p_offset, 0), 0);
+
+  v_start_timestamp := EXTRACT(EPOCH FROM p_start_date)::BIGINT;
+  v_end_timestamp   := EXTRACT(EPOCH FROM p_end_date)::BIGINT;
+
+  v_bucket_start := date_trunc('hour', p_start_date);
+  v_bucket_end   := date_trunc('hour', p_end_date);
+
+  v_cagg_cutoff := date_trunc('hour', NOW());
+
+  SET LOCAL work_mem = '64MB';
+
+  -- Step 1: Active accounts (unchanged)
+  CREATE TEMP TABLE _tmp_active_accounts ON COMMIT DROP AS
+  SELECT DISTINCT pc.account_id
+  FROM position_change_hourly pc
+  WHERE pc.bucket >= v_bucket_start
+    AND pc.bucket <= v_bucket_end
+    AND (p_term_id IS NULL OR pc.term_id = p_term_id)
+    AND (NOT p_exclude_protocol_accounts
+         OR pc.account_id NOT IN (
+           SELECT id FROM account
+           WHERE type IN ('ProtocolVault', 'AtomWallet')
+         ));
+
+  ANALYZE _tmp_active_accounts;
+
+  -- Step 2: OPTIMIZED position data -- LATERAL per account (not per position)
+  -- Uses two DISTINCT ON queries per account instead of one global DISTINCT ON
+  -- + 67K LATERAL calls. Forces narrow index seeks via account_id binding.
+  CREATE TEMP TABLE _tmp_position_data ON COMMIT DROP AS
+  SELECT pd.*
+  FROM _tmp_active_accounts aa
+  CROSS JOIN LATERAL (
+    SELECT
+      aa.account_id,
+      se.term_id,
+      se.curve_id,
+      COALESCE(ss.cumulative_shares, 0)::NUMERIC(78,0)     AS shares_at_start,
+      se.cumulative_shares::NUMERIC(78,0)                   AS shares_at_end,
+      (se.cumulative_assets_in  - COALESCE(ss.cumulative_assets_in,  0))::NUMERIC AS period_deposits,
+      (se.cumulative_assets_out - COALESCE(ss.cumulative_assets_out, 0))::NUMERIC AS period_redemptions,
+      ((se.cumulative_assets_in  - COALESCE(ss.cumulative_assets_in,  0)) > 0
+       OR
+       (se.cumulative_assets_out - COALESCE(ss.cumulative_assets_out, 0)) > 0
+      ) AS had_activity,
+      se.cumulative_assets_in::NUMERIC                      AS cumulative_deposits,
+      (se.cumulative_shares_in  - COALESCE(ss.cumulative_shares_in,  0))::NUMERIC AS shares_acquired_in_period,
+      (se.cumulative_shares_out - COALESCE(ss.cumulative_shares_out, 0))::NUMERIC AS shares_redeemed_in_period
+    FROM (
+      -- snap_end: latest cumulative for all (term, curve) for this account
+      SELECT DISTINCT ON (pch.term_id, pch.curve_id)
+        pch.term_id, pch.curve_id,
+        pch.cumulative_shares, pch.cumulative_assets_in, pch.cumulative_assets_out,
+        pch.cumulative_shares_in, pch.cumulative_shares_out
+      FROM position_cumulative_hourly pch
+      WHERE pch.account_id = aa.account_id
+        AND pch.bucket <= v_bucket_end
+        AND (p_term_id IS NULL OR pch.term_id = p_term_id)
+      ORDER BY pch.term_id, pch.curve_id, pch.bucket DESC
+    ) se
+    LEFT JOIN (
+      -- snap_start: latest cumulative before period start for this account
+      SELECT DISTINCT ON (pch.term_id, pch.curve_id)
+        pch.term_id, pch.curve_id,
+        pch.cumulative_shares, pch.cumulative_assets_in, pch.cumulative_assets_out,
+        pch.cumulative_shares_in, pch.cumulative_shares_out
+      FROM position_cumulative_hourly pch
+      WHERE pch.account_id = aa.account_id
+        AND pch.bucket < v_bucket_start
+        AND (p_term_id IS NULL OR pch.term_id = p_term_id)
+      ORDER BY pch.term_id, pch.curve_id, pch.bucket DESC
+    ) ss ON se.term_id = ss.term_id AND se.curve_id = ss.curve_id
+  ) pd;
+
+  ANALYZE _tmp_position_data;
+
+  -- Steps 3-5: Price and vault state lookups (unchanged from 1771526434000)
+  CREATE TEMP TABLE _tmp_prices_at_start ON COMMIT DROP AS
+  SELECT DISTINCT ON (c.term_id, c.curve_id)
+    c.term_id, c.curve_id, c.last_share_price AS share_price
+  FROM share_price_change_stats_hourly c
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+    WHERE COALESCE(shares_at_start, 0) > 0
+  ) pd ON c.term_id = pd.term_id AND c.curve_id = pd.curve_id
+  WHERE c.bucket <= date_trunc('hour', p_start_date)
+  ORDER BY c.term_id, c.curve_id, c.bucket DESC;
+
+  CREATE TEMP TABLE _tmp_prices_at_end ON COMMIT DROP AS
+  SELECT DISTINCT ON (c.term_id, c.curve_id)
+    c.term_id, c.curve_id, c.last_share_price AS share_price
+  FROM share_price_change_stats_hourly c
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+    WHERE shares_at_end > 0
+  ) pd ON c.term_id = pd.term_id AND c.curve_id = pd.curve_id
+  WHERE c.bucket <= date_trunc('hour', p_end_date)
+  ORDER BY c.term_id, c.curve_id, c.bucket DESC;
+
+  IF p_end_date > v_cagg_cutoff THEN
+    WITH raw_current_hour AS (
+      SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+        spc.term_id, spc.curve_id, spc.share_price
+      FROM share_price_change spc
+      WHERE spc.block_timestamp > EXTRACT(EPOCH FROM v_cagg_cutoff)::BIGINT
+        AND spc.block_timestamp <= v_end_timestamp
+        AND EXISTS (
+          SELECT 1 FROM _tmp_prices_at_end pe
+          WHERE pe.term_id = spc.term_id AND pe.curve_id = spc.curve_id
+        )
+      ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC
+    )
+    UPDATE _tmp_prices_at_end pe
+    SET share_price = rch.share_price
+    FROM raw_current_hour rch
+    WHERE pe.term_id = rch.term_id AND pe.curve_id = rch.curve_id;
+
+    INSERT INTO _tmp_prices_at_end (term_id, curve_id, share_price)
+    SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+      spc.term_id, spc.curve_id, spc.share_price
+    FROM share_price_change spc
+    INNER JOIN (
+      SELECT DISTINCT term_id, curve_id FROM _tmp_position_data
+      WHERE shares_at_end > 0
+    ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+    WHERE spc.block_timestamp <= v_end_timestamp
+      AND NOT EXISTS (
+        SELECT 1 FROM _tmp_prices_at_end pe
+        WHERE pe.term_id = spc.term_id AND pe.curve_id = spc.curve_id
+      )
+    ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+  END IF;
+
+  CREATE TEMP TABLE _tmp_vault_state_at_start ON COMMIT DROP AS
+  SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+    spc.term_id,
+    spc.curve_id,
+    spc.total_shares AS vault_total_shares
+  FROM share_price_change spc
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id
+    FROM _tmp_position_data
+    WHERE COALESCE(shares_at_start, 0) > 0
+      AND curve_id = 2
+  ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+  WHERE spc.block_timestamp <= v_start_timestamp
+  ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+
+  CREATE TEMP TABLE _tmp_vault_state_at_end ON COMMIT DROP AS
+  SELECT DISTINCT ON (spc.term_id, spc.curve_id)
+    spc.term_id,
+    spc.curve_id,
+    spc.total_shares AS vault_total_shares
+  FROM share_price_change spc
+  INNER JOIN (
+    SELECT DISTINCT term_id, curve_id
+    FROM _tmp_position_data
+    WHERE shares_at_end > 0
+      AND curve_id = 2
+  ) pd ON spc.term_id = pd.term_id AND spc.curve_id = pd.curve_id
+  WHERE spc.block_timestamp <= v_end_timestamp
+  ORDER BY spc.term_id, spc.curve_id, spc.block_timestamp DESC, spc.log_index DESC;
+
+  -- ---- FIFO REALIZED PnL FOR MIXED POSITIONS ----
+  -- For positions with pre-existing shares + in-epoch deposits + in-epoch redemptions,
+  -- process hourly events chronologically to correctly attribute realized PnL.
+  -- Within each hour: deposits first, then redemptions. FIFO: pre-existing shares consumed first.
+  CREATE TEMP TABLE _tmp_realized_fifo ON COMMIT DROP AS
+  WITH RECURSIVE
+  events AS (
+    SELECT pd.account_id, pd.term_id, pd.curve_id, pd.shares_at_start,
+      pc.bucket,
+      COALESCE(pc.assets_in_period, 0)::NUMERIC AS ai,
+      COALESCE(pc.assets_out_period, 0)::NUMERIC AS ao,
+      COALESCE(pc.shares_in_period, 0)::NUMERIC AS si,
+      COALESCE(pc.shares_out_period, 0)::NUMERIC AS so,
+      ROW_NUMBER() OVER (
+        PARTITION BY pd.account_id, pd.term_id, pd.curve_id ORDER BY pc.bucket
+      ) AS rn
+    FROM _tmp_position_data pd
+    JOIN position_change_hourly pc
+      ON pc.account_id = pd.account_id
+      AND pc.term_id = pd.term_id
+      AND pc.curve_id = pd.curve_id
+    WHERE pd.shares_at_start > 0
+      AND pd.period_deposits > 0
+      AND pd.period_redemptions > 0
+      AND pc.bucket >= v_bucket_start
+      AND pc.bucket <= v_bucket_end
+  ),
+  fifo AS (
+    -- Base case: first hourly bucket
+    SELECT account_id, term_id, curve_id, rn,
+      -- After deposit (first) then redeem (second), FIFO consumes pre-existing first
+      CASE WHEN so <= shares_at_start THEN shares_at_start - so
+           ELSE 0::NUMERIC END AS pre_sh,
+      CASE WHEN so <= shares_at_start THEN si
+           ELSE GREATEST(si - (so - shares_at_start), 0) END AS ep_sh,
+      CASE WHEN so <= shares_at_start THEN ai
+           WHEN si > 0 THEN ai * GREATEST(si - (so - shares_at_start), 0) / si
+           ELSE 0::NUMERIC END AS ep_cost,
+      CASE WHEN so <= shares_at_start OR si = 0 THEN 0::NUMERIC
+           ELSE ao * LEAST(so - shares_at_start, si) / NULLIF(so, 0)
+                - ai * LEAST(so - shares_at_start, si) / NULLIF(si, 0)
+      END AS rpnl
+    FROM events WHERE rn = 1
+
+    UNION ALL
+
+    -- Recursive step: subsequent hourly buckets
+    SELECT e.account_id, e.term_id, e.curve_id, e.rn,
+      CASE WHEN e.so <= f.pre_sh THEN f.pre_sh - e.so
+           ELSE 0::NUMERIC END,
+      CASE WHEN e.so <= f.pre_sh THEN f.ep_sh + e.si
+           ELSE GREATEST(f.ep_sh + e.si - (e.so - f.pre_sh), 0) END,
+      CASE WHEN e.so <= f.pre_sh THEN f.ep_cost + e.ai
+           WHEN (f.ep_sh + e.si) > 0 THEN
+             (f.ep_cost + e.ai) * GREATEST(f.ep_sh + e.si - (e.so - f.pre_sh), 0)
+             / (f.ep_sh + e.si)
+           ELSE 0::NUMERIC END,
+      CASE WHEN e.so <= f.pre_sh OR (f.ep_sh + e.si) = 0 THEN 0::NUMERIC
+           ELSE e.ao * LEAST(e.so - f.pre_sh, f.ep_sh + e.si) / NULLIF(e.so, 0)
+                - (f.ep_cost + e.ai) * LEAST(e.so - f.pre_sh, f.ep_sh + e.si)
+                  / NULLIF(f.ep_sh + e.si, 0)
+      END
+    FROM fifo f
+    JOIN events e ON e.account_id = f.account_id
+      AND e.term_id = f.term_id
+      AND e.curve_id = f.curve_id
+      AND e.rn = f.rn + 1
+  )
+  SELECT account_id, term_id, curve_id, SUM(rpnl) AS realized_pnl
+  FROM fifo
+  GROUP BY account_id, term_id, curve_id;
+
+  ANALYZE _tmp_realized_fifo;
+
+  -- Main query: CTE chain (from 1771526440000 + unrealized PnL fix for pre-epoch redemptions)
+  RETURN QUERY
+  WITH
+  position_period_metrics AS (
+    SELECT
+      pd.account_id,
+      pd.term_id,
+      pd.curve_id,
+      COALESCE(pd.shares_at_start, 0)           AS shares_at_start,
+      pd.shares_at_end                          AS shares_at_end,
+      COALESCE(pd.period_deposits, 0)           AS period_deposits,
+      COALESCE(pd.period_redemptions, 0)        AS period_redemptions,
+      pd.had_activity,
+      COALESCE(pd.cumulative_deposits, 0)       AS cumulative_deposits,
+      COALESCE(pd.shares_acquired_in_period, 0) AS shares_acquired_in_period,
+      COALESCE(pd.shares_redeemed_in_period, 0) AS shares_redeemed_in_period,
+      CASE
+        WHEN pd.curve_id = 2 AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (vs.vault_total_shares + cc."offset")
+                * (vs.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (vs.vault_total_shares + cc."offset" - pd.shares_at_start)
+                  * (vs.vault_total_shares + cc."offset" - pd.shares_at_start)
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        ELSE
+          TRUNC(
+            COALESCE(pd.shares_at_start, 0)
+            * COALESCE(ps.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+      END AS equity_at_start,
+      CASE
+        WHEN pd.curve_id = 2 AND pd.shares_at_end > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (ve.vault_total_shares + cc."offset")
+                * (ve.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (ve.vault_total_shares + cc."offset" - pd.shares_at_end)
+                  * (ve.vault_total_shares + cc."offset" - pd.shares_at_end)
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        ELSE
+          TRUNC(
+            pd.shares_at_end
+            * COALESCE(pe.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+      END AS equity_at_end,
+      -- Value of remaining shares (shares_at_end) at epoch-start prices.
+      -- Used to compute correct unrealized PnL for pre-epoch positions with
+      -- redemptions, so unrealized only reflects change in remaining equity.
+      CASE
+        WHEN pd.curve_id = 2
+             AND pd.shares_at_end > 0
+             AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            (
+              TRUNC(
+                (vs.vault_total_shares + cc."offset")
+                * (vs.vault_total_shares + cc."offset")
+                / 1000000000000000000::NUMERIC
+              )
+              -
+              TRUNC(
+                (
+                  (vs.vault_total_shares + cc."offset" - GREATEST(pd.shares_at_end, 0))
+                  * (vs.vault_total_shares + cc."offset" - GREATEST(pd.shares_at_end, 0))
+                  + 999999999999999999::NUMERIC
+                )
+                / 1000000000000000000::NUMERIC
+              )
+            ) * cc.half_slope / 1000000000000000000::NUMERIC
+          )
+        WHEN pd.shares_at_end > 0
+             AND COALESCE(pd.shares_at_start, 0) > 0 THEN
+          TRUNC(
+            GREATEST(pd.shares_at_end, 0)
+            * COALESCE(ps.share_price, 0)
+            / 1000000000000000000::NUMERIC
+          )
+        ELSE 0
+      END AS equity_of_remaining_at_start
+    FROM _tmp_position_data pd
+    LEFT JOIN _tmp_prices_at_start ps
+      ON pd.term_id = ps.term_id AND pd.curve_id = ps.curve_id
+    LEFT JOIN _tmp_prices_at_end pe
+      ON pd.term_id = pe.term_id AND pd.curve_id = pe.curve_id
+    LEFT JOIN curve_config cc
+      ON pd.curve_id = cc.curve_id
+    LEFT JOIN _tmp_vault_state_at_start vs
+      ON pd.term_id = vs.term_id AND pd.curve_id = vs.curve_id
+    LEFT JOIN _tmp_vault_state_at_end ve
+      ON pd.term_id = ve.term_id AND pd.curve_id = ve.curve_id
+  ),
+
+  position_pnl AS (
+    SELECT
+      ppm.account_id,
+      ppm.term_id,
+      ppm.curve_id,
+      ppm.shares_at_start,
+      ppm.shares_at_end,
+      ppm.period_deposits,
+      ppm.period_redemptions,
+      ppm.equity_at_start,
+      ppm.equity_at_end,
+      ppm.equity_of_remaining_at_start,
+      ppm.had_activity,
+      ppm.cumulative_deposits,
+      ppm.shares_acquired_in_period,
+      ppm.shares_redeemed_in_period,
+      (ppm.equity_at_end - ppm.equity_at_start
+        + ppm.period_redemptions - ppm.period_deposits)::NUMERIC AS period_total_pnl,
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start
+                  + ppm.period_redemptions - ppm.period_deposits) > 0
+           THEN 1 ELSE 0 END AS is_winning,
+      CASE WHEN (ppm.equity_at_end - ppm.equity_at_start
+                  + ppm.period_redemptions - ppm.period_deposits) < 0
+           THEN 1 ELSE 0 END AS is_losing,
+      -- ---- EPOCH-ONLY REALIZED PnL ----
+      -- Cases 1-3: unchanged from 1771526434000
+      -- Case 4 (mixed): uses FIFO chronological computation from _tmp_realized_fifo
+      CASE
+        WHEN ppm.period_redemptions <= 0 THEN 0::NUMERIC
+        WHEN ppm.period_deposits <= 0 THEN 0::NUMERIC
+        WHEN ppm.shares_at_start <= 0 THEN
+          (ppm.period_redemptions - TRUNC(
+            ppm.period_deposits * ppm.shares_redeemed_in_period
+            / NULLIF(ppm.shares_acquired_in_period, 0)
+          ))::NUMERIC
+        ELSE
+          -- Mixed position: use FIFO-computed realized PnL
+          COALESCE(rf.realized_pnl, 0)::NUMERIC
+      END AS realized_pnl
+    FROM position_period_metrics ppm
+    LEFT JOIN _tmp_realized_fifo rf
+      ON ppm.account_id = rf.account_id
+      AND ppm.term_id = rf.term_id
+      AND ppm.curve_id = rf.curve_id
+  ),
+
+  filtered_pnl AS (
+    SELECT * FROM position_pnl pp
+    WHERE p_min_deposit <= 0
+       OR pp.cumulative_deposits >= p_min_deposit * 1e18
+  ),
+
+  account_metrics AS (
+    SELECT
+      fp.account_id,
+      COUNT(DISTINCT (fp.term_id, fp.curve_id))
+        FILTER (WHERE fp.had_activity)                           AS period_position_count,
+      COUNT(DISTINCT (fp.term_id, fp.curve_id))
+        FILTER (WHERE fp.shares_at_end > 0)                      AS active_position_count,
+      SUM(fp.is_winning) FILTER (WHERE fp.had_activity)          AS winning_positions,
+      SUM(fp.is_losing)  FILTER (WHERE fp.had_activity)          AS losing_positions,
+      SUM(fp.period_deposits)::NUMERIC                           AS period_deposits_raw,
+      SUM(fp.period_redemptions)::NUMERIC                        AS period_redemptions_raw,
+      SUM(fp.period_total_pnl)::NUMERIC                          AS total_pnl_raw,
+      SUM(fp.realized_pnl)::NUMERIC                              AS realized_pnl_raw,
+      -- Unrealized PnL: for pre-epoch positions with redemptions, use change in
+      -- remaining equity only (not the residual total_pnl - realized_pnl, which
+      -- would include already-cashed-out redemption profit).
+      SUM(
+        CASE
+          WHEN fp.period_deposits <= 0 AND fp.period_redemptions > 0 THEN
+            GREATEST(fp.equity_at_end, 0) - fp.equity_of_remaining_at_start
+          ELSE
+            fp.period_total_pnl - fp.realized_pnl
+        END
+      )::NUMERIC                                                  AS unrealized_pnl_raw,
+      SUM(fp.equity_at_start)::NUMERIC                           AS equity_at_start,
+      SUM(fp.equity_at_end)::NUMERIC                             AS equity_at_end,
+      MAX(fp.period_total_pnl)                                   AS best_trade_pnl_raw,
+      MIN(fp.period_total_pnl)                                   AS worst_trade_pnl_raw,
+      -- ---- EPOCH-ONLY DENOMINATORS (unchanged from 1771526434000) ----
+      SUM(CASE
+        WHEN fp.period_redemptions <= 0 OR fp.period_deposits <= 0 THEN 0
+        WHEN fp.shares_at_start <= 0 THEN
+          TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_acquired_in_period, 0))
+        ELSE
+          TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_at_start + fp.shares_acquired_in_period, 0))
+      END)::NUMERIC                                              AS denominator_closed,
+      SUM(CASE
+        WHEN fp.period_deposits <= 0 OR fp.shares_at_end <= 0 THEN 0
+        WHEN fp.period_redemptions <= 0 THEN fp.period_deposits
+        WHEN fp.shares_at_start <= 0 THEN
+          fp.period_deposits - TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_acquired_in_period, 0))
+        ELSE
+          fp.period_deposits - TRUNC(fp.period_deposits * fp.shares_redeemed_in_period
+                / NULLIF(fp.shares_at_start + fp.shares_acquired_in_period, 0))
+      END)::NUMERIC                                              AS denominator_open
+    FROM filtered_pnl fp
+    GROUP BY fp.account_id
+    HAVING
+      COUNT(DISTINCT (fp.term_id, fp.curve_id)) FILTER (WHERE fp.had_activity)
+        >= GREATEST(p_min_positions, 1)
+      AND (SUM(fp.period_deposits) + SUM(fp.period_redemptions))
+        >= COALESCE(p_min_volume * 1e18, 0)
+  ),
+
+  enriched AS (
+    SELECT
+      am.account_id,
+      a.label AS account_label,
+      a.image AS account_image,
+      am.total_pnl_raw,
+      COALESCE(am.realized_pnl_raw, 0)   AS realized_pnl_raw,
+      COALESCE(am.unrealized_pnl_raw, 0) AS unrealized_pnl_raw,
+      COALESCE(
+        (am.total_pnl_raw * 100.0 / NULLIF(
+          am.equity_at_start + am.period_deposits_raw
+        , 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS pnl_pct,
+      COALESCE(
+        (COALESCE(am.realized_pnl_raw, 0) * 100.0 / NULLIF(am.denominator_closed, 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS realized_pnl_pct,
+      COALESCE(
+        (COALESCE(am.unrealized_pnl_raw, 0) * 100.0 / NULLIF(am.denominator_open, 0))::NUMERIC(20, 4),
+        0::NUMERIC(20, 4)
+      ) AS unrealized_pnl_pct,
+      am.total_pnl_raw                    AS pnl_change_raw,
+      am.period_position_count            AS total_position_count,
+      am.active_position_count,
+      am.winning_positions,
+      am.losing_positions,
+      COALESCE(
+        (am.winning_positions * 100.0 / NULLIF(am.period_position_count, 0))::NUMERIC(10, 2),
+        0::NUMERIC(10, 2)
+      ) AS win_rate,
+      am.period_deposits_raw              AS total_deposits_raw,
+      am.period_redemptions_raw           AS total_redemptions_raw,
+      (am.period_deposits_raw + am.period_redemptions_raw)::NUMERIC AS total_volume_raw,
+      am.equity_at_end                    AS current_equity_value_raw,
+      am.best_trade_pnl_raw,
+      am.worst_trade_pnl_raw,
+      p_start_date                        AS first_position_at,
+      p_end_date                          AS last_activity_at
+    FROM account_metrics am
+    JOIN account a ON am.account_id = a.id
+    WHERE NOT p_exclude_protocol_accounts
+       OR a.type NOT IN ('ProtocolVault', 'AtomWallet')
+  ),
+
+  ranked AS (
+    SELECT
+      e.*,
+      CASE
+        WHEN p_sort_by IN ('total_pnl', 'pnl') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('pnl_pct', 'roi') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'realized_pnl' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.realized_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.realized_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'unrealized_pnl' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'realized_pnl_pct' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.realized_pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.realized_pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'unrealized_pnl_pct' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_pct ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.unrealized_pnl_pct DESC NULLS LAST)
+          END
+        WHEN p_sort_by = 'win_rate' THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.win_rate ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.win_rate DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('total_volume', 'volume') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_volume_raw ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_volume_raw DESC NULLS LAST)
+          END
+        WHEN p_sort_by IN ('position_count', 'positions') THEN
+          CASE p_sort_order
+            WHEN 'ASC' THEN ROW_NUMBER() OVER (ORDER BY e.total_position_count ASC  NULLS LAST)
+            ELSE             ROW_NUMBER() OVER (ORDER BY e.total_position_count DESC NULLS LAST)
+          END
+        ELSE ROW_NUMBER() OVER (ORDER BY e.total_pnl_raw DESC NULLS LAST)
+      END AS rank
+    FROM enriched e
+  )
+
+  SELECT
+    r.rank,
+    r.account_id,
+    r.account_label,
+    r.account_image,
+    r.total_pnl_raw,
+    ROUND(r.total_pnl_raw    / 1e18, 4)::NUMERIC(30, 4) AS total_pnl_formatted,
+    r.realized_pnl_raw,
+    ROUND(r.realized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS realized_pnl_formatted,
+    r.unrealized_pnl_raw,
+    ROUND(r.unrealized_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS unrealized_pnl_formatted,
+    r.pnl_pct,
+    r.realized_pnl_pct,
+    r.unrealized_pnl_pct,
+    r.pnl_change_raw,
+    ROUND(r.pnl_change_raw   / 1e18, 4)::NUMERIC(30, 4) AS pnl_change_formatted,
+    r.total_position_count,
+    r.active_position_count,
+    r.winning_positions,
+    r.losing_positions,
+    r.win_rate,
+    r.total_deposits_raw,
+    ROUND(r.total_deposits_raw    / 1e18, 4)::NUMERIC(30, 4) AS total_deposits_formatted,
+    r.total_redemptions_raw,
+    ROUND(r.total_redemptions_raw / 1e18, 4)::NUMERIC(30, 4) AS total_redemptions_formatted,
+    r.total_volume_raw,
+    ROUND(r.total_volume_raw      / 1e18, 4)::NUMERIC(30, 4) AS total_volume_formatted,
+    r.current_equity_value_raw,
+    ROUND(r.current_equity_value_raw / 1e18, 4)::NUMERIC(30, 4) AS current_equity_value_formatted,
+    r.best_trade_pnl_raw,
+    ROUND(r.best_trade_pnl_raw  / 1e18, 4)::NUMERIC(30, 4) AS best_trade_pnl_formatted,
+    r.worst_trade_pnl_raw,
+    ROUND(r.worst_trade_pnl_raw / 1e18, 4)::NUMERIC(30, 4) AS worst_trade_pnl_formatted,
+    NULL::NUMERIC         AS redeemable_assets_raw,
+    NULL::NUMERIC(30, 4)  AS redeemable_assets_formatted,
+    r.first_position_at,
+    r.last_activity_at
+  FROM ranked r
+  ORDER BY r.rank
+  LIMIT v_limit OFFSET v_offset;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+COMMENT ON FUNCTION get_pnl_leaderboard_period IS
+  'Period-specific PnL leaderboard with hourly-granularity period boundaries. '
+  'Uses LATERAL-per-account pattern for position_cumulative_hourly lookups (19x faster). '
+  'Realized PnL uses FIFO chronological processing for mixed positions '
+  '(pre-existing shares + in-epoch deposits + in-epoch redemptions). '
+  'p_min_deposit (in ETH/TRUST units, default 0) filters out positions where '
+  'cumulative all-time deposits are below the threshold. '
+  'Sort options: total_pnl/pnl, pnl_pct/roi, realized_pnl, unrealized_pnl, '
+  'realized_pnl_pct, unrealized_pnl_pct, win_rate, total_volume/volume, position_count/positions.';
+-- END EMBEDDED 1771526445000/up.sql
+
+-- ============================================================================
+-- ASSERT: repeated calls within one transaction all succeed
+-- ============================================================================
+--
+-- Three calls, not two: the second proves the fix, and the third proves the
+-- fix is not a one-shot (i.e. the DROP runs on every entry, not just once).
+--
+-- The same-arguments calls (1st and 3rd) must agree on row count. Asserting
+-- only "no error was raised" would be satisfied by a function that returned
+-- nothing at all, so the row-count agreement is what makes this a real test.
+-- Row counts are environment-dependent (they reflect live PnL activity in the
+-- window), so the assertion compares calls against each other rather than
+-- pinning an absolute number.
+DO $$
+DECLARE
+  v_first  INTEGER;
+  v_second INTEGER;
+  v_third  INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_first FROM get_pnl_leaderboard_period(
+    TIMESTAMPTZ '2026-08-11 00:00:00+00', TIMESTAMPTZ '2026-08-25 00:00:00+00',
+    25, 0, 'total_pnl', 'DESC', TRUE, 1, 0, NULL);
+
+  -- Pre-migration, THIS call raised 42P07.
+  SELECT COUNT(*) INTO v_second FROM get_pnl_leaderboard_period(
+    TIMESTAMPTZ '2026-08-11 00:00:00+00', TIMESTAMPTZ '2026-08-25 00:00:00+00',
+    25, 0, 'pnl_pct', 'DESC', TRUE, 1, 0, NULL);
+
+  SELECT COUNT(*) INTO v_third FROM get_pnl_leaderboard_period(
+    TIMESTAMPTZ '2026-08-11 00:00:00+00', TIMESTAMPTZ '2026-08-25 00:00:00+00',
+    25, 0, 'total_pnl', 'DESC', TRUE, 1, 0, NULL);
+
+  ASSERT v_first = v_third,
+    format('same-argument calls disagree (%s vs %s) - the temp-table DROP may be '
+           'leaving stale state behind between calls', v_first, v_third);
+
+  RAISE NOTICE 'PASS: three get_pnl_leaderboard_period calls in one transaction all succeeded (%, %, % rows); same-argument calls agree', v_first, v_second, v_third;
+END $$;
+
+SELECT 'ALL ASSERTIONS PASSED for GWTH-4354 get_pnl_leaderboard_period temp-table fix' AS result;
+
+ROLLBACK;


### PR DESCRIPTION
Linear: [GWTH-4354](https://linear.app/0xintuition/issue/GWTH-4354/leaderboard-wind-down-freeze-at-epoch-20-banner-nav-swap-to-featured)
Frontend counterpart: [intuition-portal-new#603](https://github.com/0xIntuition/intuition-portal-new/pull/603)

Epoch 20 is the last epoch that pays leaderboard IQ. **Fee IQ must keep accruing unchanged for every epoch, including 21+** — the two are separate entry types in one settlement function, so this is a selective guard, not an off-switch.

SQL and docs only. **No Rust, no `Cargo.toml`/`Cargo.lock` changes.**

## What's here

1. `season2_last_leaderboard_epoch()` — a greppable `IMMUTABLE` cutoff constant instead of a bare `20` buried in the function body.
2. `settle_season2_epoch` re-created with the **identical signature and `RETURNS TABLE` column list** (Postgres can't change a return type via `CREATE OR REPLACE`). Body copied verbatim; the only behavioural change is wrapping the `leaderboard_pnl` and `leaderboard_roi` INSERTs in `IF p_epoch <= season2_last_leaderboard_epoch()`. Snapshot averaging, the `fee` INSERT, the `settled_at` update and the final recompute are untouched.
3. Idempotent reversal `DELETE` for leaderboard IQ past the cutoff. A no-op today — `season2_iq_ledger` is empty in every environment — kept so the migration stays correct if anyone settles before it lands.

`season2_epoch` is deliberately **not** trimmed: epochs 21–30 must keep existing so fee IQ can still be settled for them.

## ⚠️ Two pre-existing bugs fixed (please review these closely)

Validating this against a real database surfaced two crash bugs in `settle_season2_epoch`, both present since `1771526400000_add_season2_iq_points_mvp`. **Confirmed against the currently deployed function**, not inferred:

| | Error | Cause | Fix |
|---|---|---|---|
| 1 | `42702 column reference "epoch" is ambiguous` | every `ON CONFLICT (epoch, ...)` collides with the function's own `RETURNS TABLE` OUT column named `epoch` | `#variable_conflict use_column` |
| 2 | `42P07 relation "_tmp_active_accounts" already exists` | `get_pnl_leaderboard_period`'s seven `ON COMMIT DROP` temp tables survive between calls in a transaction; settlement calls it twice (pnl, then roi) | `DROP TABLE IF EXISTS` before each call, inside `settle_season2_epoch` only |

Bug 1 meant `settle_season2_epoch` **could never settle any epoch at all** — which is also why the ledger is empty everywhere. Fixing it is not optional scope creep: an unfixed function cannot award fee IQ for epoch 21+ either, which is the one thing requirement 2 needs to keep working.

Fix 2 is deliberately scoped to `settle_season2_epoch` and does **not** touch `get_pnl_leaderboard_period`, which is live and portal-facing.

`down.sql` reintroduces both bugs verbatim — a rollback that quietly kept the fixes wouldn't be a true revert.

## Verification on real data

`up.sql` applied in a transaction against `intuition-mainnet-nested-triples`, both epochs settled with real data, then rolled back:

| Epoch | fee entries | fee IQ | leaderboard entries | pnl IQ | roi IQ |
|---|---|---|---|---|---|
| **20** (≤ cutoff) | 3,977 | 828,289 | **25 pnl + 25 roi** | 3,000,000 | 3,000,000 |
| **21** (> cutoff) | 16,297 | 2,996,047 | **0** | 0 | 0 |

Both halves matter. Epoch 21 awards fee IQ *and only* fee IQ; epoch 20 still pays the full 25-rank payout on both boards. An implementation that simply broke settlement would fail the epoch-20 row.

**Reversibility** (up → down, one transaction, testnet-next): cutoff function dropped, `settle_season2_epoch` restored, original `42702` behaviour back.

`scripts/season2_verify_leaderboard_cutoff.sql` is a self-contained `BEGIN;…ROLLBACK;` harness — this repo had no SQL test harness, so it's new. Assertions are differential rather than "epoch 21 has no leaderboard rows", which a crashed function would also satisfy.

## Deliberately not done

- **Price-capture CronJobs left running.** Notion step 3 said suspend them, but fee IQ is `(amount_trust × average_trust_usd) × 2000` and settlement hard-fails without snapshots in the epoch window. Suspending would make fee IQ for Epoch 23+ permanently unsettleable — snapshots can't be backfilled. Directly contradicts requirement 2. Confirmed with the ticket owner.
- **Hasura leaderboard functions left tracked.** The archive reads via Hasura Action → chart-api → `get_pnl_leaderboard_period`; the four *tracked* functions are unused by the portal but are public GraphQL fields, so removing them is a breaking API change worth its own ticket.
- **`protocol_fee_accrued.epoch`** — an earlier draft flagged this as a possible latent bug. It isn't: mainnet runs 0–22, matching on-chain `currentEpoch()`. The 1–322 spread is testnet-only. Corrected in the doc; no follow-up needed.

## CI

`cargo fmt`, `clippy` and `test` all fail on this branch — and identically on `origin/v2_0`. Pre-existing formatting drift plus an `ethnum v1.5.2` / rustc 1.98.1 `E0512` compile error. **This PR changes no Rust**, so these are pre-existing by construction. `deny.toml` doesn't exist, so `cargo deny` was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXNsoyDVUTbJEZj7JYykMj